### PR TITLE
Add shared unit test suite for OpenAI-compatible provider adapters

### DIFF
--- a/internal/agent/provider/claude_adapter_beta_call_test.go
+++ b/internal/agent/provider/claude_adapter_beta_call_test.go
@@ -1,0 +1,225 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClaudeMCPAdapter builds a ClaudeAdapter in beta-MCP mode (useBetaMCP),
+// the path Call/ForceFinalResponse/AppendToolResults take when an MCP server is
+// configured. Same wire format as the plain Messages API (id/type/role/model/
+// content/stop_reason/usage), just routed through client.Beta.Messages.
+func newTestClaudeMCPAdapter(baseURL string) *ClaudeAdapter {
+	provider := NewClaudeProviderWithBaseURL("test-key", baseURL, nil, nil)
+	params := anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
+		},
+	}
+	mcp := &ClaudeMCPConfig{
+		Servers: []anthropic.BetaRequestMCPServerURLDefinitionParam{
+			{Name: "mcp-a", URL: "https://mcp.example.com"},
+		},
+	}
+	return NewClaudeAdapter(provider, params, nil, false, mcp, nil)
+}
+
+func TestClaudeAdapter_BetaMode_Call_TextResponse(t *testing.T) {
+	srv := jsonHandlerServer(t, claudeMessageTextJSON("bmsg_1", "hello beta claude"))
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	require.True(t, a.useBetaMCP)
+
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, "hello beta claude", resp.Text)
+	require.Len(t, a.AllRawBetaMessages(), 1)
+	require.Zero(t, a.WebSearchCompletedCount())
+}
+
+func TestClaudeAdapter_BetaMode_Call_ToolUse(t *testing.T) {
+	srv := jsonHandlerServer(t, claudeMessageToolUseJSON("bmsg_2", "toolu_b1", "do_thing", `{"x":1}`))
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, toolUses, 1)
+	require.Equal(t, "toolu_b1", toolUses[0].ID)
+	require.Equal(t, "do_thing", toolUses[0].Name)
+}
+
+func TestClaudeAdapter_BetaMode_Call_APIErrorIsWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}`))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Anthropic Beta API call failed")
+	require.Nil(t, resp)
+	require.Nil(t, toolUses)
+}
+
+func TestClaudeAdapter_BetaMode_AppendToolResults_FoldsIntoNextCall(t *testing.T) {
+	var lastBody string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		lastBody = string(body)
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			_, _ = w.Write([]byte(claudeMessageToolUseJSON("bmsg_3", "toolu_b2", "do_thing", `{}`)))
+			return
+		}
+		_, _ = w.Write([]byte(claudeMessageTextJSON("bmsg_4", "beta final answer")))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	_, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Len(t, toolUses, 1)
+
+	a.AppendToolResults([]ToolResult{{ID: toolUses[0].ID, Output: "beta-42"}})
+
+	resp, toolUses2, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses2)
+	require.Equal(t, "beta final answer", resp.Text)
+	require.Contains(t, lastBody, "toolu_b2")
+	require.Contains(t, lastBody, "beta-42")
+}
+
+func TestClaudeAdapter_BetaMode_ForceFinalResponse(t *testing.T) {
+	var lastBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		lastBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(claudeMessageTextJSON("bmsg_5", "beta forced final")))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "beta forced final", resp.Text)
+	require.Empty(t, a.betaParams.Tools, "ForceFinalResponse must strip the beta tool list too")
+	require.Contains(t, lastBody, "final response")
+}
+
+func TestClaudeAdapter_BetaMode_ForceFinalResponse_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"nope"}}`))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Anthropic beta final-response call failed")
+	require.Nil(t, resp)
+}
+
+func TestExtractClaudeBetaToolUses(t *testing.T) {
+	require.Empty(t, extractClaudeBetaToolUses(nil))
+
+	raw := `{"id":"bmsg_6","type":"message","role":"assistant","model":"test-model",` +
+		`"content":[{"type":"tool_use","id":"toolu_x","name":"do_thing","input":{"x":1}}],` +
+		`"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(raw), &msg))
+
+	uses := extractClaudeBetaToolUses(&msg)
+	require.Len(t, uses, 1)
+	require.Equal(t, "toolu_x", uses[0].ID)
+	require.Equal(t, "do_thing", uses[0].Name)
+	require.JSONEq(t, `{"x":1}`, string(uses[0].Input))
+}
+
+func TestCountWebSearchToolResultsInBetaMessage(t *testing.T) {
+	require.Zero(t, countWebSearchToolResultsInBetaMessage(nil))
+
+	raw := `{"id":"bmsg_ws","type":"message","role":"assistant","model":"test-model","content":[
+		{"type":"text","text":"searching"},
+		{"type":"web_search_tool_result","tool_use_id":"srv_01","content":[{"type":"web_search_result","title":"Example","url":"https://example.com","encrypted_content":"enc"}]}
+	],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(raw), &msg))
+	require.Equal(t, 1, countWebSearchToolResultsInBetaMessage(&msg))
+}
+
+func TestClaudeBetaWebSearchToolResultReplayable(t *testing.T) {
+	replayable := `{"type":"web_search_tool_result","tool_use_id":"srv_01","content":[{"type":"web_search_result","title":"Example","url":"https://example.com","encrypted_content":"enc"}]}`
+	var withURL anthropic.BetaWebSearchToolResultBlock
+	require.NoError(t, json.Unmarshal([]byte(replayable), &withURL))
+	require.True(t, claudeBetaWebSearchToolResultReplayable(withURL))
+
+	empty := `{"type":"web_search_tool_result","tool_use_id":"srv_02","content":[]}`
+	var noContent anthropic.BetaWebSearchToolResultBlock
+	require.NoError(t, json.Unmarshal([]byte(empty), &noContent))
+	require.False(t, claudeBetaWebSearchToolResultReplayable(noContent))
+}
+
+func TestAppendClaudeInLoopWebSearchContextText(t *testing.T) {
+	require.NotPanics(t, func() { appendClaudeInLoopWebSearchContextText(nil, "text") })
+
+	params := &anthropic.MessageNewParams{}
+	appendClaudeInLoopWebSearchContextText(params, "   ")
+	require.Empty(t, params.Messages, "blank text must not append a message")
+
+	appendClaudeInLoopWebSearchContextText(params, "web search results here")
+	require.Len(t, params.Messages, 1)
+	require.Equal(t, anthropic.MessageParamRoleUser, params.Messages[0].Role)
+}
+
+func TestAppendClaudeBetaInLoopWebSearchContextText(t *testing.T) {
+	require.NotPanics(t, func() { appendClaudeBetaInLoopWebSearchContextText(nil, "text") })
+
+	params := &anthropic.BetaMessageNewParams{}
+	appendClaudeBetaInLoopWebSearchContextText(params, "")
+	require.Empty(t, params.Messages, "empty text must not append a message")
+
+	appendClaudeBetaInLoopWebSearchContextText(params, "beta web search results here")
+	require.Len(t, params.Messages, 1)
+	require.Equal(t, anthropic.BetaMessageParamRoleUser, params.Messages[0].Role)
+}
+
+func TestBuildClaudeBetaMCPParams(t *testing.T) {
+	base := anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 128,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("hello")),
+		},
+	}
+	mcp := &ClaudeMCPConfig{
+		Servers: []anthropic.BetaRequestMCPServerURLDefinitionParam{
+			{Name: "mcp-a", URL: "https://mcp.example.com"},
+		},
+	}
+	out, err := BuildClaudeBetaMCPParams(base, mcp)
+	require.NoError(t, err)
+	require.Equal(t, base.Model, out.Model)
+	require.Len(t, out.MCPServers, 1)
+	require.NotEmpty(t, out.Betas)
+}

--- a/internal/agent/provider/claude_adapter_call_test.go
+++ b/internal/agent/provider/claude_adapter_call_test.go
@@ -1,0 +1,209 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClaudeAdapter(baseURL string) *ClaudeAdapter {
+	provider := NewClaudeProviderWithBaseURL("test-key", baseURL, nil, nil)
+	params := anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
+		},
+	}
+	return NewClaudeAdapter(provider, params, nil, false, nil, nil)
+}
+
+func claudeMessageTextJSON(id, text string) string {
+	return `{"id":"` + id + `","type":"message","role":"assistant","model":"test-model",` +
+		`"content":[{"type":"text","text":"` + text + `"}],"stop_reason":"end_turn","stop_sequence":null,` +
+		`"usage":{"input_tokens":5,"output_tokens":7}}`
+}
+
+func claudeMessageToolUseJSON(id, toolID, name string, input string) string {
+	return `{"id":"` + id + `","type":"message","role":"assistant","model":"test-model",` +
+		`"content":[{"type":"tool_use","id":"` + toolID + `","name":"` + name + `","input":` + input + `}],` +
+		`"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":5,"output_tokens":7}}`
+}
+
+// claudeSSEServer streams Anthropic Messages API events. Unlike the OpenAI/Gemini
+// SSE format (a bare `data: <json>` line with the event type embedded in the JSON),
+// the Anthropic SDK's stream decoder dispatches strictly on the SSE `event:` line
+// (packages/ssestream), so each frame needs both lines.
+func claudeSSEServer(t *testing.T, events []struct{ event, data string }) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+		for _, e := range events {
+			_, _ = w.Write([]byte("event: " + e.event + "\ndata: " + e.data + "\n\n"))
+			flusher.Flush()
+		}
+	}))
+}
+
+func TestClaudeAdapter_Call_TextResponse(t *testing.T) {
+	srv := jsonHandlerServer(t, claudeMessageTextJSON("msg_1", "hello claude"))
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, "hello claude", resp.Text)
+	require.Equal(t, int64(5), resp.InputTokens)
+	require.Equal(t, int64(7), resp.OutputTokens)
+
+	require.Len(t, a.AllRawMessages(), 1)
+	require.Zero(t, a.WebSearchCompletedCount())
+}
+
+func TestClaudeAdapter_Call_ToolUse(t *testing.T) {
+	srv := jsonHandlerServer(t, claudeMessageToolUseJSON("msg_2", "toolu_1", "do_thing", `{"x":1}`))
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, toolUses, 1)
+	require.Equal(t, "toolu_1", toolUses[0].ID)
+	require.Equal(t, "do_thing", toolUses[0].Name)
+	require.JSONEq(t, `{"x":1}`, string(toolUses[0].Input))
+}
+
+func TestClaudeAdapter_Call_APIErrorIsWrappedNotSafetyViolation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}`))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Anthropic API call failed")
+	_, isSafety := IsSafetyViolationError(err)
+	require.False(t, isSafety)
+	require.Nil(t, resp)
+	require.Nil(t, toolUses)
+}
+
+func TestClaudeAdapter_AppendToolResults_FoldsIntoNextCall(t *testing.T) {
+	var lastBody string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		lastBody = string(body)
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			_, _ = w.Write([]byte(claudeMessageToolUseJSON("msg_3", "toolu_2", "do_thing", `{}`)))
+			return
+		}
+		_, _ = w.Write([]byte(claudeMessageTextJSON("msg_4", "final answer")))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	_, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Len(t, toolUses, 1)
+
+	a.AppendToolResults([]ToolResult{{ID: toolUses[0].ID, Output: "42"}})
+
+	resp, toolUses2, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses2)
+	require.Equal(t, "final answer", resp.Text)
+
+	require.Contains(t, lastBody, "tool_result")
+	require.Contains(t, lastBody, "toolu_2")
+	require.Contains(t, lastBody, "42")
+}
+
+func TestClaudeAdapter_ForceFinalResponse(t *testing.T) {
+	var lastBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		lastBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(claudeMessageTextJSON("msg_5", "final claude answer")))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	a.params.Tools = []anthropic.ToolUnionParam{ClaudeFunctionTool("some_tool", "desc", nil, nil, false)}
+
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "final claude answer", resp.Text)
+	require.Empty(t, a.params.Tools, "ForceFinalResponse must strip the tool list")
+	require.Contains(t, lastBody, "final response")
+	require.Len(t, a.AllRawMessages(), 1)
+}
+
+func TestClaudeAdapter_ForceFinalResponse_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"nope"}}`))
+	}))
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Anthropic final-response call failed")
+	require.Nil(t, resp)
+}
+
+func TestClaudeAdapter_SetTextDeltaHandlerEnablesStreaming(t *testing.T) {
+	events := []struct{ event, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"msg_6","type":"message","role":"assistant","model":"test-model","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there"}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	}
+	srv := claudeSSEServer(t, events)
+	defer srv.Close()
+
+	a := newTestClaudeAdapter(srv.URL)
+	var deltas []string
+	a.SetTextDeltaHandler(func(d string) { deltas = append(deltas, d) })
+
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, []string{"Hi", " there"}, deltas)
+	require.Equal(t, "Hi there", resp.Text)
+	require.Equal(t, int64(10), resp.InputTokens)
+	require.Equal(t, int64(5), resp.OutputTokens)
+}
+
+func TestCountWebSearchToolResultsInMessage(t *testing.T) {
+	require.Zero(t, countWebSearchToolResultsInMessage(nil))
+
+	raw := `{"id":"msg_ws","type":"message","role":"assistant","model":"test-model","content":[
+		{"type":"text","text":"searching"},
+		{"type":"web_search_tool_result","tool_use_id":"srv_01","content":[{"type":"web_search_result","title":"Example","url":"https://example.com","encrypted_content":"enc","page_age":"1d"}]},
+		{"type":"web_search_tool_result","tool_use_id":"srv_02","content":[]}
+	],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}`
+	var msg anthropic.Message
+	require.NoError(t, json.Unmarshal([]byte(raw), &msg))
+	require.Equal(t, 2, countWebSearchToolResultsInMessage(&msg))
+}

--- a/internal/agent/provider/gemini_adapter_call_test.go
+++ b/internal/agent/provider/gemini_adapter_call_test.go
@@ -1,0 +1,195 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newTestGeminiAdapter(baseURL string) *GeminiAdapter {
+	return NewGeminiAdapter(NewGeminiProvider("test-key", baseURL, nil, nil), openai.ChatCompletionNewParams{Model: "test"}, nil, nil, zap.NewNop())
+}
+
+func TestGeminiAdapter_Call_TextResponse(t *testing.T) {
+	srv, _ := sequencedJSONServer(t, []string{chatCompletionTextJSON("cmpl-g1", "gemini reply")})
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, "gemini reply", resp.Text)
+	require.Equal(t, int64(5), resp.InputTokens)
+	require.Equal(t, int64(7), resp.OutputTokens)
+	require.Zero(t, a.WebSearchCompletedCount())
+}
+
+func TestGeminiAdapter_Call_ToolUse(t *testing.T) {
+	srv, _ := sequencedJSONServer(t, []string{chatCompletionToolCallJSON("cmpl-g2", "call_g1", "do_thing", `{}`)})
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, toolUses, 1)
+	require.Equal(t, "do_thing", toolUses[0].Name)
+	require.Equal(t, toolUses, a.lastRequested)
+
+	// The assistant tool-call turn must be persisted so a follow-up
+	// AppendToolResults can find the tool name for this call id.
+	require.Len(t, a.params.Messages, 1)
+}
+
+func TestGeminiAdapter_Call_NoChoicesError(t *testing.T) {
+	srv, _ := sequencedJSONServer(t, []string{chatCompletionEmptyChoicesJSON})
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no choices")
+	require.Nil(t, resp)
+	require.Nil(t, toolUses)
+}
+
+func TestGeminiAdapter_Call_APIErrorIsWrappedWithContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad request: invalid model"}}`))
+	}))
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	resp, toolUses, err := a.Call(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Gemini API call failed")
+	_, isSafety := IsSafetyViolationError(err)
+	require.False(t, isSafety)
+	require.Nil(t, resp)
+	require.Nil(t, toolUses)
+}
+
+func TestGeminiAdapter_ForceFinalResponse(t *testing.T) {
+	srv, requestBody := sequencedJSONServer(t, []string{chatCompletionTextJSON("cmpl-g3", "final gemini answer")})
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	a.params.Tools = []openai.ChatCompletionToolUnionParam{
+		openai.ChatCompletionFunctionTool(openai.FunctionDefinitionParam{Name: "some_tool"}),
+	}
+
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "final gemini answer", resp.Text)
+
+	msgs := decodeRequestMessages(t, requestBody(0))
+	last := msgs[len(msgs)-1]
+	require.Equal(t, "user", last["role"])
+	require.Contains(t, last["content"], "final response")
+	require.Empty(t, a.params.Tools, "ForceFinalResponse must strip the tool list")
+}
+
+func TestGeminiAdapter_ForceFinalResponse_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"nope"}}`))
+	}))
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Gemini final-response call failed")
+	require.Nil(t, resp)
+}
+
+func TestGeminiAdapter_SetTextDeltaHandlerEnablesStreaming(t *testing.T) {
+	frames := []string{
+		`{"id":"g1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}`,
+		`{"id":"g1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"content":" gemini"},"finish_reason":"stop"}]}`,
+		`{"id":"g1","object":"chat.completion.chunk","created":1,"model":"test","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":2,"total_tokens":4}}`,
+	}
+	srv := sseServer(t, frames)
+	defer srv.Close()
+
+	a := newTestGeminiAdapter(srv.URL)
+	var deltas []string
+	a.SetTextDeltaHandler(func(d string) { deltas = append(deltas, d) })
+
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, []string{"Hi", " gemini"}, deltas)
+	require.Equal(t, "Hi gemini", resp.Text)
+}
+
+func TestGeminiAdapter_ToolNameForResult_FallsBackToIndex(t *testing.T) {
+	a := newTestGeminiAdapter("http://unused.invalid")
+	a.lastRequested = []ToolUse{{ID: "", Name: "only_tool"}}
+	require.Equal(t, "only_tool", a.toolNameForResult("nonexistent-id", 0))
+	require.Equal(t, "", a.toolNameForResult("nonexistent-id", 5))
+}
+
+func TestExtractGeminiToolUses(t *testing.T) {
+	require.Empty(t, extractGeminiToolUses(nil))
+
+	resp := &openai.ChatCompletion{
+		Choices: []openai.ChatCompletionChoice{
+			{Message: openai.ChatCompletionMessage{
+				ToolCalls: []openai.ChatCompletionMessageToolCallUnion{
+					{ID: "c1", Type: "function", Function: openai.ChatCompletionMessageFunctionToolCallFunction{Name: "t1", Arguments: "{}"}},
+				},
+			}},
+		},
+	}
+	uses := extractGeminiToolUses(resp)
+	require.Len(t, uses, 1)
+	require.Equal(t, "c1", uses[0].ID)
+	require.Equal(t, "t1", uses[0].Name)
+}
+
+func TestTruncateLogString(t *testing.T) {
+	require.Equal(t, "abc", truncateLogString("abc", 10))
+	require.Equal(t, "abc", truncateLogString("abc", 3))
+	require.Equal(t, "ab…(truncated)", truncateLogString("abcdef", 2))
+	require.Equal(t, "abcdef", truncateLogString("abcdef", 0))
+	require.Equal(t, "abcdef", truncateLogString("abcdef", -1))
+}
+
+func TestOpenAIErrorDetail(t *testing.T) {
+	require.Empty(t, openAIErrorDetail(nil))
+	require.Equal(t, "boom", openAIErrorDetail(errNonAPI{}))
+}
+
+type errNonAPI struct{}
+
+func (errNonAPI) Error() string { return "boom" }
+
+func TestSummarizeGeminiMessages(t *testing.T) {
+	msgs := []openai.ChatCompletionMessageParamUnion{
+		openai.UserMessage("hello"),
+		openai.AssistantMessage("hi there"),
+	}
+	summary := summarizeGeminiMessages(msgs)
+	require.Contains(t, summary, `"content_len":5`)
+	require.Contains(t, summary, `"content_len":8`)
+
+	require.Equal(t, "[]", summarizeGeminiMessages(nil))
+
+	// More than the 4-message tail window: only the last 4 must appear.
+	many := make([]openai.ChatCompletionMessageParamUnion, 0, 6)
+	for i := 0; i < 6; i++ {
+		many = append(many, openai.UserMessage("msg"))
+	}
+	var decoded []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(summarizeGeminiMessages(many)), &decoded))
+	require.Len(t, decoded, 4)
+}

--- a/internal/agent/provider/openai_adapter_call_test.go
+++ b/internal/agent/provider/openai_adapter_call_test.go
@@ -1,0 +1,181 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOpenAIProvider(baseURL string) *OpenAIProvider {
+	client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(baseURL))
+	return NewOpenAIProvider(nil, &client, nil, nil)
+}
+
+func responseTextJSON(id, text string) string {
+	return `{"id":"` + id + `","object":"response","created_at":1,"model":"test","status":"completed",` +
+		`"output":[{"type":"message","id":"m1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"` + text + `"}]}],` +
+		`"usage":{"input_tokens":5,"output_tokens":7,"total_tokens":12}}`
+}
+
+func responseToolCallJSON(id, callID, name, args string) string {
+	return `{"id":"` + id + `","object":"response","created_at":1,"model":"test","status":"completed",` +
+		`"output":[{"type":"function_call","call_id":"` + callID + `","name":"` + name + `","arguments":"` + args + `"}],` +
+		`"usage":{"input_tokens":5,"output_tokens":7,"total_tokens":12}}`
+}
+
+func jsonHandlerServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestOpenAIAdapter_Call_TextResponse(t *testing.T) {
+	srv := jsonHandlerServer(t, responseTextJSON("resp_1", "hello from openai"))
+	defer srv.Close()
+
+	a := NewOpenAIAdapter(newTestOpenAIProvider(srv.URL), responses.ResponseNewParams{Model: "test"})
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, "hello from openai", resp.Text)
+	require.Equal(t, int64(5), resp.InputTokens)
+	require.Equal(t, int64(7), resp.OutputTokens)
+
+	require.Equal(t, "resp_1", a.LastRawResponse().ID)
+	require.Len(t, a.AllRawResponses(), 1)
+	require.Zero(t, a.WebSearchCompletedCount())
+}
+
+func TestOpenAIAdapter_Call_ToolUse(t *testing.T) {
+	srv := jsonHandlerServer(t, responseToolCallJSON("resp_2", "call_1", "do_thing", `{\"x\":1}`))
+	defer srv.Close()
+
+	a := NewOpenAIAdapter(newTestOpenAIProvider(srv.URL), responses.ResponseNewParams{Model: "test"})
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, toolUses, 1)
+	require.Equal(t, "call_1", toolUses[0].ID)
+	require.Equal(t, "do_thing", toolUses[0].Name)
+	require.JSONEq(t, `{"x":1}`, string(toolUses[0].Input))
+
+	// A successful Call must thread previousResponseID for the next request.
+	require.Equal(t, "resp_2", a.previousResponseID)
+}
+
+func TestOpenAIAdapter_Call_APIErrorIsWrappedNotSafetyViolation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad request: invalid model"}}`))
+	}))
+	defer srv.Close()
+
+	a := NewOpenAIAdapter(newTestOpenAIProvider(srv.URL), responses.ResponseNewParams{Model: "test"})
+	resp, toolUses, err := a.Call(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OpenAI API call failed")
+	_, isSafety := IsSafetyViolationError(err)
+	require.False(t, isSafety)
+	require.Nil(t, resp)
+	require.Nil(t, toolUses)
+}
+
+func TestOpenAIAdapter_ForceFinalResponse(t *testing.T) {
+	srv := jsonHandlerServer(t, responseTextJSON("resp_3", "final openai answer"))
+	defer srv.Close()
+
+	a := NewOpenAIAdapter(newTestOpenAIProvider(srv.URL), responses.ResponseNewParams{
+		Model: "test",
+		Tools: []responses.ToolUnionParam{{OfFunction: &responses.FunctionToolParam{Name: "some_tool"}}},
+	})
+
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "final openai answer", resp.Text)
+	require.Empty(t, a.params.Tools, "ForceFinalResponse must strip the tool list")
+	require.Len(t, a.AllRawResponses(), 1)
+}
+
+func TestOpenAIAdapter_ForceFinalResponse_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"nope"}}`))
+	}))
+	defer srv.Close()
+
+	a := NewOpenAIAdapter(newTestOpenAIProvider(srv.URL), responses.ResponseNewParams{Model: "test"})
+	resp, err := a.ForceFinalResponse(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OpenAI final-response call failed")
+	require.Nil(t, resp)
+}
+
+func TestOpenAIAdapter_SetTextDeltaHandlerEnablesStreaming(t *testing.T) {
+	frames := []string{
+		`{"type":"response.output_text.delta","delta":"Hi","sequence_number":1}`,
+		`{"type":"response.output_text.delta","delta":" there","sequence_number":2}`,
+		`{"type":"response.completed","sequence_number":3,"response":` +
+			responseTextJSON("resp_4", "Hi there") + `}`,
+	}
+	srv := sseServer(t, frames)
+	defer srv.Close()
+
+	a := NewOpenAIAdapter(newTestOpenAIProvider(srv.URL), responses.ResponseNewParams{Model: "test"})
+	var deltas []string
+	a.SetTextDeltaHandler(func(d string) { deltas = append(deltas, d) })
+
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, []string{"Hi", " there"}, deltas)
+	require.Equal(t, "Hi there", resp.Text)
+}
+
+func TestAllRawResponses_EmptyWhenNoCallsMade(t *testing.T) {
+	a := NewOpenAIAdapter(newTestOpenAIProvider("http://unused.invalid"), responses.ResponseNewParams{Model: "test"})
+	require.Nil(t, a.AllRawResponses())
+}
+
+func TestCountCompletedWebSearchesOpenAI(t *testing.T) {
+	require.Zero(t, countCompletedWebSearchesOpenAI(nil))
+
+	// AsWebSearchCall() re-parses each output item from its own captured raw
+	// JSON, so the fixture must come through json.Unmarshal (a bare struct
+	// literal has no raw JSON behind it and always reports zero values).
+	raw := `{"id":"resp_ws","object":"response","created_at":1,"model":"test","status":"completed","output":[
+		{"type":"web_search_call","id":"ws1","status":"completed","action":{"type":"search","query":"q"}},
+		{"type":"web_search_call","id":"ws2","status":"in_progress","action":{"type":"search","query":"q"}},
+		{"type":"message","id":"m1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"x"}]}
+	],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+	require.Equal(t, 1, countCompletedWebSearchesOpenAI(&resp))
+}
+
+func TestWaitForRetry(t *testing.T) {
+	t.Run("returns nil once the timer elapses", func(t *testing.T) {
+		require.NoError(t, waitForRetry(context.Background(), time.Millisecond))
+	})
+
+	t.Run("returns the context error when cancelled first", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := waitForRetry(ctx, time.Minute)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestIsRateLimitAndServerError_NilError(t *testing.T) {
+	require.False(t, isRateLimitError(nil))
+	require.False(t, isServerError(nil))
+}

--- a/internal/agent/provider/openai_compatible_adapters_test.go
+++ b/internal/agent/provider/openai_compatible_adapters_test.go
@@ -1,0 +1,364 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// The Mistral, DeepSeek, Qwen, Xiaomi, and Local adapters are near-identical
+// wrappers over the same OpenAI-compatible Chat Completions API — this file
+// drives all five through one shared table rather than duplicating the same
+// assertions five times. Local differs in one respect (no streaming path),
+// which is covered by its own dedicated tests at the bottom of this file.
+
+type openAICompatSpec struct {
+	name              string
+	supportsStreaming bool
+	newAdapter        func(baseURL string) AgentAdapter
+}
+
+func openAICompatSpecs() []openAICompatSpec {
+	params := func() openai.ChatCompletionNewParams { return openai.ChatCompletionNewParams{Model: "test"} }
+	return []openAICompatSpec{
+		{
+			name:              "mistral",
+			supportsStreaming: true,
+			newAdapter: func(baseURL string) AgentAdapter {
+				return NewMistralAdapter(NewMistralProvider("test-key", baseURL, nil, nil), params(), nil, nil)
+			},
+		},
+		{
+			name:              "deepseek",
+			supportsStreaming: true,
+			newAdapter: func(baseURL string) AgentAdapter {
+				return NewDeepSeekAdapter(NewDeepSeekProvider("test-key", baseURL, nil, nil), params(), nil, nil)
+			},
+		},
+		{
+			name:              "qwen",
+			supportsStreaming: true,
+			newAdapter: func(baseURL string) AgentAdapter {
+				return NewQwenAdapter(NewQwenProvider("test-key", baseURL, nil, nil), params(), nil, nil)
+			},
+		},
+		{
+			name:              "xiaomi",
+			supportsStreaming: true,
+			newAdapter: func(baseURL string) AgentAdapter {
+				return NewXiaomiAdapter(NewXiaomiProvider("test-key", baseURL, nil, nil), params(), nil, nil)
+			},
+		},
+		{
+			name:              "local",
+			supportsStreaming: false,
+			newAdapter: func(baseURL string) AgentAdapter {
+				return NewLocalAdapter(NewLocalProvider(baseURL, nil, nil), params(), nil, nil)
+			},
+		},
+	}
+}
+
+func chatCompletionTextJSON(id, text string) string {
+	return `{"id":"` + id + `","object":"chat.completion","created":1,"model":"test",` +
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"` + text + `"},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}`
+}
+
+func chatCompletionToolCallJSON(id, toolCallID, toolName, args string) string {
+	return `{"id":"` + id + `","object":"chat.completion","created":1,"model":"test",` +
+		`"choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"` + toolCallID +
+		`","type":"function","function":{"name":"` + toolName + `","arguments":"` + args + `"}}]},"finish_reason":"tool_calls"}],` +
+		`"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}`
+}
+
+const chatCompletionEmptyChoicesJSON = `{"id":"cmpl-empty","object":"chat.completion","created":1,"model":"test","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":0,"total_tokens":1}}`
+
+// sequencedJSONServer replies to request N with bodies[N] (clamped to the last
+// entry), recording each request's raw body so a test can inspect what a
+// later call sent — e.g. that AppendToolResults actually folded a tool result
+// into the next request, without reaching into adapter-private fields.
+func sequencedJSONServer(t *testing.T, bodies []string) (srv *httptest.Server, requestBody func(i int) []byte) {
+	t.Helper()
+	var mu sync.Mutex
+	var seen [][]byte
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		idx := len(seen)
+		seen = append(seen, b)
+		mu.Unlock()
+		if idx >= len(bodies) {
+			idx = len(bodies) - 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(bodies[idx]))
+	}))
+	requestBody = func(i int) []byte {
+		mu.Lock()
+		defer mu.Unlock()
+		return seen[i]
+	}
+	return srv, requestBody
+}
+
+func decodeRequestMessages(t *testing.T, body []byte) []map[string]interface{} {
+	t.Helper()
+	var decoded struct {
+		Messages []map[string]interface{} `json:"messages"`
+		Tools    []interface{}            `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	return decoded.Messages
+}
+
+func TestOpenAICompatibleAdapters_Call_TextResponse(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv, _ := sequencedJSONServer(t, []string{chatCompletionTextJSON("cmpl-1", "hello there")})
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			resp, toolUses, err := a.Call(context.Background())
+			require.NoError(t, err)
+			require.Empty(t, toolUses)
+			require.NotNil(t, resp)
+			require.Equal(t, "hello there", resp.Text)
+			require.Equal(t, int64(5), resp.InputTokens)
+			require.Equal(t, int64(7), resp.OutputTokens)
+			require.Zero(t, a.WebSearchCompletedCount())
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_Call_ToolUse(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv, _ := sequencedJSONServer(t, []string{chatCompletionToolCallJSON("cmpl-2", "call_1", "do_thing", `{\"x\":1}`)})
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			resp, toolUses, err := a.Call(context.Background())
+			require.NoError(t, err)
+			require.Nil(t, resp)
+			require.Len(t, toolUses, 1)
+			require.Equal(t, "call_1", toolUses[0].ID)
+			require.Equal(t, "do_thing", toolUses[0].Name)
+			require.JSONEq(t, `{"x":1}`, string(toolUses[0].Input))
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_Call_NoChoicesError(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv, _ := sequencedJSONServer(t, []string{chatCompletionEmptyChoicesJSON})
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			resp, toolUses, err := a.Call(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "no choices")
+			require.Nil(t, resp)
+			require.Nil(t, toolUses)
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_Call_APIErrorIsWrappedNotSafetyViolation(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"bad request: invalid model"}}`))
+			}))
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			resp, toolUses, err := a.Call(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "call failed")
+			_, isSafety := IsSafetyViolationError(err)
+			require.False(t, isSafety, "a plain API error must not be misclassified as a safety violation")
+			require.Nil(t, resp)
+			require.Nil(t, toolUses)
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_AppendToolResults_FoldsIntoNextCall(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv, requestBody := sequencedJSONServer(t, []string{
+				chatCompletionToolCallJSON("cmpl-3", "call_9", "do_thing", `{}`),
+				chatCompletionTextJSON("cmpl-4", "final answer"),
+			})
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			_, toolUses, err := a.Call(context.Background())
+			require.NoError(t, err)
+			require.Len(t, toolUses, 1)
+
+			a.AppendToolResults([]ToolResult{{ID: toolUses[0].ID, Output: "42"}})
+
+			resp, toolUses2, err := a.Call(context.Background())
+			require.NoError(t, err)
+			require.Empty(t, toolUses2)
+			require.Equal(t, "final answer", resp.Text)
+
+			msgs := decodeRequestMessages(t, requestBody(1))
+			require.NotEmpty(t, msgs)
+			last := msgs[len(msgs)-1]
+			require.Equal(t, "tool", last["role"])
+			require.Equal(t, "42", last["content"])
+			require.Equal(t, toolUses[0].ID, last["tool_call_id"])
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_AppendToolResults_EmptyOutputDefaultsMessage(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv, requestBody := sequencedJSONServer(t, []string{
+				chatCompletionToolCallJSON("cmpl-5", "call_e", "do_thing", `{}`),
+				chatCompletionTextJSON("cmpl-6", "ok"),
+			})
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			_, toolUses, err := a.Call(context.Background())
+			require.NoError(t, err)
+			require.Len(t, toolUses, 1)
+
+			a.AppendToolResults([]ToolResult{{ID: toolUses[0].ID, Output: "", IsErr: true}})
+			_, _, err = a.Call(context.Background())
+			require.NoError(t, err)
+
+			msgs := decodeRequestMessages(t, requestBody(1))
+			last := msgs[len(msgs)-1]
+			require.Equal(t, "unknown error occurred", last["content"])
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_ForceFinalResponse(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		t.Run(spec.name, func(t *testing.T) {
+			srv, requestBody := sequencedJSONServer(t, []string{chatCompletionTextJSON("cmpl-7", "final")})
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			resp, err := a.ForceFinalResponse(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, "final", resp.Text)
+
+			var decoded struct {
+				Tools []interface{} `json:"tools"`
+			}
+			require.NoError(t, json.Unmarshal(requestBody(0), &decoded))
+			require.Empty(t, decoded.Tools, "ForceFinalResponse must strip the tool list")
+
+			msgs := decodeRequestMessages(t, requestBody(0))
+			last := msgs[len(msgs)-1]
+			require.Equal(t, "user", last["role"])
+			require.Contains(t, last["content"], "final response")
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapters_SetTextDeltaHandlerEnablesStreaming(t *testing.T) {
+	for _, spec := range openAICompatSpecs() {
+		if !spec.supportsStreaming {
+			continue
+		}
+		t.Run(spec.name, func(t *testing.T) {
+			frames := []string{
+				`{"id":"s1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}`,
+				`{"id":"s1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"content":" there"},"finish_reason":"stop"}]}`,
+				`{"id":"s1","object":"chat.completion.chunk","created":1,"model":"test","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":2,"total_tokens":4}}`,
+			}
+			srv := sseServer(t, frames)
+			defer srv.Close()
+
+			a := spec.newAdapter(srv.URL)
+			var deltas []string
+			a.SetTextDeltaHandler(func(d string) { deltas = append(deltas, d) })
+
+			resp, toolUses, err := a.Call(context.Background())
+			require.NoError(t, err)
+			require.Empty(t, toolUses)
+			require.Equal(t, []string{"Hi", " there"}, deltas)
+			require.Equal(t, "Hi there", resp.Text)
+		})
+	}
+}
+
+// Local has no streaming path at all: LocalProvider has no CallStreaming, and
+// LocalAdapter.Call always issues a plain (non-streaming) request even once a
+// delta handler is set. A local server that only understands non-streaming
+// JSON responses proves this — a stray SSE-shaped request would fail to parse.
+func TestLocalAdapter_TextDeltaHandlerNeverInvoked(t *testing.T) {
+	srv, _ := sequencedJSONServer(t, []string{chatCompletionTextJSON("cmpl-l", "local reply")})
+	defer srv.Close()
+
+	a := NewLocalAdapter(NewLocalProvider(srv.URL, nil, nil), openai.ChatCompletionNewParams{Model: "test"}, nil, nil)
+	a.SetTextDeltaHandler(func(d string) { t.Fatalf("unexpected text delta %q: local adapter must never stream", d) })
+
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, "local reply", resp.Text)
+}
+
+func TestLocalAdapter_DisabledToolsAreFilteredAtConstruction(t *testing.T) {
+	tools := []openai.ChatCompletionToolUnionParam{
+		openai.ChatCompletionFunctionTool(openai.FunctionDefinitionParam{Name: "enabled_tool"}),
+		openai.ChatCompletionFunctionTool(openai.FunctionDefinitionParam{Name: "disabled_tool"}),
+	}
+	a := NewLocalAdapter(
+		NewLocalProvider("http://unused.invalid", nil, nil),
+		openai.ChatCompletionNewParams{Model: "test"},
+		tools,
+		map[string]bool{"disabled_tool": true},
+	)
+	require.Len(t, a.params.Tools, 1)
+	require.Equal(t, "enabled_tool", a.params.Tools[0].OfFunction.Function.Name)
+}
+
+func TestOpenAICompatibleAdapters_DisabledToolsAreFilteredAtConstruction(t *testing.T) {
+	tools := []openai.ChatCompletionToolUnionParam{
+		openai.ChatCompletionFunctionTool(openai.FunctionDefinitionParam{Name: "enabled_tool"}),
+		openai.ChatCompletionFunctionTool(openai.FunctionDefinitionParam{Name: "disabled_tool"}),
+	}
+	disabled := map[string]bool{"disabled_tool": true}
+
+	require.Len(t, NewMistralAdapter(NewMistralProvider("k", "http://unused.invalid", nil, nil), openai.ChatCompletionNewParams{Model: "test"}, tools, disabled).params.Tools, 1)
+	require.Len(t, NewDeepSeekAdapter(NewDeepSeekProvider("k", "http://unused.invalid", nil, nil), openai.ChatCompletionNewParams{Model: "test"}, tools, disabled).params.Tools, 1)
+	require.Len(t, NewQwenAdapter(NewQwenProvider("k", "http://unused.invalid", nil, nil), openai.ChatCompletionNewParams{Model: "test"}, tools, disabled).params.Tools, 1)
+	require.Len(t, NewXiaomiAdapter(NewXiaomiProvider("k", "http://unused.invalid", nil, nil), openai.ChatCompletionNewParams{Model: "test"}, tools, disabled).params.Tools, 1)
+}
+
+func TestDefaultBaseURLFallbacks(t *testing.T) {
+	require.NotEmpty(t, DefaultMistralBaseURL)
+	require.NotEmpty(t, DefaultDeepSeekBaseURL)
+	require.NotEmpty(t, DefaultQwenBaseURL)
+	require.NotEmpty(t, DefaultXiaomiBaseURL)
+	require.NotEmpty(t, DefaultLocalBaseURL)
+
+	// An empty baseURL argument must fall back to the provider's documented
+	// default rather than leaving the SDK client with no base URL at all.
+	require.NotNil(t, NewMistralProvider("k", "", nil, nil))
+	require.NotNil(t, NewDeepSeekProvider("k", "", nil, nil))
+	require.NotNil(t, NewQwenProvider("k", "", nil, nil))
+	require.NotNil(t, NewXiaomiProvider("k", "", nil, nil))
+	require.NotNil(t, NewLocalProvider("", nil, nil))
+}


### PR DESCRIPTION
Stacked on #10 (checkpoint 2), which stacks on #4 (checkpoint 1) —
checkpoint 3 of the coverage handoff plan, plus a follow-up closing
the claude/openai/gemini gap noted below.

## Summary
Mistral, DeepSeek, Qwen, Xiaomi, and Local (`internal/agent/provider/
{mistral,deepseek,qwen,xiaomi}_adapter.go` and `local.go`) are
near-identical wrappers over the OpenAI Chat Completions API — same
shape, different constants and error text. One shared table-driven
suite (`openai_compatible_adapters_test.go`) drives all five through
`httptest` servers rather than duplicating the same assertions five
times:

- text responses and tool-call rounds
- `AppendToolResults` folding into the next request (verified by
  inspecting the actual outgoing request body, not adapter-private
  fields)
- `ForceFinalResponse` stripping the tool list and appending the nudge
  message
- streaming via a text-delta handler
- a plain API error (400, non-safety-violation body) passing through
  wrapped but *not* misclassified as a safety violation
- disabled-tool filtering at adapter construction

Local gets two dedicated tests beyond the shared table: it has no
streaming path at all (no `CallStreaming`, and `Call` ignores any
delta handler even when one is set), which the shared table can't
express.

Every function in these five files now sits at 83–100% coverage (was
0–89%, with `Call`/`CallStreaming`/`AppendToolResults`/
`ForceFinalResponse`/`call`/`toGenerateResponse` all previously
untested). No test hits real network — everything is a local
`httptest.Server` with `option.WithBaseURL`, matching the pattern
already established in `chat_completions_stream_test.go`.

## Follow-up: claude/openai/gemini Call/ForceFinalResponse paths
Claude, OpenAI, and Gemini already had substantial dedicated test
files, but each adapter's core `Call`/`ForceFinalResponse`/streaming
paths were completely untested since they require a live HTTP
round-trip through their respective SDK clients — the earlier PR
description below flagged this as its own follow-up rather than
bolting mismatched tests onto the shared-adapter suite.

All three now get `httptest`-server-backed tests, same
`option.WithBaseURL` pattern as the shared suite above: text
responses, tool-call rounds, `AppendToolResults` folding into the
next request, `ForceFinalResponse` stripping tools and appending the
nudge message, streaming via a text-delta handler, and a plain API
error passing through wrapped but not misclassified as a safety
violation.

Anthropic's SSE stream decoder dispatches on the SSE `event:` line
rather than a type field embedded in the JSON body (unlike OpenAI's
and Gemini's Chat Completions streams), so Claude's streaming test
needed its own two-line `event:`/`data:` frame helper. Claude's
beta-MCP path (used when an MCP server is configured) is a
near-complete parallel implementation of the same logic against Beta
SDK types, so it gets its own equivalent test file.

Per-function coverage in these three files: 0% or 30-50% average
before, now at or near 100% except for a handful of narrow branches
not exercised by these tests (e.g.
`claudeBetaImageBlocksFromUserImages`'s non-image-generating-tool-call
branches).

## Original scope note — claude/openai/gemini adapters
The handoff doc's checkpoint 3 named all eight provider files as
"near-identical." That's true of the five covered by the shared
suite above, but not of `claude_adapter.go`, `openai_adapter.go`, or
`gemini_adapter.go` — those already had substantial dedicated test
files, and their previously-remaining uncovered functions were
bespoke, provider-specific SDK paths, not simple wrapper methods a
shared suite could cover. That gap is what the follow-up section
above closes.

## Coverage note
`go-unit` moved 33.6% → 34.3% → 35.7% across the two commits in this
PR (checkpoint 2 left it at 33.6%, originally 33.4% before checkpoint
1). This checkpoint's ≥48% target assumed all eight adapter files
were equally cheap to cover; even with the claude/openai/gemini
follow-up included, the total movement is well short of that number
because these files carry a bounded number of statements against a
much larger whole-codebase `-coverpkg` denominator. Flagging rather
than force-fitting unrelated work to hit the number.

## Test plan
- [x] `go test ./internal/agent/provider/...` passes
- [x] `make test-ci` passes (full suite green)
- [x] `make coverage-summary PROFILE=coverage/go-unit.out` →
      `35.7%` (from 33.6% at the start of this PR)
- [x] `gofmt`/`go vet` clean