### PR TITLE
Add unit tests for pure-logic internal packages

### DIFF
--- a/internal/apicontext/user_test.go
+++ b/internal/apicontext/user_test.go
@@ -1,0 +1,62 @@
+package apicontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithUserIDAndUserIDFrom(t *testing.T) {
+	tests := []struct {
+		name   string
+		seed   func(ctx context.Context) context.Context
+		wantID uuid.UUID
+		wantOK bool
+	}{
+		{
+			name: "context carries the user id it was given",
+			seed: func(ctx context.Context) context.Context {
+				return WithUserID(ctx, uuid.MustParse("11111111-1111-1111-1111-111111111111"))
+			},
+			wantID: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			wantOK: true,
+		},
+		{
+			name: "bare context has no user id",
+			seed: func(ctx context.Context) context.Context {
+				return ctx
+			},
+			wantID: uuid.Nil,
+			wantOK: false,
+		},
+		{
+			name: "nil uuid is still a present value",
+			seed: func(ctx context.Context) context.Context {
+				return WithUserID(ctx, uuid.Nil)
+			},
+			wantID: uuid.Nil,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.seed(context.Background())
+			id, ok := UserIDFrom(ctx)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
+func TestUserIDFromWrongValueType(t *testing.T) {
+	// A context.Value under an unrelated key type must not be mistaken for
+	// the user id, even if by some other package's bug it stored a string
+	// under an identically-named-but-distinct key type.
+	ctx := context.WithValue(context.Background(), struct{ marker string }{"userIDKey{}"}, "not-a-uuid")
+	id, ok := UserIDFrom(ctx)
+	assert.False(t, ok)
+	assert.Equal(t, uuid.Nil, id)
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,49 @@
+package buildinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet(t *testing.T) {
+	origVersion, origCommit, origBuiltAt, origOverlayCommit := Version, Commit, BuiltAt, OverlayCommit
+	t.Cleanup(func() {
+		Version, Commit, BuiltAt, OverlayCommit = origVersion, origCommit, origBuiltAt, origOverlayCommit
+	})
+
+	tests := []struct {
+		name string
+		set  func()
+		want Info
+	}{
+		{
+			name: "unstamped defaults",
+			set: func() {
+				Version, Commit, BuiltAt, OverlayCommit = "dev", "unknown", "unknown", ""
+			},
+			want: Info{Version: "dev", Commit: "unknown", BuiltAt: "unknown", OverlayCommit: ""},
+		},
+		{
+			name: "stamped at build time",
+			set: func() {
+				Version, Commit, BuiltAt, OverlayCommit = "v1.2.3", "abc123", "2026-01-01T00:00:00Z", ""
+			},
+			want: Info{Version: "v1.2.3", Commit: "abc123", BuiltAt: "2026-01-01T00:00:00Z", OverlayCommit: ""},
+		},
+		{
+			name: "overlay build stamps OverlayCommit",
+			set: func() {
+				Version, Commit, BuiltAt, OverlayCommit = "v1.2.3", "abc123", "2026-01-01T00:00:00Z", "def456"
+			},
+			want: Info{Version: "v1.2.3", Commit: "abc123", BuiltAt: "2026-01-01T00:00:00Z", OverlayCommit: "def456"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.set()
+			assert.Equal(t, tt.want, Get())
+		})
+	}
+}

--- a/internal/featuregate/featuregate_test.go
+++ b/internal/featuregate/featuregate_test.go
@@ -1,0 +1,59 @@
+package featuregate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeGate struct {
+	entitled bool
+	calledID uuid.UUID
+}
+
+func (g *fakeGate) IsEntitled(_ context.Context, userID uuid.UUID) bool {
+	g.calledID = userID
+	return g.entitled
+}
+
+func TestIsEntitled(t *testing.T) {
+	origActive := Active
+	t.Cleanup(func() { Active = origActive })
+
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	tests := []struct {
+		name string
+		gate Gate
+		want bool
+	}{
+		{
+			name: "no gate linked: every feature is available",
+			gate: nil,
+			want: true,
+		},
+		{
+			name: "linked gate denies",
+			gate: &fakeGate{entitled: false},
+			want: false,
+		},
+		{
+			name: "linked gate allows",
+			gate: &fakeGate{entitled: true},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Active = tt.gate
+			got := IsEntitled(context.Background(), userID)
+			assert.Equal(t, tt.want, got)
+			if fg, ok := tt.gate.(*fakeGate); ok {
+				assert.Equal(t, userID, fg.calledID, "gate should be invoked with the same userID")
+			}
+		})
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,96 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		level   string
+		want    zapcore.Level
+		wantErr bool
+	}{
+		{name: "debug", level: "debug", want: zapcore.DebugLevel},
+		{name: "info", level: "info", want: zapcore.InfoLevel},
+		{name: "warn", level: "warn", want: zapcore.WarnLevel},
+		{name: "error", level: "error", want: zapcore.ErrorLevel},
+		{name: "uppercase is normalized", level: "DEBUG", want: zapcore.DebugLevel},
+		{name: "mixed case is normalized", level: "WaRn", want: zapcore.WarnLevel},
+		{name: "unknown level", level: "trace", wantErr: true},
+		{name: "empty string", level: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLogLevel(tt.level)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.level)
+				assert.Equal(t, zapcore.InfoLevel, got, "default level is returned alongside the error")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewLogger(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       string
+		logLevel  string
+		wantLevel zapcore.Level
+		wantErr   bool
+	}{
+		{
+			name:      "production config by default",
+			env:       "",
+			wantLevel: zapcore.InfoLevel,
+		},
+		{
+			name:      "development environment",
+			env:       "development",
+			wantLevel: zapcore.DebugLevel,
+		},
+		{
+			name:      "dev shorthand, case-insensitive",
+			env:       "DEV",
+			wantLevel: zapcore.DebugLevel,
+		},
+		{
+			name:      "explicit LOG_LEVEL overrides the environment default",
+			env:       "production",
+			logLevel:  "debug",
+			wantLevel: zapcore.DebugLevel,
+		},
+		{
+			name:     "invalid LOG_LEVEL fails the build",
+			logLevel: "not-a-level",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvEnvironment, tt.env)
+			t.Setenv(EnvLogLevel, tt.logLevel)
+
+			logger, err := NewLogger()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, logger)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, logger)
+			t.Cleanup(func() { _ = logger.Sync() })
+			assert.True(t, logger.Core().Enabled(tt.wantLevel))
+		})
+	}
+}

--- a/internal/metering/noop_test.go
+++ b/internal/metering/noop_test.go
@@ -1,0 +1,64 @@
+package metering
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNoopMeterCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		tier       string
+		actionType string
+	}{
+		{name: "known tier and action", tier: "high", actionType: "chat"},
+		{name: "empty tier is treated conservatively but still allowed", tier: "", actionType: "chat"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NoopMeter{}
+			got := m.Check(context.Background(), uuid.New(), tt.tier, tt.actionType)
+			assert.Equal(t, Decision{Allowed: true, DontRecordUsage: true}, got)
+		})
+	}
+}
+
+func TestNoopMeterRecordWithNilLogger(t *testing.T) {
+	m := NoopMeter{}
+	// Must not panic when Logger is unset.
+	assert.NotPanics(t, func() {
+		m.Record(context.Background(), Decision{Allowed: true}, Usage{UserID: uuid.New()})
+	})
+}
+
+func TestNoopMeterRecordLogsAtDebug(t *testing.T) {
+	core, logs := observer.New(zap.DebugLevel)
+	m := NoopMeter{Logger: zap.New(core)}
+
+	userID := uuid.New()
+	m.Record(context.Background(), Decision{}, Usage{
+		UserID:     userID,
+		ActionType: "chat",
+		Model:      "test-model",
+		Tokens:     42,
+	})
+
+	entries := logs.All()
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	assert.Equal(t, zap.DebugLevel, entry.Level)
+	assert.Equal(t, "metering(noop): turn not tracked", entry.Message)
+
+	fields := entry.ContextMap()
+	assert.Equal(t, userID.String(), fields["user_id"])
+	assert.Equal(t, "chat", fields["action_type"])
+	assert.Equal(t, "test-model", fields["model"])
+	assert.Equal(t, int64(42), fields["tokens"])
+}

--- a/internal/modeltypes/chat_tags.go
+++ b/internal/modeltypes/chat_tags.go
@@ -20,6 +20,12 @@ const (
 //
 // Callers that need PATCH semantics should check nil before deciding whether to write.
 func NormalizeAndValidateChatTags(tags []string) ([]string, error) {
+	// make([]string, 0) below is non-nil, so nil input must be special-cased
+	// to actually return nil — otherwise the documented nil-in/nil-out PATCH
+	// contract silently never holds.
+	if tags == nil {
+		return nil, nil
+	}
 	if len(tags) > MaxChatTags {
 		return nil, fmt.Errorf("chat can have at most %d tags", MaxChatTags)
 	}

--- a/internal/modeltypes/chat_tags_test.go
+++ b/internal/modeltypes/chat_tags_test.go
@@ -1,0 +1,114 @@
+package modeltypes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAndValidateChatTags(t *testing.T) {
+	tests := []struct {
+		name      string
+		tags      []string
+		want      []string
+		wantErr   string
+		expectNil bool
+	}{
+		{
+			name:      "nil input returns nil output",
+			tags:      nil,
+			expectNil: true,
+		},
+		{
+			name: "empty-but-non-nil input returns empty slice",
+			tags: []string{},
+			want: []string{},
+		},
+		{
+			name: "trims each tag",
+			tags: []string{"  work  ", "\tpersonal\n"},
+			want: []string{"work", "personal"},
+		},
+		{
+			name:    "too many tags",
+			tags:    make([]string, MaxChatTags+1),
+			wantErr: "chat can have at most 10 tags",
+		},
+		{
+			name:    "tag empty after trimming",
+			tags:    []string{"ok", "   "},
+			wantErr: "chat tags cannot be empty",
+		},
+		{
+			name:    "tag too long after trimming",
+			tags:    []string{strings.Repeat("a", MaxChatTagLength+1)},
+			wantErr: "chat tags must be at most 10 characters",
+		},
+		{
+			name: "tag exactly at the length limit is valid",
+			tags: []string{strings.Repeat("a", MaxChatTagLength)},
+			want: []string{strings.Repeat("a", MaxChatTagLength)},
+		},
+		{
+			name: "tag count exactly at the limit is valid",
+			tags: func() []string {
+				tags := make([]string, MaxChatTags)
+				for i := range tags {
+					tags[i] = "tag"
+				}
+				return tags
+			}(),
+			want: func() []string {
+				tags := make([]string, MaxChatTags)
+				for i := range tags {
+					tags[i] = "tag"
+				}
+				return tags
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeAndValidateChatTags(tt.tags)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			if tt.expectNil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateChatTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    []string
+		wantErr bool
+	}{
+		{name: "valid tags", tags: []string{"work", "personal"}, wantErr: false},
+		{name: "invalid: empty tag", tags: []string{""}, wantErr: true},
+		{name: "invalid: too many tags", tags: make([]string, MaxChatTags+1), wantErr: true},
+		{name: "nil tags is valid (no-op)", tags: nil, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateChatTags(tt.tags)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -1,0 +1,57 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// withCleanRegistrars runs fn with the package-level registrars slice reset
+// to empty, restoring whatever was there afterward. Register/Apply operate
+// on shared package state, so tests must not leak registrations into each
+// other or into the rest of the suite.
+func withCleanRegistrars(t *testing.T, fn func()) {
+	t.Helper()
+	orig := registrars
+	registrars = nil
+	t.Cleanup(func() { registrars = orig })
+	fn()
+}
+
+func TestApplyWithNoRegistrars(t *testing.T) {
+	withCleanRegistrars(t, func() {
+		// Must not panic and must not call anything.
+		assert.NotPanics(t, func() { Apply(Deps{}) })
+	})
+}
+
+func TestRegisterAndApply(t *testing.T) {
+	withCleanRegistrars(t, func() {
+		var calls []Deps
+
+		Register(func(d Deps) { calls = append(calls, d) })
+		Register(func(d Deps) { calls = append(calls, d) })
+
+		want := Deps{}
+		Apply(want)
+
+		assert.Len(t, calls, 2, "every registered registrar should run exactly once per Apply")
+		for _, got := range calls {
+			assert.Equal(t, want, got, "each registrar should receive the same Deps passed to Apply")
+		}
+	})
+}
+
+func TestApplyRunsRegistrarsInRegistrationOrder(t *testing.T) {
+	withCleanRegistrars(t, func() {
+		var order []int
+
+		Register(func(Deps) { order = append(order, 1) })
+		Register(func(Deps) { order = append(order, 2) })
+		Register(func(Deps) { order = append(order, 3) })
+
+		Apply(Deps{})
+
+		assert.Equal(t, []int{1, 2, 3}, order)
+	})
+}


### PR DESCRIPTION
Fixes #11

Stacked on #4 — checkpoint 2 of the coverage handoff plan.

## Summary
- Table-driven unit tests for `internal/buildinfo`, `internal/apicontext`,
  `internal/modeltypes`, `internal/featuregate`, `internal/logging`,
  `internal/metering`, and `internal/plugins` — the pure-logic packages
  with no DB, fixtures, or network dependency, matching the style in
  `internal/agent/tools/tool_helpers_test.go`.
- `internal/userhooks` and `internal/providers` are intentionally left
  without test files: both are declarations only (a `Hook`/`Meter` type,
  package-level function vars, and interfaces respectively) with no
  executable statements to cover.
- Writing the `modeltypes` tests surfaced a real bug:
  `NormalizeAndValidateChatTags`'s doc comment promises nil input
  produces nil output (documented for PATCH-style unset handling), but
  `make([]string, len(tags))` on a nil slice returns a non-nil empty
  slice, so the documented contract never actually held. Fixed with an
  explicit nil check.

## Coverage note
Every function touched by these tests is now at 100% (one branch in
`NewLogger` sits at 95.7% — the `zap.Config.Build()` internal-error
path, not practically triggerable without mocking zap internals).
However, the overall `go-unit` total only moved from 33.4% to 33.6% —
these packages are individually tiny (a few dozen statements total)
against a large `-coverpkg` denominator, so they can't move a
codebase-wide percentage much regardless of how thoroughly they're
tested. The handoff doc's ≥40% target for this checkpoint looks like
an optimistic estimate rather than something achievable from this
specific package list; the real per-checkpoint movement should come
from checkpoint 3 onward (provider adapters, datastore, agent
internals), which have far more uncovered surface.

## Test plan
- [x] `go test ./internal/buildinfo/... ./internal/apicontext/...
      ./internal/modeltypes/... ./internal/featuregate/...
      ./internal/logging/... ./internal/metering/... ./internal/plugins/...`
      passes
- [x] `make test-ci` passes (full suite green)
- [x] `make coverage-summary PROFILE=coverage/go-unit.out` →
      `33.6%` (from 33.4%)
- [x] `gofmt`/`go vet` clean