### PR TITLE
Warn on AUTO_MIGRATE, support arm64 for visual-docker

### DIFF
--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -97,6 +97,18 @@ if [ -n "$db_port" ] && [ "$db_port" != "$compose_port" ]; then
   warn "DB_PORT ($db_port) != compose exposed port CHATAPP_DB_EXPOSED_PORT ($compose_port)"
 fi
 
+# --- migrations ---
+# This script never connects to the database, so it cannot tell whether the
+# schema is already migrated — AUTO_MIGRATE=false is entirely normal against
+# an existing DB. It is only a trap against a *fresh* one: cmd/api-server
+# skips migrations and then dies on boot with `relation "..." does not
+# exist` instead of a clear message, which is what a first `make run-mock`
+# against a just-created `make db-up` volume hits. Warn, don't fail — this
+# script has no way to distinguish the two cases.
+if [ "$(envval AUTO_MIGRATE)" != "true" ]; then
+  warn "AUTO_MIGRATE is not \"true\" — fine against an already-migrated DB, but the first run against a fresh one (e.g. right after 'make db-up') will fail to boot with a 'relation ... does not exist' error. Set AUTO_MIGRATE=true in .env for that first run."
+fi
+
 # --- secrets ---
 # Mirrors internal/auth.ValidateSecret and datastore.ValidateTokenEncryptionSecret
 # exactly: the server hard-fails at boot on any of these conditions, so this

--- a/web/app/e2e/scripts/visual-docker.sh
+++ b/web/app/e2e/scripts/visual-docker.sh
@@ -44,6 +44,23 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 app_dir="web/app"
 
+# The published image (ci-image.yml) is amd64-only. On a non-amd64 host
+# (Apple Silicon) `docker run`/`docker build` would otherwise silently pick
+# whatever the daemon defaults to — an arm64 build renders fonts differently
+# than CI's amd64, reintroducing the exact baseline-diffs-that-look-like-UI-
+# regressions problem this recipe exists to avoid, or (for `docker run`
+# against the published tag) just fails outright with a "no matching
+# manifest" error. Force amd64 explicitly instead of trusting the default.
+platform_flag=()
+host_arch="$(uname -m)"
+case "$host_arch" in
+  x86_64 | amd64) ;;
+  *)
+    platform_flag=(--platform linux/amd64)
+    echo "Host arch is ${host_arch} — using --platform linux/amd64 so rendering matches CI"
+    ;;
+esac
+
 # Resolved by the same script CI uses (scripts/ci-image.sh) so the renderer
 # that produces committed baseline PNGs and the renderer that checks them in
 # CI (e2e-mock.yml's visual project) are always the same image — a mismatch
@@ -66,6 +83,7 @@ if ! docker manifest inspect "${image}" >/dev/null 2>&1; then
     build_arg_flags+=(--build-arg "$line")
   done <<<"$build_args"
   docker build \
+    "${platform_flag[@]}" \
     -f "$repo_root/docker/ci/Dockerfile" \
     --target e2e \
     "${build_arg_flags[@]}" \
@@ -86,6 +104,7 @@ echo "Using image ${image}"
 # native deps like esbuild are platform-specific and that would break the
 # host toolchain afterwards.
 docker run --rm \
+  "${platform_flag[@]}" \
   --add-host=host.docker.internal:host-gateway \
   -v "${repo_root}:/repo" \
   -v "/repo/${app_dir}/node_modules" \


### PR DESCRIPTION
Fixes #8

## Summary
- `scripts/check-env.sh` now warns when `AUTO_MIGRATE` isn't `"true"`.
  It can't tell whether a given database is already migrated, so a
  fresh one (right after `make db-up`) previously only surfaced this
  as a fatal `relation "roles" does not exist` panic from the API
  server on first boot, well past the point `check-env` said
  everything was fine.
- `e2e/scripts/visual-docker.sh` now detects a non-amd64 host
  (`uname -m`) and adds `--platform linux/amd64` to both the local
  `docker build` fallback and the `docker run` invocation. The
  published CI image is amd64-only; without this, the script fails
  outright on Apple Silicon with `no matching manifest for
  linux/arm64/v8`, and a local arm64 build (had one been produced)
  would render fonts differently than CI, reintroducing the very
  baseline-diff-that-looks-like-a-UI-regression problem this script
  exists to avoid.

## Test plan
- [x] `make check-env` with `AUTO_MIGRATE=false` prints the new
      warning; with `AUTO_MIGRATE=true` it's silent on that line.
      Exit code stays 0 either way (advisory, not blocking).
- [x] `make check-env` still reports "Environment looks good" overall.
- [x] Ran `e2e/scripts/visual-docker.sh` end-to-end on Apple Silicon
      against a local mock-LLM API + Postgres: prints "Host arch is
      arm64 — using --platform linux/amd64 so rendering matches CI",
      pulls/runs the amd64 image successfully (no manifest error),
      and the suite executes (10 passed, 2 failed — the 2 failures
      are the pre-existing stale visual baseline this branch doesn't
      include the fix for yet, not a regression from this change).