### PR TITLE
Add datastore unit tests: shared harness, account backup, agent jobs

### DIFF
--- a/internal/datastore/accountbackup_test.go
+++ b/internal/datastore/accountbackup_test.go
@@ -3,6 +3,8 @@ package datastore
 import (
 	"archive/zip"
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -10,8 +12,891 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent/agentjob"
+	"github.com/theimaginaryfoundation/what-iff/ent/chatmessage"
+	"github.com/theimaginaryfoundation/what-iff/ent/mood"
+	"github.com/theimaginaryfoundation/what-iff/ent/personality"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
 )
+
+// createAccountBackupTestSchema creates the tables account backup import touches that
+// createMemoryImportTestSchema does not already provide: chat_messages (parent of
+// chat_message_context_items and tool_calls), moods, rituals, models, user_preferences,
+// tool_calls, agent_jobs, chat_message_context_items, personality_moods, and audit_logs.
+//
+// Must be composed after createMemoryImportTestSchema (users/chats/personalities are FK
+// parents here) via newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema).
+func createAccountBackupTestSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	statements := []string{
+		`CREATE TABLE moods (
+			id uuid PRIMARY KEY,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			name text NOT NULL,
+			description text NOT NULL DEFAULT '',
+			prompt_snippet text NOT NULL DEFAULT '',
+			thumbnail_data blob,
+			recommended_model text DEFAULT '',
+			user_moods uuid NOT NULL
+		)`,
+		`CREATE TABLE models (
+			id uuid PRIMARY KEY,
+			name text NOT NULL,
+			display_name text NOT NULL,
+			description text NOT NULL,
+			provider text NOT NULL DEFAULT 'openai',
+			tool_support bool NOT NULL DEFAULT false,
+			base_credits_per_slab integer NOT NULL DEFAULT 1,
+			subscription_tier text NOT NULL DEFAULT 'high',
+			deleted bool NOT NULL DEFAULT false,
+			is_default bool NOT NULL DEFAULT false
+		)`,
+		`CREATE TABLE user_preferences (
+			id uuid PRIMARY KEY,
+			theme text NOT NULL DEFAULT 'dark',
+			last_seen_announcement text DEFAULT '',
+			experimental_memory_dedupe_chain bool NOT NULL DEFAULT false,
+			favorite_model_ids json NOT NULL DEFAULT '[]',
+			user_preferences uuid NOT NULL UNIQUE,
+			default_model uuid NOT NULL,
+			default_personality uuid
+		)`,
+		`CREATE TABLE rituals (
+			id uuid PRIMARY KEY,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			name text NOT NULL,
+			description text NOT NULL,
+			content text NOT NULL,
+			hotkeys text NOT NULL,
+			agent_job_rituals uuid,
+			mood_rituals uuid,
+			ritual_personality uuid,
+			user_rituals uuid NOT NULL
+		)`,
+		`CREATE TABLE chat_messages (
+			id uuid PRIMARY KEY,
+			message text NOT NULL,
+			origin text NOT NULL,
+			read_status text NOT NULL DEFAULT 'read',
+			response_id text,
+			sent_at datetime NOT NULL,
+			tokens integer,
+			generation_model text,
+			generation_personality text,
+			generation_expression_reasoning text,
+			last_error_message text,
+			checkpoint_completed_at datetime,
+			context_breakdown json,
+			chat_messages uuid NOT NULL,
+			chat_message_generation_mood uuid,
+			chat_message_generation_expression uuid
+		)`,
+		`CREATE TABLE chat_message_context_items (
+			id uuid PRIMARY KEY,
+			type text NOT NULL,
+			content text NOT NULL,
+			memory_id uuid,
+			scope text,
+			chat_message_context_items uuid NOT NULL
+		)`,
+		`CREATE TABLE tool_calls (
+			id uuid PRIMARY KEY,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			tool_name text NOT NULL,
+			tool_input text,
+			tool_output text,
+			tool_error text,
+			chat_message_tool_calls uuid NOT NULL
+		)`,
+		`CREATE TABLE agent_jobs (
+			id uuid PRIMARY KEY,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			title text,
+			prompt text NOT NULL,
+			schedule_input text NOT NULL,
+			schedule_type text NOT NULL,
+			schedule text,
+			run_at datetime,
+			timezone text NOT NULL DEFAULT 'UTC',
+			status text NOT NULL DEFAULT 'active',
+			next_run_at datetime,
+			last_run_at datetime,
+			last_error text,
+			run_count integer NOT NULL DEFAULT 0,
+			personality_id uuid,
+			model_id uuid,
+			chat_agent_jobs uuid,
+			user_agent_jobs uuid NOT NULL
+		)`,
+		`CREATE TABLE personality_moods (
+			personality_id uuid NOT NULL,
+			mood_id uuid NOT NULL,
+			PRIMARY KEY (personality_id, mood_id)
+		)`,
+		`CREATE TABLE audit_logs (
+			id uuid PRIMARY KEY,
+			occurred_at datetime NOT NULL,
+			category text NOT NULL,
+			action text NOT NULL,
+			message text NOT NULL,
+			actor_user_id uuid,
+			subject_user_id uuid
+		)`,
+	}
+	for _, stmt := range statements {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err)
+	}
+}
+
+func newAccountBackupTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema)
+}
+
+func TestAdminImportAccountBackup_UserNotFound(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+	})
+
+	_, err := ds.AdminImportAccountBackup(context.Background(), uuid.New(), zr, nil)
+	require.ErrorIs(t, err, ErrUserNotFound)
+}
+
+func createAccountBackupTestUser(t *testing.T, ds *Datastore, userID uuid.UUID) {
+	t.Helper()
+	_, err := ds.dbClient.User.Create().
+		SetID(userID).
+		SetUsername("backup-" + userID.String()[:8]).
+		SetEmail("backup-" + userID.String()[:8] + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+}
+
+func TestAdminImportAccountBackup_UnsupportedVersion(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":99}`,
+	})
+
+	_, err := ds.AdminImportAccountBackup(context.Background(), userID, zr, nil)
+	require.ErrorIs(t, err, ErrUnsupportedAccountBackupVersion)
+}
+
+func TestAdminImportAccountBackup_MissingManifest(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"moods.jsonl": "",
+	})
+
+	_, err := ds.AdminImportAccountBackup(context.Background(), userID, zr, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errBackupEntryNotFound)
+}
+
+// createAccountBackupTestModelAndPreference creates a model row and a user_preferences row
+// pointing the given user's default model at it, so defaultModelIDForUser resolves.
+func createAccountBackupTestModelAndPreference(t *testing.T, ds *Datastore, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	m, err := ds.dbClient.Model.Create().
+		SetName("gpt-test").
+		SetDisplayName("GPT Test").
+		SetDescription("test model").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = ds.dbClient.UserPreference.Create().
+		SetUserID(userID).
+		SetModelID(m.ID).
+		Save(ctx)
+	require.NoError(t, err)
+	return m.ID
+}
+
+func accountBackupJSONL[T any](t *testing.T, records ...T) string {
+	t.Helper()
+	lines := make([]string, len(records))
+	for i, rec := range records {
+		b, err := json.Marshal(rec)
+		require.NoError(t, err)
+		lines[i] = string(b)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestAdminImportAccountBackup_HappyPath(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	moodID := uuid.New()
+	personalityID := uuid.New()
+	ritualID := uuid.New()
+	chatID := uuid.New()
+	chatMessageID := uuid.New()
+	contextItemID := uuid.New()
+	toolCallID := uuid.New()
+	agentJobID := uuid.New()
+
+	entries := map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"moods.jsonl": accountBackupJSONL(t, models.AccountBackupMood{
+			ID: moodID, Name: "Curious", Description: "d", PromptSnippet: "p",
+			CreatedAt: now, UpdatedAt: now,
+		}),
+		"personalities.jsonl": accountBackupJSONL(t, models.AccountBackupPersonality{
+			ID: personalityID, Name: "Vix", SystemPrompt: "system prompt",
+			CreatedAt: now, UpdatedAt: now,
+		}),
+		"personality_moods.jsonl": accountBackupJSONL(t, models.AccountBackupPersonalityMood{
+			PersonalityID: personalityID, MoodID: moodID,
+		}),
+		"rituals.jsonl": accountBackupJSONL(t, models.AccountBackupRitual{
+			ID: ritualID, Name: "Morning", Description: "desc", Content: "content", Hotkeys: "",
+			CreatedAt: now, UpdatedAt: now,
+		}),
+		"chats.jsonl": accountBackupJSONL(t, models.AccountBackupChat{
+			ID: chatID, Name: "Chat 1", PersonalityID: &personalityID, ActiveMoodID: &moodID,
+			CreatedAt: now, UpdatedAt: now,
+		}),
+		"chat_messages.jsonl": accountBackupJSONL(t, models.AccountBackupChatMessage{
+			ID: chatMessageID, ChatID: chatID, Message: "hello", Origin: models.MessageOriginUser,
+			ReadStatus: "read", SentAt: now,
+		}),
+		"chat_message_context_items.jsonl": accountBackupJSONL(t, models.AccountBackupChatMessageContextItem{
+			ID: contextItemID, ChatMessageID: chatMessageID, Type: "note", Content: "ctx",
+		}),
+		"tool_calls.jsonl": accountBackupJSONL(t, models.AccountBackupToolCall{
+			ID: toolCallID, ChatMessageID: chatMessageID, ToolName: "search",
+			CreatedAt: now, UpdatedAt: now,
+		}),
+		"agent_jobs.jsonl": accountBackupJSONL(t, models.AccountBackupAgentJob{
+			ID: agentJobID, Prompt: "do things", ScheduleInput: "daily",
+			ScheduleType: models.AgentJobScheduleTypeCron, Timezone: "UTC",
+			Status: models.AgentJobStatusActive, CreatedAt: now, UpdatedAt: now,
+		}),
+	}
+	zr := buildZipReaderForTest(t, entries)
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, func(context.Context, string) ([]float32, error) {
+		return []float32{0.1}, nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, models.AccountBackupFormatVersion, result.FormatVersion)
+	require.Equal(t, 1, result.Sections["moods"].Created)
+	require.Equal(t, 1, result.Sections["personalities"].Created)
+	require.Equal(t, 1, result.Sections["personality_moods"].Created)
+	require.Equal(t, 1, result.Sections["rituals"].Created)
+	require.Equal(t, 1, result.Sections["chats"].Created)
+	require.Equal(t, 1, result.Sections["chat_messages"].Created)
+	require.Equal(t, 1, result.Sections["chat_message_context_items"].Created)
+	require.Equal(t, 1, result.Sections["tool_calls"].Created)
+	require.Equal(t, 1, result.Sections["agent_jobs"].Created)
+
+	moodOK, err := ds.moodBelongsToUser(ctx, userID, moodID)
+	require.NoError(t, err)
+	require.True(t, moodOK)
+	personalityOK, err := ds.personalityBelongsToUser(ctx, userID, personalityID)
+	require.NoError(t, err)
+	require.True(t, personalityOK)
+	ritualOK, err := ds.ritualBelongsToUser(ctx, userID, ritualID)
+	require.NoError(t, err)
+	require.True(t, ritualOK)
+	chatOK, err := ds.chatBelongsToUser(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.True(t, chatOK)
+	chatMessageOK, err := ds.chatMessageBelongsToUser(ctx, userID, chatMessageID)
+	require.NoError(t, err)
+	require.True(t, chatMessageOK)
+	contextItemOK, err := ds.contextItemBelongsToUser(ctx, userID, contextItemID)
+	require.NoError(t, err)
+	require.True(t, contextItemOK)
+	toolCallOK, err := ds.toolCallBelongsToUser(ctx, userID, toolCallID)
+	require.NoError(t, err)
+	require.True(t, toolCallOK)
+	agentJobOK, err := ds.agentJobBelongsToUser(ctx, userID, agentJobID)
+	require.NoError(t, err)
+	require.True(t, agentJobOK)
+
+	linked, err := ds.dbClient.Personality.Query().
+		Where(personality.ID(personalityID), personality.HasMoodsWith(mood.ID(moodID))).
+		Exist(ctx)
+	require.NoError(t, err)
+	require.True(t, linked, "personality_moods join row should exist")
+}
+
+func TestAdminImportAccountBackup_MoodDuplicateAndConflict(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	createAccountBackupTestUser(t, ds, otherUserID)
+	createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Owned by target user already -> re-import is a duplicate no-op.
+	existingOwnID := uuid.New()
+	_, err := ds.dbClient.Mood.Create().
+		SetID(existingOwnID).SetName("Existing").SetOwnerID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	// Owned by a different user -> conflict.
+	conflictID := uuid.New()
+	_, err = ds.dbClient.Mood.Create().
+		SetID(conflictID).SetName("Other's").SetOwnerID(otherUserID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	newID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"moods.jsonl": accountBackupJSONL(t,
+			models.AccountBackupMood{ID: existingOwnID, Name: "Existing", CreatedAt: now, UpdatedAt: now},
+			models.AccountBackupMood{ID: conflictID, Name: "Other's", CreatedAt: now, UpdatedAt: now},
+			models.AccountBackupMood{ID: newID, Name: "New", CreatedAt: now, UpdatedAt: now},
+		),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.AccountBackupSectionResult{Created: 1, Duplicate: 1, Conflict: 1}, result.Sections["moods"])
+
+	ok, err := ds.moodBelongsToUser(ctx, userID, newID)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestAdminImportAccountBackup_ChatDuplicateAndConflict(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	createAccountBackupTestUser(t, ds, otherUserID)
+	modelID := createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	existingOwnID := uuid.New()
+	_, err := ds.dbClient.Chat.Create().
+		SetID(existingOwnID).SetName("Existing Chat").SetOwnerID(userID).SetModelID(modelID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	conflictID := uuid.New()
+	_, err = ds.dbClient.Chat.Create().
+		SetID(conflictID).SetName("Other's Chat").SetOwnerID(otherUserID).SetModelID(modelID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	newID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"chats.jsonl": accountBackupJSONL(t,
+			models.AccountBackupChat{ID: existingOwnID, Name: "Existing Chat", CreatedAt: now, UpdatedAt: now},
+			models.AccountBackupChat{ID: conflictID, Name: "Other's Chat", CreatedAt: now, UpdatedAt: now},
+			models.AccountBackupChat{ID: newID, Name: "New Chat", CreatedAt: now, UpdatedAt: now},
+		),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Sections["chats"].Created)
+	require.Equal(t, 1, result.Sections["chats"].Duplicate)
+	require.Equal(t, 1, result.Sections["chats"].Conflict)
+
+	ok, err := ds.chatBelongsToUser(ctx, userID, newID)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestAdminImportAccountBackup_ChatMessageMissingRefChat(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	missingChatID := uuid.New()
+	msgID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"chat_messages.jsonl": accountBackupJSONL(t, models.AccountBackupChatMessage{
+			ID: msgID, ChatID: missingChatID, Message: "orphan", Origin: models.MessageOriginUser,
+			ReadStatus: "read", SentAt: now,
+		}),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.AccountBackupSectionResult{MissingRef: 1}, result.Sections["chat_messages"])
+
+	exists, err := ds.dbClient.ChatMessage.Query().Where(chatmessage.ID(msgID)).Exist(ctx)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestAdminImportAccountBackup_PersonalityMoodMissingRef(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	personalityID := uuid.New()
+	_, err := ds.dbClient.Personality.Create().
+		SetID(personalityID).SetName("Vix").SetSystemPrompt("sp").SetUserID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	missingMoodID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"personality_moods.jsonl": accountBackupJSONL(t, models.AccountBackupPersonalityMood{
+			PersonalityID: personalityID, MoodID: missingMoodID,
+		}),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.AccountBackupSectionResult{MissingRef: 1}, result.Sections["personality_moods"])
+}
+
+func TestAdminImportAccountBackup_ChatMissingPersonalityAndMoodRefsStillCreatesChat(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	chatID := uuid.New()
+	missingPersonalityID := uuid.New()
+	missingMoodID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"chats.jsonl": accountBackupJSONL(t, models.AccountBackupChat{
+			ID: chatID, Name: "Chat", PersonalityID: &missingPersonalityID, ActiveMoodID: &missingMoodID,
+			CreatedAt: now, UpdatedAt: now,
+		}),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Sections["chats"].Created)
+	require.Equal(t, 2, result.Sections["chats"].MissingRef)
+
+	ok, err := ds.chatBelongsToUser(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.True(t, ok, "chat should still be created despite missing refs")
+}
+
+func TestAdminImportAccountBackup_InvalidRitualAndPersonality(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"personalities.jsonl": accountBackupJSONL(t, models.AccountBackupPersonality{
+			ID: uuid.New(), Name: "  ", SystemPrompt: "sp", CreatedAt: now, UpdatedAt: now,
+		}),
+		"rituals.jsonl": accountBackupJSONL(t, models.AccountBackupRitual{
+			ID: uuid.New(), Name: "ok", Description: "", Content: "content", CreatedAt: now, UpdatedAt: now,
+		}),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.AccountBackupSectionResult{Invalid: 1}, result.Sections["personalities"])
+	require.Equal(t, models.AccountBackupSectionResult{Invalid: 1}, result.Sections["rituals"])
+}
+
+func TestReadBackupJSONL_SkipsMalformedLinesAndCountsInvalid(t *testing.T) {
+	validID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+	content := strings.Join([]string{
+		accountBackupJSONL(t, models.AccountBackupMood{ID: validID, Name: "ok", CreatedAt: now, UpdatedAt: now}),
+		`{"id":`,
+		"",
+		"   ",
+	}, "\n")
+
+	zr := buildZipReaderForTest(t, map[string]string{"moods.jsonl": content})
+
+	records, invalid, err := readBackupJSONL[models.AccountBackupMood](zr, "moods.jsonl")
+	require.NoError(t, err)
+	require.Equal(t, 1, invalid)
+	require.Len(t, records, 1)
+	require.Equal(t, validID, records[0].ID)
+}
+
+func TestReadBackupJSONL_MissingFileReturnsNoError(t *testing.T) {
+	zr := buildZipReaderForTest(t, map[string]string{"other.jsonl": ""})
+
+	records, invalid, err := readBackupJSONL[models.AccountBackupMood](zr, "moods.jsonl")
+	require.NoError(t, err)
+	require.Zero(t, invalid)
+	require.Nil(t, records)
+}
+
+func TestDefaultModelIDForUser(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+
+	_, err := ds.defaultModelIDForUser(ctx, userID)
+	require.ErrorIs(t, err, ErrAccountBackupDefaultModelMissing)
+
+	modelID := createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	got, err := ds.defaultModelIDForUser(ctx, userID)
+	require.NoError(t, err)
+	require.Equal(t, modelID, got)
+}
+
+func TestOpenBackupEntry_NotFound(t *testing.T) {
+	zr := buildZipReaderForTest(t, map[string]string{"other.json": "{}"})
+
+	_, err := openBackupEntry(zr, "manifest.json")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errBackupEntryNotFound)
+}
+
+func TestReadBackupManifest_MissingFileWrapsErrBackupEntryNotFound(t *testing.T) {
+	zr := buildZipReaderForTest(t, map[string]string{"other.json": "{}"})
+
+	_, err := readBackupManifest(zr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errBackupEntryNotFound)
+}
+
+func TestUserOwnedIDState(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	createAccountBackupTestUser(t, ds, otherUserID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	ownedID := uuid.New()
+	_, err := ds.dbClient.Mood.Create().
+		SetID(ownedID).SetName("mine").SetOwnerID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	conflictID := uuid.New()
+	_, err = ds.dbClient.Mood.Create().
+		SetID(conflictID).SetName("theirs").SetOwnerID(otherUserID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		id   uuid.UUID
+		want accountBackupIDState
+	}{
+		{name: "nil id is a conflict", id: uuid.Nil, want: accountBackupIDConflict},
+		{name: "owned by target user is a duplicate", id: ownedID, want: accountBackupIDDuplicate},
+		{name: "owned by another user is a conflict", id: conflictID, want: accountBackupIDConflict},
+		{name: "unknown id is missing", id: uuid.New(), want: accountBackupIDMissing},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ds.userOwnedIDState(ctx, accountBackupEntityMood, tc.id, userID)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEntityExistsAndBelongsToUser_UnknownEntity(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := ds.entityExists(ctx, accountBackupEntity("bogus"), uuid.New())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown account backup entity")
+
+	_, err = ds.entityBelongsToUser(ctx, accountBackupEntity("bogus"), uuid.New(), uuid.New())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown account backup entity")
+}
+
+func TestEntityExistsAndBelongsToUser_PerEntity(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	ritualID := uuid.New()
+	_, err := ds.dbClient.Ritual.Create().
+		SetID(ritualID).SetOwnerID(userID).SetName("r").SetDescription("d").SetContent("c").SetHotkeys("").
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	agentJobID := uuid.New()
+	_, err = ds.dbClient.AgentJob.Create().
+		SetID(agentJobID).SetOwnerID(userID).SetPrompt("p").SetScheduleInput("daily").
+		SetScheduleType(agentjob.ScheduleTypeCron).SetStatus(agentjob.StatusActive).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	for _, entity := range []accountBackupEntity{accountBackupEntityRitual, accountBackupEntityAgentJob} {
+		var id uuid.UUID
+		switch entity {
+		case accountBackupEntityRitual:
+			id = ritualID
+		case accountBackupEntityAgentJob:
+			id = agentJobID
+		}
+		exists, err := ds.entityExists(ctx, entity, id)
+		require.NoError(t, err)
+		require.True(t, exists, "entityExists should find %s", entity)
+
+		belongs, err := ds.entityBelongsToUser(ctx, entity, id, userID)
+		require.NoError(t, err)
+		require.True(t, belongs, "entityBelongsToUser should find %s owned by user", entity)
+
+		exists, err = ds.entityExists(ctx, entity, uuid.New())
+		require.NoError(t, err)
+		require.False(t, exists)
+	}
+}
+
+func TestAdminImportAccountBackup_AgentJobFullFieldsAndDuplicate(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	modelID := createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	personalityID := uuid.New()
+	_, err := ds.dbClient.Personality.Create().
+		SetID(personalityID).SetName("Vix").SetSystemPrompt("sp").SetUserID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	chatID := uuid.New()
+	_, err = ds.dbClient.Chat.Create().
+		SetID(chatID).SetName("Chat").SetOwnerID(userID).SetModelID(modelID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	m, err := ds.dbClient.Model.Query().Only(ctx)
+	require.NoError(t, err)
+
+	title := "Weekly digest"
+	schedule := "0 9 * * MON"
+	agentJobID := uuid.New()
+	missingChatID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"agent_jobs.jsonl": accountBackupJSONL(t,
+			models.AccountBackupAgentJob{
+				ID: agentJobID, ChatID: &chatID, PersonalityID: &personalityID, ModelName: m.Name,
+				Title: &title, Prompt: "summarize", ScheduleInput: "weekly",
+				ScheduleType: models.AgentJobScheduleTypeCron, Schedule: &schedule, Timezone: "UTC",
+				Status: models.AgentJobStatusActive, RunCount: 3, LastError: "previous failure",
+				CreatedAt: now, UpdatedAt: now,
+			},
+			models.AccountBackupAgentJob{
+				ID: uuid.New(), ChatID: &missingChatID, Prompt: "orphan", ScheduleInput: "once",
+				ScheduleType: models.AgentJobScheduleTypeAt, Timezone: "UTC",
+				Status: models.AgentJobStatusPaused, CreatedAt: now, UpdatedAt: now,
+			},
+			models.AccountBackupAgentJob{
+				ID: agentJobID, Prompt: "summarize", ScheduleInput: "weekly",
+				ScheduleType: models.AgentJobScheduleTypeCron, Timezone: "UTC",
+				Status: models.AgentJobStatusActive, CreatedAt: now, UpdatedAt: now,
+			},
+		),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Sections["agent_jobs"].Created)
+	require.Equal(t, 1, result.Sections["agent_jobs"].MissingRef)
+	require.Equal(t, 1, result.Sections["agent_jobs"].Duplicate)
+
+	ok, err := ds.agentJobBelongsToUser(ctx, userID, agentJobID)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestAdminImportAccountBackup_RitualWithPersonalityRef(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	personalityID := uuid.New()
+	_, err := ds.dbClient.Personality.Create().
+		SetID(personalityID).SetName("Vix").SetSystemPrompt("sp").SetUserID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	ritualWithRefID := uuid.New()
+	ritualMissingRefID := uuid.New()
+	missingPersonalityID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"rituals.jsonl": accountBackupJSONL(t,
+			models.AccountBackupRitual{
+				ID: ritualWithRefID, Name: "Linked", Description: "d", Content: "c",
+				PersonalityID: &personalityID, CreatedAt: now, UpdatedAt: now,
+			},
+			models.AccountBackupRitual{
+				ID: ritualMissingRefID, Name: "Orphan", Description: "d", Content: "c",
+				PersonalityID: &missingPersonalityID, CreatedAt: now, UpdatedAt: now,
+			},
+		),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Sections["rituals"].Created)
+	require.Equal(t, 1, result.Sections["rituals"].MissingRef)
+
+	ok, err := ds.ritualBelongsToUser(ctx, userID, ritualWithRefID)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestAdminImportAccountBackup_ChatMessageDuplicateAndContextItemToolCallGenerationMood(t *testing.T) {
+	ds, cleanup := newAccountBackupTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := uuid.New()
+	createAccountBackupTestUser(t, ds, userID)
+	modelID := createAccountBackupTestModelAndPreference(t, ds, userID)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	chatID := uuid.New()
+	_, err := ds.dbClient.Chat.Create().
+		SetID(chatID).SetName("Chat").SetOwnerID(userID).SetModelID(modelID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	moodID := uuid.New()
+	_, err = ds.dbClient.Mood.Create().
+		SetID(moodID).SetName("Curious").SetOwnerID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	existingMsgID := uuid.New()
+	_, err = ds.dbClient.ChatMessage.Create().
+		SetID(existingMsgID).SetMessage("hi").SetOrigin(chatmessage.OriginUser).
+		SetReadStatus(chatmessage.ReadStatusRead).SetChatID(chatID).SetSentAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	newMsgID := uuid.New()
+	missingMoodID := uuid.New()
+
+	zr := buildZipReaderForTest(t, map[string]string{
+		"manifest.json": `{"format_version":1}`,
+		"chat_messages.jsonl": accountBackupJSONL(t,
+			models.AccountBackupChatMessage{
+				ID: existingMsgID, ChatID: chatID, Message: "hi", Origin: models.MessageOriginUser,
+				ReadStatus: "read", SentAt: now,
+			},
+			models.AccountBackupChatMessage{
+				ID: newMsgID, ChatID: chatID, Message: "with mood", Origin: models.MessageOriginAssistant,
+				ReadStatus: "read", GenerationModel: "gpt-test", GenerationPersonality: "Vix",
+				GenerationMoodID: &moodID, SentAt: now, Tokens: 42,
+			},
+			models.AccountBackupChatMessage{
+				ID: uuid.New(), ChatID: chatID, Message: "missing mood", Origin: models.MessageOriginAssistant,
+				ReadStatus: "read", GenerationMoodID: &missingMoodID, SentAt: now,
+			},
+		),
+		"chat_message_context_items.jsonl": accountBackupJSONL(t, models.AccountBackupChatMessageContextItem{
+			ID: uuid.New(), ChatMessageID: newMsgID, Type: "note", Content: "ctx",
+		}),
+		"tool_calls.jsonl": accountBackupJSONL(t, models.AccountBackupToolCall{
+			ID: uuid.New(), ChatMessageID: newMsgID, ToolName: "search",
+			ToolInput: "q", ToolOutput: "result", ToolError: "",
+			CreatedAt: now, UpdatedAt: now,
+		}),
+	})
+
+	result, err := ds.AdminImportAccountBackup(ctx, userID, zr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.Sections["chat_messages"].Created)
+	require.Equal(t, 1, result.Sections["chat_messages"].Duplicate)
+	require.Equal(t, 1, result.Sections["chat_messages"].MissingRef)
+	require.Equal(t, 1, result.Sections["chat_message_context_items"].Created)
+	require.Equal(t, 1, result.Sections["tool_calls"].Created)
+}
 
 func TestReadBackupJSONLAllowsLargeRecords(t *testing.T) {
 	var buf bytes.Buffer

--- a/internal/datastore/agentjob.go
+++ b/internal/datastore/agentjob.go
@@ -709,10 +709,18 @@ func (d *Datastore) SetAgentJobOverrides(ctx context.Context, userID, id uuid.UU
 	update := tx.AgentJob.Update().
 		Where(agentjob.ID(id), agentjob.HasOwnerWith(user.ID(userID)))
 	if patch.UpdatePersonality {
-		update.SetNillablePersonalityID(patch.PersonalityID)
+		if patch.PersonalityID != nil {
+			update.SetPersonalityID(*patch.PersonalityID)
+		} else {
+			update.ClearPersonalityID()
+		}
 	}
 	if patch.UpdateModel {
-		update.SetNillableModelID(patch.ModelID)
+		if patch.ModelID != nil {
+			update.SetModelID(*patch.ModelID)
+		} else {
+			update.ClearModelID()
+		}
 	}
 
 	affected, err := update.Save(ctx)

--- a/internal/datastore/agentjob_test.go
+++ b/internal/datastore/agentjob_test.go
@@ -783,21 +783,15 @@ func TestSetAgentJobOverrides_HappyPath(t *testing.T) {
 	require.NotNil(t, got.ModelID)
 	require.Equal(t, modelID, *got.ModelID)
 
-	// NOTE: despite the SetAgentJobOverridesPatch doc comment saying a nil ID with the
-	// Update flag set "clears" the override, the implementation calls SetNillablePersonalityID /
-	// SetNillableModelID, which are no-ops when the pointer is nil (see ent's generated
-	// AgentJobUpdate.SetNillableModelID). So passing UpdatePersonality/UpdateModel = true with a
-	// nil ID currently leaves the existing override untouched rather than clearing it. This test
-	// documents that actual (likely unintended) behavior rather than the doc comment's contract.
+	// Per the SetAgentJobOverridesPatch doc comment, the Update flag set with a nil ID clears
+	// the override rather than leaving the existing value untouched.
 	got, err = ds.SetAgentJobOverrides(ctx, userID, created.ID, models.SetAgentJobOverridesPatch{
 		UpdatePersonality: true,
 		UpdateModel:       true,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, got.PersonalityID)
-	require.Equal(t, personalityID, *got.PersonalityID)
-	require.NotNil(t, got.ModelID)
-	require.Equal(t, modelID, *got.ModelID)
+	require.Nil(t, got.PersonalityID)
+	require.Nil(t, got.ModelID)
 }
 
 func TestSetAgentJobOverrides_InvalidPersonality(t *testing.T) {

--- a/internal/datastore/agentjob_test.go
+++ b/internal/datastore/agentjob_test.go
@@ -1,0 +1,1136 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// alterChatsTableForAgentJobTests adds columns that exist in the real ent chats schema
+// (ent/migrate/schema.go's ChatsColumns) but not in createMemoryImportTestSchema's chats
+// table fixture. agentjob.go's WithChat() eager-load selects every chat column, so a missing
+// column ("source" and friends) surfaces as a sqlite "no such column" error at query time.
+func alterChatsTableForAgentJobTests(t *testing.T, db *sql.DB) {
+	t.Helper()
+	statements := []string{
+		`ALTER TABLE chats ADD COLUMN source text`,
+		`ALTER TABLE chats ADD COLUMN import_hash text`,
+		`ALTER TABLE chats ADD COLUMN rehydration_state text`,
+	}
+	for _, stmt := range statements {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err)
+	}
+}
+
+func newAgentJobTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, alterChatsTableForAgentJobTests)
+}
+
+func createAgentJobTestUser(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := ds.dbClient.User.Create().
+		SetID(id).
+		SetUsername("job-" + id.String()[:8]).
+		SetEmail("job-" + id.String()[:8] + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+	return id
+}
+
+func createAgentJobTestModel(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	m, err := ds.dbClient.Model.Create().
+		SetName("model-" + uuid.NewString()[:8]).
+		SetDisplayName("Test Model").
+		SetDescription("test model").
+		Save(context.Background())
+	require.NoError(t, err)
+	return m.ID
+}
+
+func createAgentJobTestPersonality(t *testing.T, ds *Datastore, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	p, err := ds.dbClient.Personality.Create().
+		SetName("Vix").
+		SetSystemPrompt("system prompt").
+		SetUserID(userID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return p.ID
+}
+
+func createAgentJobTestChat(t *testing.T, ds *Datastore, userID, modelID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	c, err := ds.dbClient.Chat.Create().
+		SetName("Chat").
+		SetOwnerID(userID).
+		SetModelID(modelID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return c.ID
+}
+
+func createAgentJobTestRitual(t *testing.T, ds *Datastore, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	r, err := ds.dbClient.Ritual.Create().
+		SetOwnerID(userID).
+		SetName("Morning").
+		SetDescription("desc").
+		SetContent("content").
+		SetHotkeys("").
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return r.ID
+}
+
+func baseAgentJobModel() models.AgentJob {
+	return models.AgentJob{
+		Prompt:        "do the thing",
+		ScheduleInput: "daily",
+		ScheduleType:  models.AgentJobScheduleTypeCron,
+		Timezone:      "UTC",
+		Status:        models.AgentJobStatusActive,
+	}
+}
+
+func TestNormalizeAgentJobDatastoreUnexpectedError(t *testing.T) {
+	require.NoError(t, normalizeAgentJobDatastoreUnexpectedError(nil))
+
+	err := normalizeAgentJobDatastoreUnexpectedError(errors.New("boom"))
+	require.ErrorIs(t, err, ErrInternalDatastore)
+}
+
+func TestToAgentJobModel_Nil(t *testing.T) {
+	require.Nil(t, toAgentJobModel(nil))
+}
+
+// shouldReactivateAgentJobAfterScheduleSave already has direct unit coverage in
+// agentjob_schedule_reactivate_test.go; the full UpdateAgentJobSchedule tests below
+// exercise its effect end-to-end (status flips back to active).
+
+func TestCreateAgentJob_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	modelID := createAgentJobTestModel(t, ds)
+	personalityID := createAgentJobTestPersonality(t, ds, userID)
+	chatID := createAgentJobTestChat(t, ds, userID, modelID)
+
+	title := "Weekly digest"
+	jobModel := baseAgentJobModel()
+	jobModel.Title = &title
+	jobModel.ChatID = &chatID
+	jobModel.PersonalityID = &personalityID
+	jobModel.ModelID = &modelID
+
+	got, err := ds.CreateAgentJob(ctx, userID, jobModel)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, userID, got.UserID)
+	require.NotNil(t, got.ChatID)
+	require.Equal(t, chatID, *got.ChatID)
+	require.NotNil(t, got.PersonalityID)
+	require.Equal(t, personalityID, *got.PersonalityID)
+	require.NotNil(t, got.ModelID)
+	require.Equal(t, modelID, *got.ModelID)
+	require.Equal(t, title, *got.Title)
+	require.Equal(t, "do the thing", got.Prompt)
+	require.Equal(t, models.AgentJobStatusActive, got.Status)
+}
+
+func TestCreateAgentJob_UserNotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.CreateAgentJob(context.Background(), uuid.New(), baseAgentJobModel())
+	require.ErrorIs(t, err, ErrUnauthorized)
+}
+
+func TestCreateAgentJob_ChatNotOwnedByUser(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	modelID := createAgentJobTestModel(t, ds)
+	chatID := createAgentJobTestChat(t, ds, otherUserID, modelID)
+
+	jobModel := baseAgentJobModel()
+	jobModel.ChatID = &chatID
+
+	_, err := ds.CreateAgentJob(context.Background(), userID, jobModel)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestCreateAgentJob_ChatDoesNotExist(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	missingChatID := uuid.New()
+
+	jobModel := baseAgentJobModel()
+	jobModel.ChatID = &missingChatID
+
+	_, err := ds.CreateAgentJob(context.Background(), userID, jobModel)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestCreateAgentJob_InvalidPersonalityOverride(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	missingPersonalityID := uuid.New()
+
+	jobModel := baseAgentJobModel()
+	jobModel.PersonalityID = &missingPersonalityID
+
+	_, err := ds.CreateAgentJob(context.Background(), userID, jobModel)
+	require.ErrorIs(t, err, ErrInvalidRequestBody)
+}
+
+func TestCreateAgentJob_PersonalityOwnedByAnotherUser(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	personalityID := createAgentJobTestPersonality(t, ds, otherUserID)
+
+	jobModel := baseAgentJobModel()
+	jobModel.PersonalityID = &personalityID
+
+	_, err := ds.CreateAgentJob(context.Background(), userID, jobModel)
+	require.ErrorIs(t, err, ErrInvalidRequestBody)
+}
+
+func TestCreateAgentJob_InvalidModelOverride(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	missingModelID := uuid.New()
+
+	jobModel := baseAgentJobModel()
+	jobModel.ModelID = &missingModelID
+
+	_, err := ds.CreateAgentJob(context.Background(), userID, jobModel)
+	require.ErrorIs(t, err, ErrInvalidRequestBody)
+}
+
+func TestGetAgentJob_Found(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	got, err := ds.GetAgentJob(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+	require.Equal(t, "do the thing", got.Prompt)
+}
+
+func TestGetAgentJob_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.GetAgentJob(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestGetAgentJob_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.GetAgentJob(ctx, otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestListAgentJobs_UserScoping(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+
+	_, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+	_, err = ds.CreateAgentJob(ctx, otherUserID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	resp, err := ds.ListAgentJobs(ctx, userID, 1, 10, models.AgentJobFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.TotalCount)
+	require.Len(t, resp.Results, 1)
+}
+
+func TestListAgentJobs_FiltersAndPagination(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+
+	active := baseAgentJobModel()
+	active.Title = strPtr("Morning report")
+	_, err := ds.CreateAgentJob(ctx, userID, active)
+	require.NoError(t, err)
+
+	paused := baseAgentJobModel()
+	paused.Status = models.AgentJobStatusPaused
+	paused.ScheduleType = models.AgentJobScheduleTypeAt
+	paused.Title = strPtr("Evening cleanup")
+	_, err = ds.CreateAgentJob(ctx, userID, paused)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		filters models.AgentJobFilters
+		want    int
+	}{
+		{
+			name:    "no filters returns all",
+			filters: models.AgentJobFilters{},
+			want:    2,
+		},
+		{
+			name:    "status filter",
+			filters: models.AgentJobFilters{Status: statusPtr(models.AgentJobStatusPaused)},
+			want:    1,
+		},
+		{
+			name:    "schedule type filter",
+			filters: models.AgentJobFilters{ScheduleType: scheduleTypePtr(models.AgentJobScheduleTypeAt)},
+			want:    1,
+		},
+		{
+			name:    "query filter matches title case-insensitively",
+			filters: models.AgentJobFilters{Query: strPtr("morning")},
+			want:    1,
+		},
+		{
+			name:    "query filter with no match",
+			filters: models.AgentJobFilters{Query: strPtr("nonexistent")},
+			want:    0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := ds.ListAgentJobs(ctx, userID, 1, 10, tc.filters)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, resp.TotalCount)
+			require.Len(t, resp.Results, tc.want)
+		})
+	}
+
+	// Pagination: page size 1 should split the 2 unfiltered results across 2 pages.
+	page1, err := ds.ListAgentJobs(ctx, userID, 1, 1, models.AgentJobFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 2, page1.TotalCount)
+	require.Len(t, page1.Results, 1)
+	require.Equal(t, 1, page1.Page)
+
+	page2, err := ds.ListAgentJobs(ctx, userID, 2, 1, models.AgentJobFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 2, page2.TotalCount)
+	require.Len(t, page2.Results, 1)
+	require.Equal(t, 2, page2.Page)
+
+	// Invalid pageNum/pageSize fall back to defaults (page 1, size 10).
+	fallback, err := ds.ListAgentJobs(ctx, userID, 0, 0, models.AgentJobFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 1, fallback.Page)
+	require.Len(t, fallback.Results, 2)
+}
+
+func strPtr(s string) *string { return &s }
+
+func statusPtr(s models.AgentJobStatus) *models.AgentJobStatus { return &s }
+
+func scheduleTypePtr(s models.AgentJobScheduleType) *models.AgentJobScheduleType { return &s }
+
+func TestUpdateAgentJobSchedule_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	schedule := "0 9 * * *"
+	runAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	nextRunAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+
+	got, err := ds.UpdateAgentJobSchedule(ctx, userID, created.ID, "daily at 9am", models.AgentJobScheduleTypeCron, &schedule, &runAt, "America/New_York", &nextRunAt)
+	require.NoError(t, err)
+	require.Equal(t, "daily at 9am", got.ScheduleInput)
+	require.Equal(t, schedule, *got.Schedule)
+	require.WithinDuration(t, runAt, *got.RunAt, time.Second)
+	require.WithinDuration(t, nextRunAt, *got.NextRunAt, time.Second)
+	require.Equal(t, "America/New_York", got.Timezone)
+	require.Equal(t, models.AgentJobStatusActive, got.Status)
+}
+
+func TestUpdateAgentJobSchedule_ClearsScheduleRunAtNextRunAt(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	schedule := "0 9 * * *"
+	runAt := time.Now().Add(time.Hour)
+	nextRunAt := time.Now().Add(2 * time.Hour)
+	jobModel := baseAgentJobModel()
+	jobModel.Schedule = &schedule
+	jobModel.RunAt = &runAt
+	jobModel.NextRunAt = &nextRunAt
+	created, err := ds.CreateAgentJob(ctx, userID, jobModel)
+	require.NoError(t, err)
+
+	got, err := ds.UpdateAgentJobSchedule(ctx, userID, created.ID, "once", models.AgentJobScheduleTypeAt, nil, nil, "UTC", nil)
+	require.NoError(t, err)
+	require.Nil(t, got.Schedule)
+	require.Nil(t, got.RunAt)
+	require.Nil(t, got.NextRunAt)
+}
+
+func TestUpdateAgentJobSchedule_ReactivatesTerminalJobWithNextRun(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	jobModel := baseAgentJobModel()
+	jobModel.Status = models.AgentJobStatusFailed
+	jobModel.LastError = "boom"
+	created, err := ds.CreateAgentJob(ctx, userID, jobModel)
+	require.NoError(t, err)
+	require.Equal(t, models.AgentJobStatusFailed, created.Status)
+
+	nextRunAt := time.Now().Add(time.Hour)
+	got, err := ds.UpdateAgentJobSchedule(ctx, userID, created.ID, "daily", models.AgentJobScheduleTypeCron, nil, nil, "UTC", &nextRunAt)
+	require.NoError(t, err)
+	require.Equal(t, models.AgentJobStatusActive, got.Status)
+	require.Empty(t, got.LastError)
+}
+
+func TestUpdateAgentJobSchedule_TerminalJobWithoutNextRunStaysTerminal(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	jobModel := baseAgentJobModel()
+	jobModel.Status = models.AgentJobStatusComplete
+	created, err := ds.CreateAgentJob(ctx, userID, jobModel)
+	require.NoError(t, err)
+
+	got, err := ds.UpdateAgentJobSchedule(ctx, userID, created.ID, "once", models.AgentJobScheduleTypeAt, nil, nil, "UTC", nil)
+	require.NoError(t, err)
+	require.Equal(t, models.AgentJobStatusComplete, got.Status)
+}
+
+func TestUpdateAgentJobSchedule_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.UpdateAgentJobSchedule(context.Background(), userID, uuid.New(), "daily", models.AgentJobScheduleTypeCron, nil, nil, "UTC", nil)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobSchedule_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.UpdateAgentJobSchedule(ctx, otherUserID, created.ID, "daily", models.AgentJobScheduleTypeCron, nil, nil, "UTC", nil)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobStatus_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	got, err := ds.UpdateAgentJobStatus(ctx, userID, created.ID, models.AgentJobStatusFailed, "it broke")
+	require.NoError(t, err)
+	require.Equal(t, models.AgentJobStatusFailed, got.Status)
+	require.Equal(t, "it broke", got.LastError)
+
+	// Clearing lastError with an empty string.
+	got, err = ds.UpdateAgentJobStatus(ctx, userID, created.ID, models.AgentJobStatusActive, "")
+	require.NoError(t, err)
+	require.Equal(t, models.AgentJobStatusActive, got.Status)
+	require.Empty(t, got.LastError)
+}
+
+func TestUpdateAgentJobStatus_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.UpdateAgentJobStatus(context.Background(), userID, uuid.New(), models.AgentJobStatusPaused, "")
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobStatus_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.UpdateAgentJobStatus(ctx, otherUserID, created.ID, models.AgentJobStatusPaused, "")
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobTitle_SetAndClear(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	title := "  My Job  "
+	got, err := ds.UpdateAgentJobTitle(ctx, userID, created.ID, &title)
+	require.NoError(t, err)
+	require.NotNil(t, got.Title)
+	require.Equal(t, "My Job", *got.Title)
+
+	got, err = ds.UpdateAgentJobTitle(ctx, userID, created.ID, nil)
+	require.NoError(t, err)
+	require.Nil(t, got.Title)
+
+	// Whitespace-only title also clears.
+	blank := "   "
+	got, err = ds.UpdateAgentJobTitle(ctx, userID, created.ID, &blank)
+	require.NoError(t, err)
+	require.Nil(t, got.Title)
+}
+
+func TestUpdateAgentJobTitle_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.UpdateAgentJobTitle(context.Background(), userID, uuid.New(), strPtr("x"))
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobTitle_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.UpdateAgentJobTitle(ctx, otherUserID, created.ID, strPtr("x"))
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobPrompt_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	got, err := ds.UpdateAgentJobPrompt(ctx, userID, created.ID, "new prompt")
+	require.NoError(t, err)
+	require.Equal(t, "new prompt", got.Prompt)
+}
+
+func TestUpdateAgentJobPrompt_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.UpdateAgentJobPrompt(context.Background(), userID, uuid.New(), "p")
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestUpdateAgentJobPrompt_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.UpdateAgentJobPrompt(ctx, otherUserID, created.ID, "p")
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestSetAgentJobChat_SetAndClear(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	modelID := createAgentJobTestModel(t, ds)
+	chatID := createAgentJobTestChat(t, ds, userID, modelID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	got, err := ds.SetAgentJobChat(ctx, userID, created.ID, &chatID)
+	require.NoError(t, err)
+	require.NotNil(t, got.ChatID)
+	require.Equal(t, chatID, *got.ChatID)
+
+	got, err = ds.SetAgentJobChat(ctx, userID, created.ID, nil)
+	require.NoError(t, err)
+	require.Nil(t, got.ChatID)
+}
+
+func TestSetAgentJobChat_ChatNotOwned(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	modelID := createAgentJobTestModel(t, ds)
+	chatID := createAgentJobTestChat(t, ds, otherUserID, modelID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.SetAgentJobChat(ctx, userID, created.ID, &chatID)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestSetAgentJobChat_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.SetAgentJobChat(context.Background(), userID, uuid.New(), nil)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestSetAgentJobChat_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.SetAgentJobChat(ctx, otherUserID, created.ID, nil)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestValidateAgentJobOverrideIDs(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	personalityID := createAgentJobTestPersonality(t, ds, userID)
+	otherPersonalityID := createAgentJobTestPersonality(t, ds, otherUserID)
+	modelID := createAgentJobTestModel(t, ds)
+	missingID := uuid.New()
+
+	tests := []struct {
+		name    string
+		patch   models.SetAgentJobOverridesPatch
+		wantErr error
+	}{
+		{
+			name:    "no-op patch is valid",
+			patch:   models.SetAgentJobOverridesPatch{},
+			wantErr: nil,
+		},
+		{
+			name:    "valid personality owned by user",
+			patch:   models.SetAgentJobOverridesPatch{UpdatePersonality: true, PersonalityID: &personalityID},
+			wantErr: nil,
+		},
+		{
+			name:    "clearing personality (nil id) is valid",
+			patch:   models.SetAgentJobOverridesPatch{UpdatePersonality: true, PersonalityID: nil},
+			wantErr: nil,
+		},
+		{
+			name:    "personality not owned by user is invalid",
+			patch:   models.SetAgentJobOverridesPatch{UpdatePersonality: true, PersonalityID: &otherPersonalityID},
+			wantErr: ErrInvalidRequestBody,
+		},
+		{
+			name:    "personality does not exist is invalid",
+			patch:   models.SetAgentJobOverridesPatch{UpdatePersonality: true, PersonalityID: &missingID},
+			wantErr: ErrInvalidRequestBody,
+		},
+		{
+			name:    "valid model",
+			patch:   models.SetAgentJobOverridesPatch{UpdateModel: true, ModelID: &modelID},
+			wantErr: nil,
+		},
+		{
+			name:    "clearing model (nil id) is valid",
+			patch:   models.SetAgentJobOverridesPatch{UpdateModel: true, ModelID: nil},
+			wantErr: nil,
+		},
+		{
+			name:    "model does not exist is invalid",
+			patch:   models.SetAgentJobOverridesPatch{UpdateModel: true, ModelID: &missingID},
+			wantErr: ErrInvalidRequestBody,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, err := ds.dbClient.Tx(ctx)
+			require.NoError(t, err)
+			defer tx.Rollback()
+
+			err = validateAgentJobOverrideIDs(ctx, tx, userID, tc.patch)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSetAgentJobOverrides_NoFieldsRequested(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.SetAgentJobOverrides(context.Background(), userID, uuid.New(), models.SetAgentJobOverridesPatch{})
+	require.ErrorIs(t, err, ErrInvalidRequestBody)
+}
+
+func TestSetAgentJobOverrides_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	personalityID := createAgentJobTestPersonality(t, ds, userID)
+	modelID := createAgentJobTestModel(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	got, err := ds.SetAgentJobOverrides(ctx, userID, created.ID, models.SetAgentJobOverridesPatch{
+		UpdatePersonality: true,
+		PersonalityID:     &personalityID,
+		UpdateModel:       true,
+		ModelID:           &modelID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.PersonalityID)
+	require.Equal(t, personalityID, *got.PersonalityID)
+	require.NotNil(t, got.ModelID)
+	require.Equal(t, modelID, *got.ModelID)
+
+	// NOTE: despite the SetAgentJobOverridesPatch doc comment saying a nil ID with the
+	// Update flag set "clears" the override, the implementation calls SetNillablePersonalityID /
+	// SetNillableModelID, which are no-ops when the pointer is nil (see ent's generated
+	// AgentJobUpdate.SetNillableModelID). So passing UpdatePersonality/UpdateModel = true with a
+	// nil ID currently leaves the existing override untouched rather than clearing it. This test
+	// documents that actual (likely unintended) behavior rather than the doc comment's contract.
+	got, err = ds.SetAgentJobOverrides(ctx, userID, created.ID, models.SetAgentJobOverridesPatch{
+		UpdatePersonality: true,
+		UpdateModel:       true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.PersonalityID)
+	require.Equal(t, personalityID, *got.PersonalityID)
+	require.NotNil(t, got.ModelID)
+	require.Equal(t, modelID, *got.ModelID)
+}
+
+func TestSetAgentJobOverrides_InvalidPersonality(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	otherPersonalityID := createAgentJobTestPersonality(t, ds, otherUserID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.SetAgentJobOverrides(ctx, userID, created.ID, models.SetAgentJobOverridesPatch{
+		UpdatePersonality: true,
+		PersonalityID:     &otherPersonalityID,
+	})
+	require.ErrorIs(t, err, ErrInvalidRequestBody)
+}
+
+func TestSetAgentJobOverrides_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	modelID := createAgentJobTestModel(t, ds)
+	_, err := ds.SetAgentJobOverrides(context.Background(), userID, uuid.New(), models.SetAgentJobOverridesPatch{
+		UpdateModel: true,
+		ModelID:     &modelID,
+	})
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestSetAgentJobOverrides_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	modelID := createAgentJobTestModel(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.SetAgentJobOverrides(ctx, otherUserID, created.ID, models.SetAgentJobOverridesPatch{
+		UpdateModel: true,
+		ModelID:     &modelID,
+	})
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestDeleteAgentJob_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	require.NoError(t, ds.DeleteAgentJob(ctx, userID, created.ID))
+
+	_, err = ds.GetAgentJob(ctx, userID, created.ID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestDeleteAgentJob_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	err := ds.DeleteAgentJob(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestDeleteAgentJob_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.DeleteAgentJob(ctx, otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+
+	// The job should still be there for its actual owner.
+	_, err = ds.GetAgentJob(ctx, userID, created.ID)
+	require.NoError(t, err)
+}
+
+func TestListAgentJobsForScheduler_ReturnsAllUsersJobs(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+
+	created1, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+	created2, err := ds.CreateAgentJob(ctx, otherUserID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	jobs, err := ds.ListAgentJobsForScheduler(ctx)
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+
+	ids := []uuid.UUID{jobs[0].ID, jobs[1].ID}
+	require.Contains(t, ids, created1.ID)
+	require.Contains(t, ids, created2.ID)
+}
+
+func TestListAgentJobsForScheduler_Empty(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	jobs, err := ds.ListAgentJobsForScheduler(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, jobs)
+}
+
+func TestRecordAgentJobRun_SuccessUpdatesRunMetadata(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+	require.Equal(t, 0, created.RunCount)
+
+	lastRunAt := time.Now().UTC().Truncate(time.Second)
+	nextRunAt := lastRunAt.Add(24 * time.Hour)
+
+	got, err := ds.RecordAgentJobRun(ctx, userID, created.ID, lastRunAt, &nextRunAt, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, got.RunCount)
+	require.NotNil(t, got.LastRunAt)
+	require.WithinDuration(t, lastRunAt, *got.LastRunAt, time.Second)
+	require.NotNil(t, got.NextRunAt)
+	require.WithinDuration(t, nextRunAt, *got.NextRunAt, time.Second)
+	require.Empty(t, got.LastError)
+	require.Equal(t, models.AgentJobStatusActive, got.Status)
+
+	// A second run increments the count again and can clear next_run_at.
+	got, err = ds.RecordAgentJobRun(ctx, userID, created.ID, lastRunAt, nil, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, got.RunCount)
+	require.Nil(t, got.NextRunAt)
+}
+
+func TestRecordAgentJobRun_ErrorAndStatusChange(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	newStatus := models.AgentJobStatusFailed
+	got, err := ds.RecordAgentJobRun(ctx, userID, created.ID, time.Now(), nil, "provider timeout", &newStatus)
+	require.NoError(t, err)
+	require.Equal(t, models.AgentJobStatusFailed, got.Status)
+	require.Equal(t, "provider timeout", got.LastError)
+}
+
+func TestRecordAgentJobRun_NotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	_, err := ds.RecordAgentJobRun(context.Background(), userID, uuid.New(), time.Now(), nil, "", nil)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestRecordAgentJobRun_WrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	_, err = ds.RecordAgentJobRun(ctx, otherUserID, created.ID, time.Now(), nil, "", nil)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestAddAgentJobRitual_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, userID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	require.NoError(t, ds.AddAgentJobRitual(ctx, userID, created.ID, ritualID))
+
+	got, err := ds.GetAgentJob(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Len(t, got.Rituals, 1)
+	require.Equal(t, ritualID, got.Rituals[0].ID)
+}
+
+func TestAddAgentJobRitual_JobNotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, userID)
+
+	err := ds.AddAgentJobRitual(context.Background(), userID, uuid.New(), ritualID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestAddAgentJobRitual_JobWrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, otherUserID)
+	created, err := ds.CreateAgentJob(ctx, otherUserID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.AddAgentJobRitual(ctx, userID, created.ID, ritualID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestAddAgentJobRitual_RitualNotOwned(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, otherUserID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.AddAgentJobRitual(ctx, userID, created.ID, ritualID)
+	require.ErrorIs(t, err, ErrRitualNotFound)
+}
+
+func TestAddAgentJobRitual_RitualDoesNotExist(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.AddAgentJobRitual(ctx, userID, created.ID, uuid.New())
+	require.ErrorIs(t, err, ErrRitualNotFound)
+}
+
+func TestRemoveAgentJobRitual_HappyPath(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, userID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+	require.NoError(t, ds.AddAgentJobRitual(ctx, userID, created.ID, ritualID))
+
+	require.NoError(t, ds.RemoveAgentJobRitual(ctx, userID, created.ID, ritualID))
+
+	got, err := ds.GetAgentJob(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Empty(t, got.Rituals)
+}
+
+func TestRemoveAgentJobRitual_JobNotFound(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+
+	userID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, userID)
+
+	err := ds.RemoveAgentJobRitual(context.Background(), userID, uuid.New(), ritualID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestRemoveAgentJobRitual_JobWrongOwner(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, otherUserID)
+	created, err := ds.CreateAgentJob(ctx, otherUserID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.RemoveAgentJobRitual(ctx, userID, created.ID, ritualID)
+	require.ErrorIs(t, err, ErrAgentJobNotFound)
+}
+
+func TestRemoveAgentJobRitual_RitualNotOwned(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	otherUserID := createAgentJobTestUser(t, ds)
+	ritualID := createAgentJobTestRitual(t, ds, otherUserID)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.RemoveAgentJobRitual(ctx, userID, created.ID, ritualID)
+	require.ErrorIs(t, err, ErrRitualNotFound)
+}
+
+func TestRemoveAgentJobRitual_RitualDoesNotExist(t *testing.T) {
+	ds, cleanup := newAgentJobTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createAgentJobTestUser(t, ds)
+	created, err := ds.CreateAgentJob(ctx, userID, baseAgentJobModel())
+	require.NoError(t, err)
+
+	err = ds.RemoveAgentJobRitual(ctx, userID, created.ID, uuid.New())
+	require.ErrorIs(t, err, ErrRitualNotFound)
+}

--- a/internal/datastore/compaction_event_test.go
+++ b/internal/datastore/compaction_event_test.go
@@ -6,40 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"entgo.io/ent/dialect"
-	entsql "entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/theimaginaryfoundation/what-iff/ent"
 	entsnap "github.com/theimaginaryfoundation/what-iff/ent/checkpointsnapshot"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
-	"go.uber.org/zap"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func newCompactionEventTestDatastore(t *testing.T) (*Datastore, func()) {
 	t.Helper()
-
-	db, err := sql.Open("sqlite3", "file:"+uuid.NewString()+"?mode=memory&cache=shared&_fk=1")
-	require.NoError(t, err)
-
 	// Parent (compaction_events) before child (memory_merge_events) so the FK + ON DELETE SET NULL
 	// in createMemoryMergeEventTestSchema can be applied — mirrors production ent schema order.
-	createMemoryImportTestSchema(t, db)
-	createCompactionEventTestSchema(t, db)
-	createMemoryMergeEventTestSchema(t, db)
-
-	drv := entsql.OpenDB(dialect.SQLite, db)
-	client := ent.NewClient(ent.Driver(drv))
-	ds, err := NewDatastore(client, db, zap.NewNop(), "12345678901234567890123456789012", nil)
-	require.NoError(t, err)
-
-	cleanup := func() {
-		_ = client.Close()
-		_ = db.Close()
-	}
-	return ds, cleanup
+	return newTestDatastore(t, createMemoryImportTestSchema, createCompactionEventTestSchema, createMemoryMergeEventTestSchema)
 }
 
 func createCompactionEventTestSchema(t *testing.T, db *sql.DB) {

--- a/internal/datastore/fileattachment_test.go
+++ b/internal/datastore/fileattachment_test.go
@@ -1,0 +1,997 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// createFileAttachmentTestSchema creates the file_attachments and personality_expressions
+// tables that fileattachment.go's queries touch but that createMemoryImportTestSchema and
+// createAccountBackupTestSchema do not already provide. file_attachments FKs to
+// chat_messages (from createAccountBackupTestSchema), personalities and users (from
+// createMemoryImportTestSchema), and moods (from createAccountBackupTestSchema).
+// personality_expressions FKs to personalities and file_attachments.
+//
+// Must be composed after createMemoryImportTestSchema and createAccountBackupTestSchema via
+// newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, createFileAttachmentTestSchema).
+func createFileAttachmentTestSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	statements := []string{
+		`CREATE TABLE file_attachments (
+			id uuid PRIMARY KEY,
+			file_id text,
+			name text NOT NULL,
+			file_type text NOT NULL,
+			description text,
+			file_content text,
+			chunk_status text,
+			s3_key text,
+			created_at datetime NOT NULL,
+			chat_message_file_attachments uuid,
+			mood_images uuid,
+			personality_file_attachments uuid,
+			user_file_attachments uuid NOT NULL
+		)`,
+		`CREATE TABLE personality_expressions (
+			id uuid PRIMARY KEY,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			expression_key text NOT NULL,
+			label text,
+			personality_expressions uuid NOT NULL,
+			personality_expression_image uuid
+		)`,
+	}
+
+	for _, stmt := range statements {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err)
+	}
+}
+
+func newFileAttachmentTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	// alterChatsTableForAgentJobTests is needed because GetFileAttachment eager-loads
+	// WithChatMessage(func(q) { q.WithChat() }), and ent's WithChat() selects every column
+	// on the real chats schema (including source/import_hash/rehydration_state), which
+	// createMemoryImportTestSchema's minimal chats fixture doesn't have.
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, createFileAttachmentTestSchema, alterChatsTableForAgentJobTests)
+}
+
+func createFATestUser(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := ds.dbClient.User.Create().
+		SetID(id).
+		SetUsername("fa-" + id.String()[:8]).
+		SetEmail("fa-" + id.String()[:8] + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+	return id
+}
+
+func createFATestPersonality(t *testing.T, ds *Datastore, userID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	p, err := ds.dbClient.Personality.Create().
+		SetName(name).
+		SetSystemPrompt("system prompt").
+		SetUserID(userID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return p.ID
+}
+
+func createFATestModel(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	m, err := ds.dbClient.Model.Create().
+		SetName("model-" + uuid.NewString()[:8]).
+		SetDisplayName("Test Model").
+		SetDescription("test model").
+		Save(context.Background())
+	require.NoError(t, err)
+	return m.ID
+}
+
+func createFATestChat(t *testing.T, ds *Datastore, userID, modelID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	c, err := ds.dbClient.Chat.Create().
+		SetName("Chat").
+		SetOwnerID(userID).
+		SetModelID(modelID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return c.ID
+}
+
+func createFATestChatMessage(t *testing.T, ds *Datastore, chatID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	cm, err := ds.dbClient.ChatMessage.Create().
+		SetChatID(chatID).
+		SetMessage("hello").
+		SetOrigin("User").
+		SetSentAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return cm.ID
+}
+
+func TestToFileAttachmentModel_Nil(t *testing.T) {
+	require.Nil(t, toFileAttachmentModel(nil))
+}
+
+func TestToFileAttachmentModel_NoEdges(t *testing.T) {
+	now := time.Now().UTC()
+	e := &ent.FileAttachment{
+		ID:        uuid.New(),
+		Name:      "file.txt",
+		FileType:  "text/plain",
+		S3Key:     "some/key",
+		CreatedAt: now,
+	}
+	model := toFileAttachmentModel(e)
+	require.NotNil(t, model)
+	require.Equal(t, uuid.Nil, model.UserID)
+	require.Equal(t, "file.txt", model.Name)
+	require.Nil(t, model.FileID)
+	require.Nil(t, model.ChatMessageID)
+	require.Nil(t, model.ChatID)
+	require.Nil(t, model.PersonalityID)
+}
+
+func TestCreateFileAttachment_HappyPath(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	desc := "a description"
+
+	got, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:        "report.pdf",
+		FileType:    "application/pdf",
+		Description: &desc,
+		S3Key:       "users/u/report.pdf",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, userID, got.UserID)
+	require.Equal(t, "report.pdf", got.Name)
+	require.Equal(t, "application/pdf", got.FileType)
+	require.NotNil(t, got.Description)
+	require.Equal(t, desc, *got.Description)
+	require.Equal(t, "users/u/report.pdf", got.S3Key)
+	require.Nil(t, got.PersonalityID)
+	require.Nil(t, got.ChatMessageID)
+}
+
+func TestCreateFileAttachment_UserNotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.CreateFileAttachment(context.Background(), uuid.New(), models.FileAttachment{
+		Name:     "report.pdf",
+		FileType: "application/pdf",
+	})
+	require.ErrorIs(t, err, ErrUnauthorized)
+}
+
+func TestCreateFileAttachment_WithChatMessageAndPersonality(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, userID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+	personalityID := createFATestPersonality(t, ds, userID, "Vix")
+
+	got, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "image.png",
+		FileType:      "image/png",
+		ChatMessageID: &chatMessageID,
+		PersonalityID: &personalityID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.ChatMessageID)
+	require.Equal(t, chatMessageID, *got.ChatMessageID)
+	// CreateFileAttachment's post-create reload uses WithChatMessage() without a nested
+	// WithChat(), so ChatID is never populated here (unlike GetFileAttachment, which does
+	// eager-load the chat edge). This is the real, current behavior, not a test bug.
+	require.Nil(t, got.ChatID)
+	require.NotNil(t, got.PersonalityID)
+	require.Equal(t, personalityID, *got.PersonalityID)
+	require.Len(t, got.Personalities, 1)
+	require.Equal(t, "Vix", got.Personalities[0].Name)
+}
+
+func TestGetFileAttachment_Found(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, userID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "image.png",
+		FileType:      "image/png",
+		ChatMessageID: &chatMessageID,
+	})
+	require.NoError(t, err)
+
+	got, err := ds.GetFileAttachment(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+	require.Equal(t, userID, got.UserID)
+	require.NotNil(t, got.ChatMessageID)
+	require.Equal(t, chatMessageID, *got.ChatMessageID)
+	// Unlike CreateFileAttachment, GetFileAttachment eager-loads WithChat() nested under
+	// WithChatMessage(), so ChatID is populated here.
+	require.NotNil(t, got.ChatID)
+	require.Equal(t, chatID, *got.ChatID)
+}
+
+func TestGetFileAttachment_NotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	userID := createFATestUser(t, ds)
+	_, err := ds.GetFileAttachment(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestGetFileAttachment_WrongOwner(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+
+	created, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:     "report.pdf",
+		FileType: "application/pdf",
+	})
+	require.NoError(t, err)
+
+	_, err = ds.GetFileAttachment(ctx, otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestListFileAttachments_UserScopingAndPagination(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+
+	for i := 0; i < 3; i++ {
+		_, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+			Name:     "file.txt",
+			FileType: "text/plain",
+		})
+		require.NoError(t, err)
+	}
+	_, err := ds.CreateFileAttachment(ctx, otherUserID, models.FileAttachment{
+		Name:     "other-file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	page1, err := ds.ListFileAttachments(ctx, userID, 1, 2, models.FileAttachmentFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 3, page1.TotalCount)
+	require.Equal(t, 1, page1.Page)
+	require.Len(t, page1.Results, 2)
+
+	page2, err := ds.ListFileAttachments(ctx, userID, 2, 2, models.FileAttachmentFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 3, page2.TotalCount)
+	require.Equal(t, 2, page2.Page)
+	require.Len(t, page2.Results, 1)
+}
+
+func TestListFileAttachments_InvalidPageDefaults(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	for i := 0; i < 2; i++ {
+		_, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+			Name:     "file.txt",
+			FileType: "text/plain",
+		})
+		require.NoError(t, err)
+	}
+
+	// pageNum < 1 defaults to 1, pageSize < 1 defaults to 10.
+	res, err := ds.ListFileAttachments(ctx, userID, 0, 0, models.FileAttachmentFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Page)
+	require.Len(t, res.Results, 2)
+}
+
+func TestListFileAttachments_NameFilter(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	_, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "budget-report.pdf",
+		FileType: "application/pdf",
+	})
+	require.NoError(t, err)
+	_, err = ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "vacation.png",
+		FileType: "image/png",
+	})
+	require.NoError(t, err)
+
+	search := "budget"
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{Name: &search})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	require.Len(t, res.Results, 1)
+	got := res.Results[0].(*models.FileAttachment)
+	require.Equal(t, "budget-report.pdf", got.Name)
+}
+
+func TestListFileAttachments_FileTypeFilter(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	_, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "doc.pdf",
+		FileType: "application/pdf",
+	})
+	require.NoError(t, err)
+	_, err = ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "pic.png",
+		FileType: "image/png",
+	})
+	require.NoError(t, err)
+
+	fileType := "image"
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{FileType: &fileType})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	got := res.Results[0].(*models.FileAttachment)
+	require.Equal(t, "pic.png", got.Name)
+}
+
+func TestListFileAttachments_ChatMessageIDFilter(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, userID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+	otherChatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	_, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "attached.txt",
+		FileType:      "text/plain",
+		ChatMessageID: &chatMessageID,
+	})
+	require.NoError(t, err)
+	_, err = ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "other.txt",
+		FileType:      "text/plain",
+		ChatMessageID: &otherChatMessageID,
+	})
+	require.NoError(t, err)
+
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{ChatMessageID: &chatMessageID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	got := res.Results[0].(*models.FileAttachment)
+	require.Equal(t, "attached.txt", got.Name)
+}
+
+func TestListFileAttachments_PersonalityIDFilter_UnionWithExpressionImages(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	personalityID := createFATestPersonality(t, ds, userID, "Vix")
+	otherPersonalityID := createFATestPersonality(t, ds, userID, "Nix")
+
+	// Direct doc attachment with personality FK.
+	doc, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "doc.txt",
+		FileType:      "text/plain",
+		PersonalityID: &personalityID,
+	})
+	require.NoError(t, err)
+
+	// Expression image: file attachment with no direct personality FK, linked via
+	// PersonalityExpression.
+	exprImage, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "expression-happy.png",
+		FileType: "image/png",
+	})
+	require.NoError(t, err)
+	_, err = ds.dbClient.PersonalityExpression.Create().
+		SetPersonalityID(personalityID).
+		SetImageID(exprImage.ID).
+		SetExpressionKey("happy").
+		SetCreatedAt(time.Now().UTC()).
+		SetUpdatedAt(time.Now().UTC()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Attachment belonging to a different personality; must not leak in.
+	_, err = ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "other-personality-doc.txt",
+		FileType:      "text/plain",
+		PersonalityID: &otherPersonalityID,
+	})
+	require.NoError(t, err)
+
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{PersonalityID: &personalityID})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.TotalCount)
+	names := []string{}
+	for _, r := range res.Results {
+		names = append(names, r.(*models.FileAttachment).Name)
+	}
+	require.ElementsMatch(t, []string{doc.Name, exprImage.Name}, names)
+}
+
+func TestListFileAttachments_PersonalityIDFilter_DocsOnlyExcludesImages(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	personalityID := createFATestPersonality(t, ds, userID, "Vix")
+
+	doc, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "doc.txt",
+		FileType:      "text/plain",
+		PersonalityID: &personalityID,
+	})
+	require.NoError(t, err)
+
+	// Image with a direct personality FK (e.g. a cover photo) must be excluded when
+	// DocsOnly is set, since docs can never be images per the upload form.
+	_, err = ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "cover.png",
+		FileType:      "image/png",
+		PersonalityID: &personalityID,
+	})
+	require.NoError(t, err)
+
+	docsOnly := true
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{
+		PersonalityID: &personalityID,
+		DocsOnly:      &docsOnly,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	got := res.Results[0].(*models.FileAttachment)
+	require.Equal(t, doc.Name, got.Name)
+}
+
+func TestListFileAttachments_GlobalOnlyFilter(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	personalityID := createFATestPersonality(t, ds, userID, "Vix")
+
+	global, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "global.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	_, err = ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "personality-doc.txt",
+		FileType:      "text/plain",
+		PersonalityID: &personalityID,
+	})
+	require.NoError(t, err)
+
+	exprImage, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "expression-happy.png",
+		FileType: "image/png",
+	})
+	require.NoError(t, err)
+	_, err = ds.dbClient.PersonalityExpression.Create().
+		SetPersonalityID(personalityID).
+		SetImageID(exprImage.ID).
+		SetExpressionKey("happy").
+		SetCreatedAt(time.Now().UTC()).
+		SetUpdatedAt(time.Now().UTC()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	globalOnly := true
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{GlobalOnly: &globalOnly})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	got := res.Results[0].(*models.FileAttachment)
+	require.Equal(t, global.Name, got.Name)
+}
+
+func TestListFileAttachments_DateRangeFilter(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	old, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "old.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+	// CreatedAt isn't mutable via the ent update builder, so backdate it with raw SQL.
+	_, err = ds.sqlDB.Exec(`UPDATE file_attachments SET created_at = ? WHERE id = ?`,
+		time.Now().UTC().AddDate(0, 0, -30), old.ID.String())
+	require.NoError(t, err)
+
+	recent, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "recent.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	minDate := time.Now().UTC().AddDate(0, 0, -1)
+	res, err := ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{MinDate: &minDate})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	got := res.Results[0].(*models.FileAttachment)
+	require.Equal(t, recent.Name, got.Name)
+
+	maxDate := time.Now().UTC().AddDate(0, 0, -10)
+	res, err = ds.ListFileAttachments(ctx, userID, 1, 10, models.FileAttachmentFilters{MaxDate: &maxDate})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalCount)
+	got = res.Results[0].(*models.FileAttachment)
+	require.Equal(t, old.Name, got.Name)
+}
+
+func TestUpdateFileAttachment_HappyPath(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, userID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	updated, err := ds.UpdateFileAttachment(ctx, userID, created.ID, models.FileAttachment{
+		ChatMessageID: &chatMessageID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.ChatMessageID)
+	require.Equal(t, chatMessageID, *updated.ChatMessageID)
+}
+
+func TestUpdateFileAttachment_NotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, userID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	_, err := ds.UpdateFileAttachment(ctx, userID, uuid.New(), models.FileAttachment{
+		ChatMessageID: &chatMessageID,
+	})
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestUpdateFileAttachment_WrongOwner(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, ownerID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	created, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateFileAttachment(ctx, otherUserID, created.ID, models.FileAttachment{
+		ChatMessageID: &chatMessageID,
+	})
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestUpdateFileAttachment_InvalidRequestBody(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	// Neither FileID nor ChatMessageID set is rejected as an invalid update.
+	_, err = ds.UpdateFileAttachment(ctx, userID, created.ID, models.FileAttachment{})
+	require.ErrorIs(t, err, ErrInvalidRequestBody)
+}
+
+func TestDeleteFileAttachment_HappyPath(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	err = ds.DeleteFileAttachment(ctx, userID, created.ID)
+	require.NoError(t, err)
+
+	_, err = ds.GetFileAttachment(ctx, userID, created.ID)
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestDeleteFileAttachment_NotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	userID := createFATestUser(t, ds)
+	err := ds.DeleteFileAttachment(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestDeleteFileAttachment_WrongOwner(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+
+	created, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	err = ds.DeleteFileAttachment(ctx, otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestSetFileAttachmentS3Key_HappyPath(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	err = ds.SetFileAttachmentS3Key(ctx, userID, created.ID, "users/u/file.txt")
+	require.NoError(t, err)
+
+	got, err := ds.GetFileAttachment(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "users/u/file.txt", got.S3Key)
+}
+
+func TestSetFileAttachmentS3Key_NotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	userID := createFATestUser(t, ds)
+	err := ds.SetFileAttachmentS3Key(context.Background(), userID, uuid.New(), "key")
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestSetFileAttachmentS3Key_WrongOwner(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+
+	created, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	err = ds.SetFileAttachmentS3Key(ctx, otherUserID, created.ID, "key")
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestUpdateFileAttachmentName_HappyPath(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "old-name.txt",
+		FileType: "text/plain",
+		S3Key:    "users/u/old-name.txt",
+	})
+	require.NoError(t, err)
+
+	updated, err := ds.UpdateFileAttachmentName(ctx, userID, created.ID, "new-name.txt")
+	require.NoError(t, err)
+	require.Equal(t, "new-name.txt", updated.Name)
+	// The S3 key is left unchanged so existing objects remain retrievable.
+	require.Equal(t, "users/u/old-name.txt", updated.S3Key)
+}
+
+func TestUpdateFileAttachmentName_NotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	userID := createFATestUser(t, ds)
+	_, err := ds.UpdateFileAttachmentName(context.Background(), userID, uuid.New(), "new-name.txt")
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestUpdateFileAttachmentName_WrongOwner(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+
+	created, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateFileAttachmentName(ctx, otherUserID, created.ID, "new-name.txt")
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestUpdateFileAttachmentName_EmptyName(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	// UpdateFileAttachmentName itself does not validate the name, but the ent schema's
+	// "name" field has a minimum-length validator, so an empty name still surfaces as a
+	// generic ent validation error rather than the datastore's own ErrInvalidRequestBody.
+	_, err = ds.UpdateFileAttachmentName(ctx, userID, created.ID, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "less than the required length")
+}
+
+func TestCreateFileAttachmentReference_HappyPath(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	src, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "gallery-image.png",
+		FileType: "image/png",
+		S3Key:    "users/u/images/gallery-image.png",
+	})
+	require.NoError(t, err)
+
+	ref, err := ds.CreateFileAttachmentReference(ctx, userID, src.ID)
+	require.NoError(t, err)
+	require.NotEqual(t, src.ID, ref.ID)
+	require.Equal(t, src.Name, ref.Name)
+	require.Equal(t, src.FileType, ref.FileType)
+	require.Equal(t, src.S3Key, ref.S3Key)
+}
+
+func TestCreateFileAttachmentReference_SynthesizesLegacyS3Key(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	// Legacy record predating the s3_key column: no S3Key and no chat association.
+	src, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:     "legacy-image.png",
+		FileType: "image/png",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "", src.S3Key)
+
+	ref, err := ds.CreateFileAttachmentReference(ctx, userID, src.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, ref.S3Key)
+	require.Contains(t, ref.S3Key, "images")
+}
+
+func TestCreateFileAttachmentReference_SourceNotFound(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	userID := createFATestUser(t, ds)
+	_, err := ds.CreateFileAttachmentReference(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestCreateFileAttachmentReference_SourceNotOwned(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+
+	src, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:     "file.txt",
+		FileType: "text/plain",
+	})
+	require.NoError(t, err)
+
+	_, err = ds.CreateFileAttachmentReference(ctx, otherUserID, src.ID)
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestChatHasSearchableFiles(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, userID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	// No attached files at all yet.
+	has, err := ds.ChatHasSearchableFiles(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "doc.txt",
+		FileType:      "text/plain",
+		ChatMessageID: &chatMessageID,
+	})
+	require.NoError(t, err)
+
+	// Attached but not yet chunked (chunk_status defaults to NULL, not "chunked").
+	has, err = ds.ChatHasSearchableFiles(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	_, err = ds.dbClient.FileAttachment.UpdateOneID(created.ID).
+		SetChunkStatus("chunked").
+		Save(ctx)
+	require.NoError(t, err)
+
+	has, err = ds.ChatHasSearchableFiles(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestChatHasSearchableFiles_WrongOwner(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createFATestUser(t, ds)
+	otherUserID := createFATestUser(t, ds)
+	modelID := createFATestModel(t, ds)
+	chatID := createFATestChat(t, ds, ownerID, modelID)
+	chatMessageID := createFATestChatMessage(t, ds, chatID)
+
+	created, err := ds.CreateFileAttachment(ctx, ownerID, models.FileAttachment{
+		Name:          "doc.txt",
+		FileType:      "text/plain",
+		ChatMessageID: &chatMessageID,
+	})
+	require.NoError(t, err)
+	_, err = ds.dbClient.FileAttachment.UpdateOneID(created.ID).
+		SetChunkStatus("chunked").
+		Save(ctx)
+	require.NoError(t, err)
+
+	// The chat has a searchable file, but the query is scoped to otherUserID, who does
+	// not own the attachment (HasOwnerWith(user.ID(userID)) filters it out).
+	has, err := ds.ChatHasSearchableFiles(ctx, otherUserID, chatID)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestPersonalityHasSearchableFiles(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createFATestUser(t, ds)
+	personalityID := createFATestPersonality(t, ds, userID, "Vix")
+
+	has, err := ds.PersonalityHasSearchableFiles(ctx, personalityID)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	created, err := ds.CreateFileAttachment(ctx, userID, models.FileAttachment{
+		Name:          "doc.txt",
+		FileType:      "text/plain",
+		PersonalityID: &personalityID,
+	})
+	require.NoError(t, err)
+
+	has, err = ds.PersonalityHasSearchableFiles(ctx, personalityID)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	_, err = ds.dbClient.FileAttachment.UpdateOneID(created.ID).
+		SetChunkStatus("chunked").
+		Save(ctx)
+	require.NoError(t, err)
+
+	has, err = ds.PersonalityHasSearchableFiles(ctx, personalityID)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestPersonalityHasSearchableFiles_NoAttachments(t *testing.T) {
+	ds, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	has, err := ds.PersonalityHasSearchableFiles(context.Background(), uuid.New())
+	require.NoError(t, err)
+	require.False(t, has)
+}

--- a/internal/datastore/memory_merge_test.go
+++ b/internal/datastore/memory_merge_test.go
@@ -6,18 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"entgo.io/ent/dialect"
-	entsql "entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/theimaginaryfoundation/what-iff/ent"
 	entmemory "github.com/theimaginaryfoundation/what-iff/ent/memory"
 	entmerge "github.com/theimaginaryfoundation/what-iff/ent/memorymergeevent"
 	"github.com/theimaginaryfoundation/what-iff/internal/memoryutil"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
-	"go.uber.org/zap"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestMergeLiveExtractedMemory_BatchCreateAndFoldLive(t *testing.T) {
@@ -221,26 +215,9 @@ func TestPersistMemoryLinkGroup_LinksAndUndo(t *testing.T) {
 
 func newMemoryMergeTestDatastore(t *testing.T) (*Datastore, func()) {
 	t.Helper()
-
-	db, err := sql.Open("sqlite3", "file:"+uuid.NewString()+"?mode=memory&cache=shared&_fk=1")
-	require.NoError(t, err)
-
 	// compaction_events must exist before memory_merge_events: the merge table holds an FK to it
 	// (ON DELETE SET NULL), matching ent/migrate.MemoryMergeEventsTable.
-	createMemoryImportTestSchema(t, db)
-	createCompactionEventTestSchema(t, db)
-	createMemoryMergeEventTestSchema(t, db)
-
-	drv := entsql.OpenDB(dialect.SQLite, db)
-	client := ent.NewClient(ent.Driver(drv))
-	ds, err := NewDatastore(client, db, zap.NewNop(), "12345678901234567890123456789012", nil)
-	require.NoError(t, err)
-
-	cleanup := func() {
-		_ = client.Close()
-		_ = db.Close()
-	}
-	return ds, cleanup
+	return newTestDatastore(t, createMemoryImportTestSchema, createCompactionEventTestSchema, createMemoryMergeEventTestSchema)
 }
 
 // createMemoryMergeEventTestSchema mirrors ent MemoryMergeEventsTable, including the nullable FK to

--- a/internal/datastore/memory_test.go
+++ b/internal/datastore/memory_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"entgo.io/ent/dialect"
-	entsql "entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
 	"github.com/pgvector/pgvector-go"
 	"github.com/stretchr/testify/require"
@@ -20,9 +18,6 @@ import (
 	"github.com/theimaginaryfoundation/what-iff/ent/embedding"
 	entmemory "github.com/theimaginaryfoundation/what-iff/ent/memory"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
-	"go.uber.org/zap"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestMemoryScopeValidation(t *testing.T) {
@@ -850,22 +845,7 @@ func TestImportMemoriesSkipsExistingIDsAndContinues(t *testing.T) {
 
 func newSQLiteDatastore(t *testing.T) (*Datastore, func()) {
 	t.Helper()
-
-	db, err := sql.Open("sqlite3", "file:"+uuid.NewString()+"?mode=memory&cache=shared&_fk=1")
-	require.NoError(t, err)
-
-	createMemoryImportTestSchema(t, db)
-
-	drv := entsql.OpenDB(dialect.SQLite, db)
-	client := ent.NewClient(ent.Driver(drv))
-	ds, err := NewDatastore(client, db, zap.NewNop(), "12345678901234567890123456789012", nil)
-	require.NoError(t, err)
-
-	cleanup := func() {
-		_ = client.Close()
-		_ = db.Close()
-	}
-	return ds, cleanup
+	return newTestDatastore(t, createMemoryImportTestSchema)
 }
 
 func createMemoryImportTestSchema(t *testing.T, db *sql.DB) {

--- a/internal/datastore/testharness_test.go
+++ b/internal/datastore/testharness_test.go
@@ -1,0 +1,40 @@
+package datastore
+
+import (
+	"database/sql"
+	"testing"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent"
+	"go.uber.org/zap"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newTestDatastore opens an in-memory sqlite DB, applies the given schema-creation funcs in
+// order, and wraps it in a Datastore. Schema funcs like createMemoryImportTestSchema take
+// dependencies as ordering (parent tables before child FKs) — see each func's doc comment.
+func newTestDatastore(t *testing.T, schemas ...func(*testing.T, *sql.DB)) (*Datastore, func()) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file:"+uuid.NewString()+"?mode=memory&cache=shared&_fk=1")
+	require.NoError(t, err)
+
+	for _, schema := range schemas {
+		schema(t, db)
+	}
+
+	drv := entsql.OpenDB(dialect.SQLite, db)
+	client := ent.NewClient(ent.Driver(drv))
+	ds, err := NewDatastore(client, db, zap.NewNop(), "12345678901234567890123456789012", nil)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = client.Close()
+		_ = db.Close()
+	}
+	return ds, cleanup
+}


### PR DESCRIPTION
## Summary

Checkpoint 4 of the coverage push (in progress — `fileattachment.go` still to
follow on this branch):

- Extract a shared sqlite test harness (`newTestDatastore`) out of three
  hand-rolled copies in `memory_test.go`, `compaction_event_test.go`, and
  `memory_merge_test.go`.
- Cover `internal/datastore/accountbackup.go` end to end (all 25 functions),
  including duplicate/conflict/missing-ref handling across every backup
  section importer.
- Cover `internal/datastore/agentjob.go` end to end (all 18 functions):
  CRUD, scheduling/reactivation, overrides, and ritual joins.
- Fix a real bug surfaced while writing those tests: `SetAgentJobOverrides`
  used ent's `SetNillablePersonalityID`/`SetNillableModelID`, which are no-ops
  on a nil pointer, so a nil override ID silently left the existing
  personality/model association in place instead of clearing it as documented
  on `SetAgentJobOverridesPatch`. Fixes #14.

Stacked on the open provider-adapters PR; based off its branch.

## Test plan

- [x] `go test ./internal/datastore/... -race` green
- [x] `gofmt -l` / `go vet` clean
- [ ] `fileattachment.go` tranche (in progress, will follow as another commit)