### PR TITLE
Cover memory.go and chatmessage.go datastore paths

### DIFF
--- a/internal/datastore/chatmessage_test.go
+++ b/internal/datastore/chatmessage_test.go
@@ -1,191 +1,982 @@
 package datastore
 
 import (
+	"context"
+	"database/sql"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"github.com/theimaginaryfoundation/what-iff/internal/modeltypes"
 )
 
-// TestMessageOriginFilterValidation tests the validation of message origin filter constants
-func TestMessageOriginFilterValidation(t *testing.T) {
+// createChatMessageRitualsTestSchema adds the chat_message_rituals m2m join table. CreateChatMessage
+// (and its eager-loaded WithRituals()) touches this table whenever rituals are attached, but none of
+// the other shared schema fragments define it.
+func createChatMessageRitualsTestSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`CREATE TABLE chat_message_rituals (
+		chat_message_id uuid NOT NULL,
+		ritual_id uuid NOT NULL,
+		PRIMARY KEY (chat_message_id, ritual_id)
+	)`)
+	require.NoError(t, err)
+}
+
+// newChatMessageTestDatastore composes the schema fragments chatmessage.go's queries need:
+// createMemoryImportTestSchema (users/chats/personalities), createAccountBackupTestSchema
+// (chat_messages, chat_message_context_items, tool_calls, moods), createFileAttachmentTestSchema
+// (personality_expressions, for the generation-expression edge), alterChatsTableForAgentJobTests
+// (GetChatMessage/CreateChatMessage/etc. all eager-load WithChat(), which selects every real chats
+// column), and createChatMessageRitualsTestSchema (the rituals m2m join table).
+func newChatMessageTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, createFileAttachmentTestSchema, alterChatsTableForAgentJobTests, createChatMessageRitualsTestSchema)
+}
+
+func createCMTestUser(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := ds.dbClient.User.Create().
+		SetID(id).
+		SetUsername("cm-" + id.String()[:8]).
+		SetEmail("cm-" + id.String()[:8] + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+	return id
+}
+
+func createCMTestModel(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	m, err := ds.dbClient.Model.Create().
+		SetName("model-" + uuid.NewString()[:8]).
+		SetDisplayName("Test Model").
+		SetDescription("test model").
+		Save(context.Background())
+	require.NoError(t, err)
+	return m.ID
+}
+
+func createCMTestChat(t *testing.T, ds *Datastore, userID, modelID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	c, err := ds.dbClient.Chat.Create().
+		SetName("Chat").
+		SetOwnerID(userID).
+		SetModelID(modelID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return c.ID
+}
+
+// TestToChatMessageModel_Nil documents the nil-safe conversion.
+func TestToChatMessageModel_Nil(t *testing.T) {
+	require.Nil(t, toChatMessageModel(nil))
+}
+
+func TestTrimGenerationExpressionReasoning(t *testing.T) {
 	tests := []struct {
-		name          string
-		filter        models.MessageOriginFilter
-		shouldBeValid bool
+		name string
+		in   string
+		want string
 	}{
-		{
-			name:          "Valid filter - ALL",
-			filter:        models.MessageOriginFilterAll,
-			shouldBeValid: true,
-		},
-		{
-			name:          "Valid filter - USER",
-			filter:        models.MessageOriginFilterUser,
-			shouldBeValid: true,
-		},
-		{
-			name:          "Valid filter - ASSISTANT",
-			filter:        models.MessageOriginFilterAssistant,
-			shouldBeValid: true,
-		},
-		{
-			name:          "Invalid filter - lowercase",
-			filter:        models.MessageOriginFilter("all"),
-			shouldBeValid: false,
-		},
-		{
-			name:          "Invalid filter - mixed case",
-			filter:        models.MessageOriginFilter("User"),
-			shouldBeValid: false,
-		},
-		{
-			name:          "Invalid filter - arbitrary string",
-			filter:        models.MessageOriginFilter("INVALID"),
-			shouldBeValid: false,
-		},
-		{
-			name:          "Empty filter - should default to ALL",
-			filter:        models.MessageOriginFilter(""),
-			shouldBeValid: true, // Empty is valid because it defaults to ALL
-		},
+		{name: "empty string", in: "", want: ""},
+		{name: "whitespace only", in: "   \t\n  ", want: ""},
+		{name: "trims surrounding whitespace", in: "  hello  ", want: "hello"},
+		{name: "short string unchanged", in: "short reasoning", want: "short reasoning"},
+		{name: "exactly at max runes", in: strings.Repeat("a", 512), want: strings.Repeat("a", 512)},
+		{name: "over max runes is truncated", in: strings.Repeat("a", 600), want: strings.Repeat("a", 512)},
+		{name: "truncation trims trailing whitespace", in: strings.Repeat("a", 511) + "  " + strings.Repeat("b", 100), want: strings.Repeat("a", 511)},
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Validate filter
-			filter := tc.filter
-			if filter == "" {
-				filter = models.MessageOriginFilterAll
-			}
-
-			isValid := filter == models.MessageOriginFilterAll ||
-				filter == models.MessageOriginFilterUser ||
-				filter == models.MessageOriginFilterAssistant
-
-			assert.Equal(t, tc.shouldBeValid, isValid,
-				"Filter validation result should match expected")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trimGenerationExpressionReasoning(tt.in)
+			require.Equal(t, tt.want, got)
+			require.LessOrEqual(t, len([]rune(got)), 512)
 		})
 	}
 }
 
-// TestMessageOriginFilterConstants verifies the constant values are as expected
-func TestMessageOriginFilterConstants(t *testing.T) {
-	assert.Equal(t, "ALL", string(models.MessageOriginFilterAll),
-		"MessageOriginFilterAll should be 'ALL'")
-	assert.Equal(t, "USER", string(models.MessageOriginFilterUser),
-		"MessageOriginFilterUser should be 'USER'")
-	assert.Equal(t, "ASSISTANT", string(models.MessageOriginFilterAssistant),
-		"MessageOriginFilterAssistant should be 'ASSISTANT'")
-}
+func TestCreateChatMessage_HappyPathWithContextItems(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
 
-// TestMessageOriginFilterDefaultBehavior tests that empty filter defaults to ALL
-func TestMessageOriginFilterDefaultBehavior(t *testing.T) {
-	emptyFilter := models.MessageOriginFilter("")
-	defaultFilter := models.MessageOriginFilterAll
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
 
-	// Simulate the default behavior in the actual method
-	if emptyFilter == "" {
-		emptyFilter = models.MessageOriginFilterAll
-	}
-
-	assert.Equal(t, defaultFilter, emptyFilter,
-		"Empty filter should default to MessageOriginFilterAll")
-}
-
-// TestMessageOriginFilterMapping verifies correct mapping between filter and origin
-func TestMessageOriginFilterMapping(t *testing.T) {
-	tests := []struct {
-		name           string
-		filter         models.MessageOriginFilter
-		shouldFilterTo *models.MessageOrigin // nil means no filtering
-	}{
-		{
-			name:           "ALL filter - no specific origin",
-			filter:         models.MessageOriginFilterAll,
-			shouldFilterTo: nil,
-		},
-		{
-			name:           "USER filter - User origin",
-			filter:         models.MessageOriginFilterUser,
-			shouldFilterTo: func() *models.MessageOrigin { o := models.MessageOriginUser; return &o }(),
-		},
-		{
-			name:           "ASSISTANT filter - Assistant origin",
-			filter:         models.MessageOriginFilterAssistant,
-			shouldFilterTo: func() *models.MessageOrigin { o := models.MessageOriginAssistant; return &o }(),
+	memoryID := uuid.New()
+	msg := models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hello there",
+		Origin:  models.MessageOriginUser,
+		Tokens:  12,
+		AdditionalContext: []models.AdditionalContextItem{
+			{Type: models.AdditionalContextTypeMemory, Content: "remembered fact", MemoryID: &memoryID, Scope: "personal"},
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Verify filter maps to correct origin
-			var expectedOrigin *models.MessageOrigin
+	created, err := ds.CreateChatMessage(ctx, userID, msg)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.Equal(t, "hello there", created.Message)
+	require.Equal(t, models.MessageOriginUser, created.Origin)
+	// User-origin messages are created already read.
+	require.Equal(t, models.MessageReadStatusRead, created.ReadStatus)
+	require.Len(t, created.AdditionalContext, 1)
+	require.Equal(t, "remembered fact", created.AdditionalContext[0].Content)
+	require.Equal(t, &memoryID, created.AdditionalContext[0].MemoryID)
 
-			if tc.filter == models.MessageOriginFilterUser {
-				o := models.MessageOriginUser
-				expectedOrigin = &o
-			} else if tc.filter == models.MessageOriginFilterAssistant {
-				o := models.MessageOriginAssistant
-				expectedOrigin = &o
-			}
+	// Chat's last_message_time should have been bumped to the message's sent_at.
+	chat, err := ds.dbClient.Chat.Get(ctx, chatID)
+	require.NoError(t, err)
+	require.NotNil(t, chat.LastMessageTime)
+}
 
-			if tc.shouldFilterTo == nil {
-				assert.Nil(t, expectedOrigin, "ALL filter should not map to specific origin")
-			} else {
-				assert.NotNil(t, expectedOrigin, "Filter should map to specific origin")
-				assert.Equal(t, *tc.shouldFilterTo, *expectedOrigin,
-					"Filter should map to correct origin")
-			}
+func TestCreateChatMessage_HappyPathNoContextItems(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	msg := models.ChatMessage{
+		ChatID:  chatID,
+		Message: "assistant reply",
+		Origin:  models.MessageOriginAssistant,
+	}
+
+	created, err := ds.CreateChatMessage(ctx, userID, msg)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	// Assistant-origin messages start unread.
+	require.Equal(t, models.MessageReadStatusUnread, created.ReadStatus)
+	require.Empty(t, created.AdditionalContext)
+}
+
+func TestCreateChatMessage_ChatNotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	msg := models.ChatMessage{
+		ChatID:  uuid.New(),
+		Message: "hi",
+		Origin:  models.MessageOriginUser,
+	}
+
+	_, err := ds.CreateChatMessage(ctx, userID, msg)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestCreateChatMessage_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	msg := models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginUser,
+	}
+
+	_, err := ds.CreateChatMessage(ctx, otherID, msg)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestGetChatMessage_Found(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+
+	got, err := ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+	require.Equal(t, "hi", got.Message)
+}
+
+func TestGetChatMessage_NotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	_, err := ds.GetChatMessage(ctx, userID, uuid.New())
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestGetChatMessage_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, ownerID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+
+	_, err = ds.GetChatMessage(ctx, otherID, created.ID)
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestUpdateChatMessage_HappyPath(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginUser,
+		Tokens:  1,
+	})
+	require.NoError(t, err)
+
+	responseID := "resp-123"
+	updated, err := ds.UpdateChatMessage(ctx, userID, models.ChatMessage{
+		ID:         created.ID,
+		Tokens:     99,
+		ResponseID: &responseID,
+		AdditionalContext: []models.AdditionalContextItem{
+			{Type: models.AdditionalContextTypeMemory, Content: "new context"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(99), updated.Tokens)
+	require.Equal(t, &responseID, updated.ResponseID)
+	require.Len(t, updated.AdditionalContext, 1)
+	require.Equal(t, "new context", updated.AdditionalContext[0].Content)
+
+	// Reloading should reflect the same replaced context items (not appended).
+	reloaded, err := ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Len(t, reloaded.AdditionalContext, 1)
+}
+
+func TestUpdateChatMessage_NotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	_, err := ds.UpdateChatMessage(ctx, userID, models.ChatMessage{ID: uuid.New()})
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestUpdateChatMessage_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, ownerID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateChatMessage(ctx, otherID, models.ChatMessage{ID: created.ID})
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestSetChatMessageLastError_SetAndClear(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	msg := "  provider timed out  "
+	err = ds.SetChatMessageLastError(ctx, userID, created.ID, &msg)
+	require.NoError(t, err)
+
+	got, err := ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastErrorMessage)
+	require.Equal(t, "provider timed out", *got.LastErrorMessage)
+
+	// Passing nil clears it.
+	err = ds.SetChatMessageLastError(ctx, userID, created.ID, nil)
+	require.NoError(t, err)
+
+	got, err = ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Nil(t, got.LastErrorMessage)
+}
+
+func TestSetChatMessageLastError_BlankMessageClears(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	blank := "   "
+	err = ds.SetChatMessageLastError(ctx, userID, created.ID, &blank)
+	require.NoError(t, err)
+
+	got, err := ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Nil(t, got.LastErrorMessage)
+}
+
+func TestSetChatMessageLastError_NotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	msg := "boom"
+
+	err := ds.SetChatMessageLastError(ctx, userID, uuid.New(), &msg)
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestSetChatMessageLastError_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, ownerID, models.ChatMessage{
+		ChatID:  chatID,
+		Message: "hi",
+		Origin:  models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	msg := "nope"
+	err = ds.SetChatMessageLastError(ctx, otherID, created.ID, &msg)
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestMarkChatMessagesRead_SqliteHappyPathAndNoop(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	// Two assistant (unread) messages and one user (already read) message.
+	for i := 0; i < 2; i++ {
+		_, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+			ChatID: chatID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
 		})
+		require.NoError(t, err)
 	}
+	_, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "user turn", Origin: models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+
+	count, err := ds.MarkChatMessagesRead(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	// Calling again is a no-op: nothing left unread.
+	count, err = ds.MarkChatMessagesRead(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
 }
 
-// TestMessageOriginToFilterConversion tests conceptual conversion between types
-func TestMessageOriginToFilterConversion(t *testing.T) {
+func TestMarkChatMessagesRead_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	_, err := ds.MarkChatMessagesRead(ctx, otherID, chatID)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestGetChatMessageCount_OriginFilters(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	_, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "u1", Origin: models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+	_, err = ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "a1", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+	_, err = ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "a2", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
 	tests := []struct {
 		name   string
-		origin models.MessageOrigin
 		filter models.MessageOriginFilter
+		want   int
 	}{
-		{
-			name:   "User origin maps to USER filter",
-			origin: models.MessageOriginUser,
-			filter: models.MessageOriginFilterUser,
-		},
-		{
-			name:   "Assistant origin maps to ASSISTANT filter",
-			origin: models.MessageOriginAssistant,
-			filter: models.MessageOriginFilterAssistant,
-		},
+		{name: "empty defaults to all", filter: "", want: 3},
+		{name: "all", filter: models.MessageOriginFilterAll, want: 3},
+		{name: "user only", filter: models.MessageOriginFilterUser, want: 1},
+		{name: "assistant only", filter: models.MessageOriginFilterAssistant, want: 2},
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Verify that the string representations are consistent
-			// (USER/User, ASSISTANT/Assistant)
-			assert.NotEqual(t, string(tc.origin), string(tc.filter),
-				"Origin and Filter should have different string representations")
-
-			// Verify expected values
-			if tc.origin == models.MessageOriginUser {
-				assert.Equal(t, models.MessageOriginFilterUser, tc.filter)
-			} else if tc.origin == models.MessageOriginAssistant {
-				assert.Equal(t, models.MessageOriginFilterAssistant, tc.filter)
-			}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := ds.GetChatMessageCount(ctx, userID, chatID, tt.filter)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, count)
 		})
 	}
 }
 
-// TestFilterTypeDistinction ensures filter types are distinct from origin types
-func TestFilterTypeDistinction(t *testing.T) {
-	// These should be different types and not directly assignable
-	var filter models.MessageOriginFilter = models.MessageOriginFilterUser
-	var origin models.MessageOrigin = models.MessageOriginUser
+func TestGetChatMessageCount_InvalidFilter(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
 
-	// Verify they have different string values
-	assert.Equal(t, "USER", string(filter))
-	assert.Equal(t, "User", string(origin))
-	assert.NotEqual(t, string(filter), string(origin),
-		"Filter and Origin should have distinct string representations")
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	_, err := ds.GetChatMessageCount(ctx, userID, chatID, models.MessageOriginFilter("BOGUS"))
+	require.ErrorIs(t, err, ErrInvalidMessageOriginFilter)
+}
+
+func TestGetChatMessageCount_ChatNotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	_, err := ds.GetChatMessageCount(ctx, userID, uuid.New(), models.MessageOriginFilterAll)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestSetChatMessageCheckpointCompletedAt_HappyPath(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	completedAt := time.Now().Add(-time.Minute)
+	err = ds.SetChatMessageCheckpointCompletedAt(ctx, userID, created.ID, completedAt)
+	require.NoError(t, err)
+
+	got, err := ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.CheckpointCompletedAt)
+	require.WithinDuration(t, completedAt, *got.CheckpointCompletedAt, time.Second)
+}
+
+func TestSetChatMessageCheckpointCompletedAt_NotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	err := ds.SetChatMessageCheckpointCompletedAt(ctx, userID, uuid.New(), time.Now())
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestSetChatMessageCheckpointCompletedAt_WrongOriginNotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	// A user-origin message doesn't match the OriginEQ(Assistant) predicate, so it's
+	// indistinguishable from "not found" to this call.
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "user turn", Origin: models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+
+	err = ds.SetChatMessageCheckpointCompletedAt(ctx, userID, created.ID, time.Now())
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestSetChatMessageCheckpointCompletedAt_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, ownerID, models.ChatMessage{
+		ChatID: chatID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	err = ds.SetChatMessageCheckpointCompletedAt(ctx, otherID, created.ID, time.Now())
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestSetChatMessageContextBreakdown_HappyPath(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	breakdown := &modeltypes.ContextBreakdown{
+		Version:      modeltypes.ContextBreakdownVersion,
+		Segments:     []modeltypes.ContextSegmentStat{{Kind: "system_prompt", Segments: 1, Tokens: 100, Cacheable: true}},
+		TotalTokens:  100,
+		BudgetTokens: 8000,
+		Model:        "gpt-test",
+		Provider:     "openai",
+		CapturedAt:   time.Now().UTC(),
+	}
+
+	err = ds.SetChatMessageContextBreakdown(ctx, userID, created.ID, breakdown)
+	require.NoError(t, err)
+
+	got, err := ds.GetChatMessage(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.ContextBreakdown)
+	require.Equal(t, 100, got.ContextBreakdown.TotalTokens)
+	require.Len(t, got.ContextBreakdown.Segments, 1)
+}
+
+// TestSetChatMessageContextBreakdown_NilOrEmptyIsNoop documents the best-effort contract:
+// a nil breakdown, or one with no segments, is silently ignored rather than erroring — even
+// when the target message doesn't exist.
+func TestSetChatMessageContextBreakdown_NilOrEmptyIsNoop(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	err := ds.SetChatMessageContextBreakdown(ctx, userID, uuid.New(), nil)
+	require.NoError(t, err)
+
+	err = ds.SetChatMessageContextBreakdown(ctx, userID, uuid.New(), &modeltypes.ContextBreakdown{})
+	require.NoError(t, err)
+}
+
+func TestSetChatMessageContextBreakdown_NotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	breakdown := &modeltypes.ContextBreakdown{Segments: []modeltypes.ContextSegmentStat{{Kind: "x", Segments: 1, Tokens: 1}}}
+
+	err := ds.SetChatMessageContextBreakdown(ctx, userID, uuid.New(), breakdown)
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestSetChatMessageContextBreakdown_WrongOwner(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ownerID := createCMTestUser(t, ds)
+	otherID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, ownerID, modelID)
+
+	created, err := ds.CreateChatMessage(ctx, ownerID, models.ChatMessage{
+		ChatID: chatID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	breakdown := &modeltypes.ContextBreakdown{Segments: []modeltypes.ContextSegmentStat{{Kind: "x", Segments: 1, Tokens: 1}}}
+	err = ds.SetChatMessageContextBreakdown(ctx, otherID, created.ID, breakdown)
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+// createCMTestMessages creates n user-origin messages with strictly increasing SentAt
+// timestamps (oldest first), returning their IDs in creation order.
+func createCMTestMessages(t *testing.T, ds *Datastore, userID, chatID uuid.UUID, n int) []uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-time.Hour)
+	ids := make([]uuid.UUID, n)
+	for i := 0; i < n; i++ {
+		created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+			ChatID:  chatID,
+			Message: "message",
+			Origin:  models.MessageOriginUser,
+			SentAt:  base.Add(time.Duration(i) * time.Second),
+		})
+		require.NoError(t, err)
+		ids[i] = created.ID
+	}
+	return ids
+}
+
+func TestListChatMessages_NewestFirstAndPagination(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+	ids := createCMTestMessages(t, ds, userID, chatID, 3)
+
+	page, err := ds.ListChatMessages(ctx, userID, chatID, 1, 2, models.ChatMessageFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 3, page.TotalCount)
+	require.Len(t, page.Results, 2)
+	// Newest first: message[2] then message[1].
+	require.Equal(t, ids[2], page.Results[0].(*models.ChatMessage).ID)
+	require.Equal(t, ids[1], page.Results[1].(*models.ChatMessage).ID)
+
+	page2, err := ds.ListChatMessages(ctx, userID, chatID, 2, 2, models.ChatMessageFilters{})
+	require.NoError(t, err)
+	require.Len(t, page2.Results, 1)
+	require.Equal(t, ids[0], page2.Results[0].(*models.ChatMessage).ID)
+}
+
+func TestListChatMessages_Filters(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	now := time.Now().UTC()
+	_, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "hello world", Origin: models.MessageOriginUser, SentAt: now,
+	})
+	require.NoError(t, err)
+	_, err = ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "goodbye", Origin: models.MessageOriginAssistant, SentAt: now.Add(time.Second),
+	})
+	require.NoError(t, err)
+
+	origin := models.MessageOriginAssistant
+	page, err := ds.ListChatMessages(ctx, userID, chatID, 1, 10, models.ChatMessageFilters{Origin: &origin})
+	require.NoError(t, err)
+	require.Equal(t, 1, page.TotalCount)
+	require.Equal(t, "goodbye", page.Results[0].(*models.ChatMessage).Message)
+
+	query := "world"
+	page, err = ds.ListChatMessages(ctx, userID, chatID, 1, 10, models.ChatMessageFilters{Query: &query})
+	require.NoError(t, err)
+	require.Equal(t, 1, page.TotalCount)
+	require.Equal(t, "hello world", page.Results[0].(*models.ChatMessage).Message)
+
+	minDate := now.Add(500 * time.Millisecond)
+	page, err = ds.ListChatMessages(ctx, userID, chatID, 1, 10, models.ChatMessageFilters{MinDate: &minDate})
+	require.NoError(t, err)
+	require.Equal(t, 1, page.TotalCount)
+	require.Equal(t, "goodbye", page.Results[0].(*models.ChatMessage).Message)
+}
+
+func TestListChatMessages_ChatNotFound(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+
+	_, err := ds.ListChatMessages(ctx, userID, uuid.New(), 1, 10, models.ChatMessageFilters{})
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestListChatMessagesAfter_ChronologicalAndCursor(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+	ids := createCMTestMessages(t, ds, userID, chatID, 3)
+
+	// From the beginning: ascending order, oldest first.
+	page, err := ds.ListChatMessagesAfter(ctx, userID, chatID, time.Time{}, uuid.Nil, 2, models.ChatMessageFilters{})
+	require.NoError(t, err)
+	require.Len(t, page.Results, 2)
+	require.Equal(t, ids[0], page.Results[0].(*models.ChatMessage).ID)
+	require.Equal(t, ids[1], page.Results[1].(*models.ChatMessage).ID)
+
+	// Cursor past the first message returns the rest.
+	first := page.Results[0].(*models.ChatMessage)
+	page2, err := ds.ListChatMessagesAfter(ctx, userID, chatID, first.SentAt, first.ID, 10, models.ChatMessageFilters{})
+	require.NoError(t, err)
+	require.Len(t, page2.Results, 2)
+	require.Equal(t, ids[1], page2.Results[0].(*models.ChatMessage).ID)
+	require.Equal(t, ids[2], page2.Results[1].(*models.ChatMessage).ID)
+}
+
+func TestListChatMessagesAfter_CursorRequiresBothSentAtAndID(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	_, err := ds.ListChatMessagesAfter(ctx, userID, chatID, time.Now(), uuid.Nil, 10, models.ChatMessageFilters{})
+	require.Error(t, err)
+
+	_, err = ds.ListChatMessagesAfter(ctx, userID, chatID, time.Time{}, uuid.New(), 10, models.ChatMessageFilters{})
+	require.Error(t, err)
+}
+
+func TestListChatMessagesAfter_PageSizeTooLarge(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	_, err := ds.ListChatMessagesAfter(ctx, userID, chatID, time.Time{}, uuid.Nil, maxChronologicalMessagePageSize+1, models.ChatMessageFilters{})
+	require.Error(t, err)
+}
+
+func TestUpdateChatMessageGenerationExpression_HappyPath(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+
+	now := time.Now().UTC()
+	personality, err := ds.dbClient.Personality.Create().
+		SetName("Vix").SetSystemPrompt("sp").SetUserID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	expression, err := ds.dbClient.PersonalityExpression.Create().
+		SetExpressionKey("curious").
+		SetPersonalityID(personality.ID).
+		SetCreatedAt(now).SetUpdatedAt(now).
+		Save(ctx)
+	require.NoError(t, err)
+
+	chat, err := ds.dbClient.Chat.Create().
+		SetName("Chat").SetOwnerID(userID).SetModelID(modelID).SetPersonalityID(personality.ID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chat.ID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	updated, err := ds.UpdateChatMessageGenerationExpression(ctx, userID, created.ID, &expression.ID, "  because curious  ")
+	require.NoError(t, err)
+	require.NotNil(t, updated.GenerationExpressionKey)
+	require.Equal(t, "curious", *updated.GenerationExpressionKey)
+	require.NotNil(t, updated.GenerationExpressionReasoning)
+	require.Equal(t, "because curious", *updated.GenerationExpressionReasoning)
+
+	// Clearing (nil expressionID) also clears reasoning.
+	cleared, err := ds.UpdateChatMessageGenerationExpression(ctx, userID, created.ID, nil, "")
+	require.NoError(t, err)
+	require.Nil(t, cleared.GenerationExpressionKey)
+	require.Nil(t, cleared.GenerationExpressionReasoning)
+}
+
+func TestUpdateChatMessageGenerationExpression_PersonalityMismatch(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+
+	now := time.Now().UTC()
+	chatPersonality, err := ds.dbClient.Personality.Create().
+		SetName("Vix").SetSystemPrompt("sp").SetUserID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	otherPersonality, err := ds.dbClient.Personality.Create().
+		SetName("Other").SetSystemPrompt("sp").SetUserID(userID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	// Expression belongs to a different personality than the chat's.
+	expression, err := ds.dbClient.PersonalityExpression.Create().
+		SetExpressionKey("curious").
+		SetPersonalityID(otherPersonality.ID).
+		SetCreatedAt(now).SetUpdatedAt(now).
+		Save(ctx)
+	require.NoError(t, err)
+
+	chat, err := ds.dbClient.Chat.Create().
+		SetName("Chat").SetOwnerID(userID).SetModelID(modelID).SetPersonalityID(chatPersonality.ID).
+		SetCreatedAt(now).SetUpdatedAt(now).Save(ctx)
+	require.NoError(t, err)
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chat.ID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateChatMessageGenerationExpression(ctx, userID, created.ID, &expression.ID, "")
+	require.ErrorIs(t, err, ErrGenerationExpressionPersonalityMismatch)
+}
+
+func TestUpdateChatMessageGenerationExpression_ChatHasNoPersonality(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID) // no personality set
+
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "assistant reply", Origin: models.MessageOriginAssistant,
+	})
+	require.NoError(t, err)
+
+	expressionID := uuid.New()
+	_, err = ds.UpdateChatMessageGenerationExpression(ctx, userID, created.ID, &expressionID, "")
+	require.ErrorIs(t, err, ErrGenerationExpressionPersonalityMismatch)
+}
+
+func TestUpdateChatMessageGenerationExpression_NotFoundOrNotAssistant(t *testing.T) {
+	ds, cleanup := newChatMessageTestDatastore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	userID := createCMTestUser(t, ds)
+	modelID := createCMTestModel(t, ds)
+	chatID := createCMTestChat(t, ds, userID, modelID)
+
+	_, err := ds.UpdateChatMessageGenerationExpression(ctx, userID, uuid.New(), nil, "")
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+
+	// A user-origin message doesn't match the assistant-only predicate.
+	created, err := ds.CreateChatMessage(ctx, userID, models.ChatMessage{
+		ChatID: chatID, Message: "user turn", Origin: models.MessageOriginUser,
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateChatMessageGenerationExpression(ctx, userID, created.ID, nil, "")
+	require.ErrorIs(t, err, ErrChatMessageNotFound)
+}
+
+func TestTrimChatMessageLastError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty string", in: "", want: ""},
+		{name: "whitespace only", in: "  \n ", want: ""},
+		{name: "trims surrounding whitespace", in: "  boom  ", want: "boom"},
+		{name: "short string unchanged", in: "connection reset", want: "connection reset"},
+		{name: "exactly at max runes", in: strings.Repeat("e", 4096), want: strings.Repeat("e", 4096)},
+		{name: "over max runes is truncated without re-trimming", in: strings.Repeat("e", 4096) + "   tail", want: strings.Repeat("e", 4096)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trimChatMessageLastError(tt.in)
+			require.Equal(t, tt.want, got)
+			require.LessOrEqual(t, len([]rune(got)), 4096)
+		})
+	}
 }

--- a/internal/datastore/memory2_test.go
+++ b/internal/datastore/memory2_test.go
@@ -1,0 +1,1295 @@
+package datastore
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pgvector/pgvector-go"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent"
+	"github.com/theimaginaryfoundation/what-iff/ent/embedding"
+	entmemory "github.com/theimaginaryfoundation/what-iff/ent/memory"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// --- Pure/logic helper tests ---
+
+func TestValidateMemoryType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   models.MemoryType
+		wantErr bool
+	}{
+		{name: "empty type is valid", input: "", wantErr: false},
+		{name: "context type is valid", input: models.MemoryTypeContext, wantErr: false},
+		{name: "unknown type is invalid", input: models.MemoryType("bogus"), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMemoryType(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidRequestBody)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNormalizeMemoryStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		input models.MemoryStatus
+		want  entmemory.Status
+	}{
+		{name: "inactive maps to inactive", input: models.MemoryStatusInactive, want: entmemory.StatusInactive},
+		{name: "active maps to active", input: models.MemoryStatusActive, want: entmemory.StatusActive},
+		{name: "empty defaults to active", input: "", want: entmemory.StatusActive},
+		{name: "unknown defaults to active", input: models.MemoryStatus("bogus"), want: entmemory.StatusActive},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeMemoryStatus(tc.input))
+		})
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{name: "shorter than max is unchanged", input: "hello", maxLen: 10, want: "hello"},
+		{name: "equal to max is unchanged", input: "hello", maxLen: 5, want: "hello"},
+		{name: "longer than max is truncated with ellipsis", input: "hello world", maxLen: 5, want: "hello..."},
+		{name: "empty string", input: "", maxLen: 5, want: ""},
+		{name: "zero max length truncates everything", input: "hi", maxLen: 0, want: "..."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, truncateString(tc.input, tc.maxLen))
+		})
+	}
+}
+
+func TestChainMetadataToModel(t *testing.T) {
+	require.Nil(t, chainMetadataToModel(nil))
+}
+
+// --- embeddingCosineRelevance tests ---
+
+func TestEmbeddingCosineRelevance(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     []float32
+		stored    []float32
+		wantOK    bool
+		wantScore float64
+	}{
+		{
+			name:      "identical vectors have similarity 1",
+			query:     []float32{1, 0, 0},
+			stored:    []float32{1, 0, 0},
+			wantOK:    true,
+			wantScore: 1,
+		},
+		{
+			name:      "orthogonal vectors have similarity 0",
+			query:     []float32{1, 0},
+			stored:    []float32{0, 1},
+			wantOK:    true,
+			wantScore: 0,
+		},
+		{
+			name:      "opposite vectors clamp to 0 rather than negative",
+			query:     []float32{1, 0},
+			stored:    []float32{-1, 0},
+			wantOK:    true,
+			wantScore: 0,
+		},
+		{
+			name:   "mismatched lengths return not ok",
+			query:  []float32{1, 0, 0},
+			stored: []float32{1, 0},
+			wantOK: false,
+		},
+		{
+			name:   "empty query returns not ok",
+			query:  []float32{},
+			stored: []float32{1, 0},
+			wantOK: false,
+		},
+		{
+			name:   "zero query vector returns not ok",
+			query:  []float32{0, 0},
+			stored: []float32{1, 1},
+			wantOK: false,
+		},
+		{
+			name:   "zero stored vector returns not ok",
+			query:  []float32{1, 1},
+			stored: []float32{0, 0},
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := embeddingCosineRelevance(tc.query, pgvector.NewVector(tc.stored))
+			require.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				require.InDelta(t, tc.wantScore, got, 0.0001)
+			}
+		})
+	}
+}
+
+// --- memoryCursorPredicate integration test (needs a real ent query to exercise the builder) ---
+
+func TestMemoryCursorPredicate(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	var ids []uuid.UUID
+	for i := 0; i < 3; i++ {
+		id := uuid.New()
+		_, err := ds.dbClient.Memory.Create().
+			SetID(id).
+			SetContent("mem").
+			SetScope(entmemory.ScopeUser).
+			SetOwnerID(userID).
+			SetCreatedAt(base.Add(time.Duration(i) * time.Second)).
+			Save(ctx)
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	// Zero-value cursor returns everything, in insertion order.
+	all, err := memoryCursorPredicate(time.Time{}, uuid.Nil)(
+		ds.dbClient.Memory.Query().Order(ent.Asc(entmemory.FieldCreatedAt)),
+	).All(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	// Cursor past the first record returns only the remaining two.
+	rest, err := memoryCursorPredicate(base, ids[0])(
+		ds.dbClient.Memory.Query().Order(ent.Asc(entmemory.FieldCreatedAt)),
+	).All(ctx)
+	require.NoError(t, err)
+	require.Len(t, rest, 2)
+	require.Equal(t, ids[1], rest[0].ID)
+	require.Equal(t, ids[2], rest[1].ID)
+}
+
+// --- test helpers shared by this file ---
+
+// newMemoryTestDatastore builds a sqlite datastore with the shared memory-import schema
+// plus the chats-table columns (e.g. "source") that memory.go's WithChat() eager-load
+// selects but createMemoryImportTestSchema's fixture omits.
+func newMemoryTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, alterChatsTableForAgentJobTests)
+}
+
+func createTestUser(t *testing.T, ds *Datastore, userID uuid.UUID) {
+	t.Helper()
+	_, err := ds.dbClient.User.Create().
+		SetID(userID).
+		SetUsername("user-" + userID.String()).
+		SetEmail(userID.String() + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+}
+
+func createTestChat(t *testing.T, ds *Datastore, chatID, ownerID uuid.UUID) {
+	t.Helper()
+	_, err := ds.dbClient.Chat.Create().
+		SetID(chatID).
+		SetName("chat-" + chatID.String()).
+		SetOwnerID(ownerID).
+		Save(context.Background())
+	require.NoError(t, err)
+}
+
+func createTestPersonality(t *testing.T, ds *Datastore, personalityID, ownerID uuid.UUID) {
+	t.Helper()
+	_, err := ds.dbClient.Personality.Create().
+		SetID(personalityID).
+		SetName("personality-" + personalityID.String()).
+		SetSystemPrompt("prompt").
+		SetUserID(ownerID).
+		Save(context.Background())
+	require.NoError(t, err)
+}
+
+// --- CreateMemoryFromInput / CreateMemoriesBatch / createMemoryFromLevelInput ---
+
+func TestCreateMemoryFromInput_HappyPaths(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+	personalityID := uuid.New()
+	createTestPersonality(t, ds, personalityID, userID)
+
+	tests := []struct {
+		name  string
+		input models.CreateMemoryInput
+		check func(t *testing.T, mem *models.Memory)
+	}{
+		{
+			name:  "global memory",
+			input: models.CreateMemoryInput{Content: "  global fact  ", Level: models.MemoryLevelGlobal},
+			check: func(t *testing.T, mem *models.Memory) {
+				require.Equal(t, "global fact", mem.Content)
+				require.Equal(t, models.MemoryLevelGlobal, mem.Level)
+			},
+		},
+		{
+			name:  "thread memory",
+			input: models.CreateMemoryInput{Content: "thread fact", Level: models.MemoryLevelThread, ChatID: &chatID},
+			check: func(t *testing.T, mem *models.Memory) {
+				require.Equal(t, models.MemoryLevelThread, mem.Level)
+				require.Equal(t, chatID, mem.ChatID)
+			},
+		},
+		{
+			name:  "personality memory",
+			input: models.CreateMemoryInput{Content: "personality fact", Level: models.MemoryLevelPersonality, PinnedPersonalityID: &personalityID},
+			check: func(t *testing.T, mem *models.Memory) {
+				require.Equal(t, models.MemoryLevelPersonality, mem.Level)
+				require.NotNil(t, mem.PinnedPersonalityID)
+				require.Equal(t, personalityID, *mem.PinnedPersonalityID)
+			},
+		},
+		{
+			name:  "summary memory",
+			input: models.CreateMemoryInput{Content: "summary fact", Level: models.MemoryLevelSummary, ChatID: &chatID},
+			check: func(t *testing.T, mem *models.Memory) {
+				require.Equal(t, models.MemoryLevelSummary, mem.Level)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mem, err := ds.CreateMemoryFromInput(ctx, userID, tc.input)
+			require.NoError(t, err)
+			require.NotNil(t, mem)
+			tc.check(t, mem)
+		})
+	}
+}
+
+func TestCreateMemoryFromInput_ValidationFailures(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	foreignChatID := uuid.New()
+	createTestChat(t, ds, foreignChatID, otherUserID)
+	foreignPersonalityID := uuid.New()
+	createTestPersonality(t, ds, foreignPersonalityID, otherUserID)
+	missingChatID := uuid.New()
+
+	tests := []struct {
+		name    string
+		input   models.CreateMemoryInput
+		wantErr error // nil means just require.Error
+	}{
+		{
+			name:  "empty content",
+			input: models.CreateMemoryInput{Content: "   ", Level: models.MemoryLevelGlobal},
+		},
+		{
+			name:  "invalid level",
+			input: models.CreateMemoryInput{Content: "x", Level: models.MemoryLevel("bogus")},
+		},
+		{
+			name:  "invalid type",
+			input: models.CreateMemoryInput{Content: "x", Level: models.MemoryLevelGlobal, Type: models.MemoryType("bogus")},
+		},
+		{
+			// validateLevelInput's per-level branches return a plain error (not wrapped in
+			// ErrInvalidRequestBody) — only the default/unknown-level branch wraps it.
+			name:  "thread memory without chat_id",
+			input: models.CreateMemoryInput{Content: "x", Level: models.MemoryLevelThread},
+		},
+		{
+			name:    "chat not owned by user",
+			input:   models.CreateMemoryInput{Content: "x", Level: models.MemoryLevelThread, ChatID: &foreignChatID},
+			wantErr: ErrChatNotFound,
+		},
+		{
+			name:    "chat does not exist",
+			input:   models.CreateMemoryInput{Content: "x", Level: models.MemoryLevelThread, ChatID: &missingChatID},
+			wantErr: ErrChatNotFound,
+		},
+		{
+			name:    "personality not owned by user",
+			input:   models.CreateMemoryInput{Content: "x", Level: models.MemoryLevelPersonality, PinnedPersonalityID: &foreignPersonalityID},
+			wantErr: ErrPersonalityNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mem, err := ds.CreateMemoryFromInput(ctx, userID, tc.input)
+			require.Error(t, err)
+			require.Nil(t, mem)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateMemoriesBatch_EmptyItems(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	out, err := ds.CreateMemoriesBatch(ctx, uuid.New(), models.BatchCreateMemoryInput{})
+	require.NoError(t, err)
+	require.Empty(t, out)
+}
+
+func TestCreateMemoriesBatch_AllOrNoneRollsBackOnFailure(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	input := models.BatchCreateMemoryInput{
+		AllOrNone: true,
+		Items: []models.CreateMemoryInput{
+			{Content: "good one", Level: models.MemoryLevelGlobal},
+			{Content: "bad one", Level: models.MemoryLevelThread}, // missing chat_id -> fails validation
+		},
+	}
+
+	out, err := ds.CreateMemoriesBatch(ctx, userID, input)
+	require.Error(t, err)
+	require.Nil(t, out)
+
+	count, err := ds.dbClient.Memory.Query().Where(entmemory.HasOwnerWith()).Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, count, "all-or-none batch should not persist any memory when one item fails")
+}
+
+func TestCreateMemoriesBatch_PartialSkipsInvalidItems(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	input := models.BatchCreateMemoryInput{
+		AllOrNone: false,
+		Items: []models.CreateMemoryInput{
+			{Content: "good one", Level: models.MemoryLevelGlobal},
+			{Content: "bad one", Level: models.MemoryLevelThread}, // skipped
+			{Content: "good two", Level: models.MemoryLevelGlobal},
+		},
+	}
+
+	out, err := ds.CreateMemoriesBatch(ctx, userID, input)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	count, err := ds.dbClient.Memory.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+// --- CreateMemory ---
+
+func TestCreateMemory_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+
+	mem, err := ds.CreateMemory(ctx, userID, models.Memory{
+		Content: "raw create",
+		Scope:   string(entmemory.ScopeChat),
+		ChatID:  chatID,
+	}, []float32{0.1, 0.2}, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, mem)
+	require.Equal(t, "raw create", mem.Content)
+
+	emb, err := ds.dbClient.Embedding.Query().Where(embedding.HasMemoryWith(entmemory.ID(mem.ID))).Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, emb)
+}
+
+func TestCreateMemory_ChatNotOwnedByUser(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	foreignChatID := uuid.New()
+	createTestChat(t, ds, foreignChatID, otherUserID)
+
+	mem, err := ds.CreateMemory(ctx, userID, models.Memory{
+		Content: "x",
+		Scope:   string(entmemory.ScopeChat),
+		ChatID:  foreignChatID,
+	}, nil, uuid.Nil)
+	require.ErrorIs(t, err, ErrChatNotFound)
+	require.Nil(t, mem)
+}
+
+func TestCreateMemory_AutoPinsWhenPersonalityHasAutoPinEnabled(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	personalityID := uuid.New()
+	createTestPersonality(t, ds, personalityID, userID)
+	_, err := ds.dbClient.Personality.UpdateOneID(personalityID).SetAutoPinMemories(true).Save(ctx)
+	require.NoError(t, err)
+
+	mem, err := ds.CreateMemory(ctx, userID, models.Memory{
+		Content: "auto pinned",
+		Scope:   "User",
+	}, nil, personalityID)
+	require.NoError(t, err)
+	require.NotNil(t, mem.PinnedPersonalityID)
+	require.Equal(t, personalityID, *mem.PinnedPersonalityID)
+}
+
+// --- UpdateMemory ---
+
+func TestUpdateMemory_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "original", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	newContent := "updated content"
+	updated, err := ds.UpdateMemory(ctx, userID, created.ID, models.MemoryPatch{Content: &newContent})
+	require.NoError(t, err)
+	require.Equal(t, "updated content", updated.Content)
+}
+
+func TestUpdateMemory_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	newContent := "x"
+	updated, err := ds.UpdateMemory(ctx, userID, uuid.New(), models.MemoryPatch{Content: &newContent})
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+	require.Nil(t, updated)
+}
+
+func TestUpdateMemory_WrongOwner(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	ownerID := uuid.New()
+	createTestUser(t, ds, ownerID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, ownerID, models.CreateMemoryInput{Content: "mine", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	newContent := "hijacked"
+	updated, err := ds.UpdateMemory(ctx, otherUserID, created.ID, models.MemoryPatch{Content: &newContent})
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+	require.Nil(t, updated)
+}
+
+func TestUpdateMemory_EmptyContentRejected(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "original", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	blank := "   "
+	updated, err := ds.UpdateMemory(ctx, userID, created.ID, models.MemoryPatch{Content: &blank})
+	require.Error(t, err)
+	require.Nil(t, updated)
+}
+
+// --- UpdateMemoryPin ---
+
+func TestUpdateMemoryPin_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	personalityID := uuid.New()
+	createTestPersonality(t, ds, personalityID, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "pin me", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	updated, err := ds.UpdateMemoryPin(ctx, userID, created.ID, &personalityID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.PinnedPersonalityID)
+	require.Equal(t, personalityID, *updated.PinnedPersonalityID)
+
+	// Unpin.
+	updated, err = ds.UpdateMemoryPin(ctx, userID, created.ID, nil)
+	require.NoError(t, err)
+	require.Nil(t, updated.PinnedPersonalityID)
+}
+
+func TestUpdateMemoryPin_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	updated, err := ds.UpdateMemoryPin(ctx, userID, uuid.New(), nil)
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+	require.Nil(t, updated)
+}
+
+func TestUpdateMemoryPin_RejectsChatScopedMemory(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "thread memory", Level: models.MemoryLevelThread, ChatID: &chatID})
+	require.NoError(t, err)
+
+	updated, err := ds.UpdateMemoryPin(ctx, userID, created.ID, nil)
+	require.Error(t, err)
+	require.Nil(t, updated)
+}
+
+func TestUpdateMemoryPin_PersonalityNotOwnedByUser(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	foreignPersonalityID := uuid.New()
+	createTestPersonality(t, ds, foreignPersonalityID, otherUserID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "pin me", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	updated, err := ds.UpdateMemoryPin(ctx, userID, created.ID, &foreignPersonalityID)
+	require.Error(t, err)
+	require.Nil(t, updated)
+}
+
+// --- DeleteMemory ---
+
+func TestDeleteMemory_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "delete me", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	require.NoError(t, ds.DeleteMemory(ctx, userID, created.ID))
+
+	exists, err := ds.dbClient.Memory.Query().Where(entmemory.ID(created.ID)).Exist(ctx)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDeleteMemory_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	err := ds.DeleteMemory(ctx, userID, uuid.New())
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+}
+
+func TestDeleteMemory_WrongOwner(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	ownerID := uuid.New()
+	createTestUser(t, ds, ownerID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, ownerID, models.CreateMemoryInput{Content: "mine", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	err = ds.DeleteMemory(ctx, otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+
+	exists, err := ds.dbClient.Memory.Query().Where(entmemory.ID(created.ID)).Exist(ctx)
+	require.NoError(t, err)
+	require.True(t, exists, "delete by a non-owner must not remove the memory")
+}
+
+// --- GetMemory ---
+
+func TestGetMemory_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "find me", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	got, err := ds.GetMemory(ctx, userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "find me", got.Content)
+}
+
+func TestGetMemory_NotFound(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	got, err := ds.GetMemory(ctx, userID, uuid.New())
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+	require.Nil(t, got)
+}
+
+func TestGetMemory_WrongOwner(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	ownerID := uuid.New()
+	createTestUser(t, ds, ownerID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, ownerID, models.CreateMemoryInput{Content: "mine", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	got, err := ds.GetMemory(ctx, otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+	require.Nil(t, got)
+}
+
+func TestGetMemory_InactiveNotReturned(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "inactive", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+	inactive := models.MemoryStatusInactive
+	_, err = ds.UpdateMemory(ctx, userID, created.ID, models.MemoryPatch{Status: &inactive})
+	require.NoError(t, err)
+
+	got, err := ds.GetMemory(ctx, userID, created.ID)
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+	require.Nil(t, got)
+}
+
+// --- GetMemoryByIDPrefix ---
+
+func TestGetMemoryByIDPrefix(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "prefix me", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+	prefix := strings.ReplaceAll(created.ID.String(), "-", "")[:8]
+
+	got, err := ds.GetMemoryByIDPrefix(ctx, userID, prefix)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+
+	// Not found: valid-looking prefix that matches nothing.
+	_, err = ds.GetMemoryByIDPrefix(ctx, userID, "ffffffff")
+	require.ErrorIs(t, err, ErrMemoryNotFound)
+
+	// Invalid prefix (too short) surfaces memoryIDPrefixBounds' error.
+	_, err = ds.GetMemoryByIDPrefix(ctx, userID, "abc")
+	require.Error(t, err)
+}
+
+func TestGetMemoryByIDPrefix_Ambiguous(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	// Craft two memory IDs sharing an 8-hex-digit prefix.
+	base := "aaaaaaaa"
+	id1 := uuid.MustParse(base + "-0000-0000-0000-000000000001")
+	id2 := uuid.MustParse(base + "-0000-0000-0000-000000000002")
+	for _, id := range []uuid.UUID{id1, id2} {
+		_, err := ds.dbClient.Memory.Create().
+			SetID(id).
+			SetContent("ambiguous").
+			SetScope(entmemory.ScopeUser).
+			SetOwnerID(userID).
+			SetCreatedAt(time.Now()).
+			Save(ctx)
+		require.NoError(t, err)
+	}
+
+	_, err := ds.GetMemoryByIDPrefix(ctx, userID, base)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ambiguous")
+}
+
+// --- ListMemories ---
+
+func TestListMemories_FiltersAndPagination(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+	personalityID := uuid.New()
+	createTestPersonality(t, ds, personalityID, userID)
+
+	globalMem, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "global memory", Level: models.MemoryLevelGlobal, Starred: true})
+	require.NoError(t, err)
+	_, err = ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "thread memory", Level: models.MemoryLevelThread, ChatID: &chatID})
+	require.NoError(t, err)
+	_, err = ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "personality memory", Level: models.MemoryLevelPersonality, PinnedPersonalityID: &personalityID})
+	require.NoError(t, err)
+
+	// No filters, default status active — all three returned.
+	resp, err := ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 3, resp.TotalCount)
+	require.Len(t, resp.Results, 3)
+
+	// Filter by level=global.
+	globalLevel := models.MemoryLevelGlobal
+	resp, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{Level: &globalLevel})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.TotalCount)
+	require.Equal(t, globalMem.ID, resp.Results[0].(*models.Memory).ID)
+
+	// Filter by chat_id.
+	resp, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{ChatID: &chatID})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.TotalCount)
+
+	// Filter by starred.
+	starred := true
+	resp, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{Starred: &starred})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.TotalCount)
+
+	// Filter by query substring.
+	query := "thread"
+	resp, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{Query: &query})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.TotalCount)
+
+	// Pagination: pageSize=1 across 3 results.
+	resp, err = ds.ListMemories(ctx, userID, 1, 1, models.MemoryFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 3, resp.TotalCount)
+	require.Len(t, resp.Results, 1)
+	require.Equal(t, 1, resp.Page)
+
+	resp, err = ds.ListMemories(ctx, userID, 2, 1, models.MemoryFilters{})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	require.Equal(t, 2, resp.Page)
+
+	// Invalid level filter returns an error.
+	badLevel := models.MemoryLevel("bogus")
+	_, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{Level: &badLevel})
+	require.Error(t, err)
+}
+
+func TestListMemories_DefaultsAndSort(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	first, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "first", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond) // ensure distinct created_at ordering on fast filesystems
+	second, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "second", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	// Non-positive page/pageSize default to 1/10.
+	resp, err := ds.ListMemories(ctx, userID, 0, 0, models.MemoryFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.Page)
+	require.Len(t, resp.Results, 2)
+
+	// created_asc sort.
+	ascSort := models.MemorySortCreatedAsc
+	resp, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{Sort: &ascSort})
+	require.NoError(t, err)
+	require.Equal(t, first.ID, resp.Results[0].(*models.Memory).ID)
+	require.Equal(t, second.ID, resp.Results[1].(*models.Memory).ID)
+
+	// created_desc (default) sort.
+	resp, err = ds.ListMemories(ctx, userID, 1, 10, models.MemoryFilters{})
+	require.NoError(t, err)
+	require.Equal(t, second.ID, resp.Results[0].(*models.Memory).ID)
+	require.Equal(t, first.ID, resp.Results[1].(*models.Memory).ID)
+}
+
+// --- UpsertChatSummaryMemory / GetChatSummaryMemory / ListChatsMissingSummaryMemory ---
+
+func TestUpsertChatSummaryMemory_CreatesThenUpdates(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+
+	require.NoError(t, ds.UpsertChatSummaryMemory(ctx, userID, chatID, "first summary", []float32{0.1, 0.2}))
+
+	got, err := ds.GetChatSummaryMemory(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "first summary", got.Content)
+
+	// A second upsert updates the singleton in place rather than creating another row.
+	require.NoError(t, ds.UpsertChatSummaryMemory(ctx, userID, chatID, "second summary", []float32{0.3, 0.4}))
+
+	got, err = ds.GetChatSummaryMemory(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.Equal(t, "second summary", got.Content)
+
+	count, err := ds.dbClient.Memory.Query().Where(entmemory.ScopeEQ(entmemory.ScopeSummary)).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "upsert must not create a second summary memory")
+}
+
+func TestUpsertChatSummaryMemory_EmptySummaryRejected(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+
+	err := ds.UpsertChatSummaryMemory(ctx, userID, chatID, "   ", nil)
+	require.Error(t, err)
+}
+
+func TestUpsertChatSummaryMemory_ChatNotOwnedByUser(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	foreignChatID := uuid.New()
+	createTestChat(t, ds, foreignChatID, otherUserID)
+
+	err := ds.UpsertChatSummaryMemory(ctx, userID, foreignChatID, "summary", nil)
+	require.ErrorIs(t, err, ErrChatNotFound)
+}
+
+func TestGetChatSummaryMemory_NotFoundReturnsNilNil(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+
+	got, err := ds.GetChatSummaryMemory(ctx, userID, chatID)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestListChatsMissingSummaryMemory(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	// Chat with a legacy checkpoint summary but no Summary memory yet: a candidate.
+	candidateChatID := uuid.New()
+	_, err := ds.dbClient.Chat.Create().
+		SetID(candidateChatID).
+		SetName("needs backfill").
+		SetOwnerID(userID).
+		SetCheckpointSummary("legacy summary text").
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Chat with no checkpoint summary at all: not a candidate.
+	noSummaryChatID := uuid.New()
+	createTestChat(t, ds, noSummaryChatID, userID)
+
+	// Chat with a checkpoint summary AND an existing Summary memory: not a candidate.
+	backfilledChatID := uuid.New()
+	_, err = ds.dbClient.Chat.Create().
+		SetID(backfilledChatID).
+		SetName("already backfilled").
+		SetOwnerID(userID).
+		SetCheckpointSummary("already migrated").
+		Save(ctx)
+	require.NoError(t, err)
+	require.NoError(t, ds.UpsertChatSummaryMemory(ctx, userID, backfilledChatID, "already migrated", nil))
+
+	candidates, err := ds.ListChatsMissingSummaryMemory(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, candidateChatID, candidates[0].ChatID)
+	require.Equal(t, userID, candidates[0].UserID)
+	require.Equal(t, "legacy summary text", candidates[0].Summary)
+}
+
+// --- chatOwnedByUser / personalityOwnedByUser ---
+
+func TestChatOwnedByUser(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+
+	tx, err := ds.dbClient.Tx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	owned, err := ds.chatOwnedByUser(ctx, tx, userID, chatID)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	owned, err = ds.chatOwnedByUser(ctx, tx, otherUserID, chatID)
+	require.NoError(t, err)
+	require.False(t, owned)
+
+	owned, err = ds.chatOwnedByUser(ctx, tx, userID, uuid.Nil)
+	require.NoError(t, err)
+	require.False(t, owned, "nil chat ID short-circuits to false")
+
+	owned, err = ds.chatOwnedByUser(ctx, tx, userID, uuid.New())
+	require.NoError(t, err)
+	require.False(t, owned, "nonexistent chat ID returns false")
+}
+
+func TestPersonalityOwnedByUser(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	personalityID := uuid.New()
+	createTestPersonality(t, ds, personalityID, userID)
+
+	tx, err := ds.dbClient.Tx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	owned, err := ds.personalityOwnedByUser(ctx, tx, userID, personalityID)
+	require.NoError(t, err)
+	require.True(t, owned)
+
+	owned, err = ds.personalityOwnedByUser(ctx, tx, otherUserID, personalityID)
+	require.NoError(t, err)
+	require.False(t, owned)
+
+	owned, err = ds.personalityOwnedByUser(ctx, tx, userID, uuid.Nil)
+	require.NoError(t, err)
+	require.False(t, owned, "nil personality ID short-circuits to false")
+}
+
+// --- existingAnyMemoryIDs / existingChatIDs / existingPersonalityIDs ---
+
+func TestExistingAnyMemoryIDs(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	created, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "exists", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+
+	missingID := uuid.New()
+	set, err := ds.existingAnyMemoryIDs(ctx, []uuid.UUID{created.ID, missingID})
+	require.NoError(t, err)
+	require.Len(t, set, 1)
+	_, ok := set[created.ID]
+	require.True(t, ok)
+	_, ok = set[missingID]
+	require.False(t, ok)
+
+	// Empty input returns an empty (non-nil) set without querying.
+	empty, err := ds.existingAnyMemoryIDs(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+func TestExistingChatIDs(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	ownChatID := uuid.New()
+	createTestChat(t, ds, ownChatID, userID)
+	foreignChatID := uuid.New()
+	createTestChat(t, ds, foreignChatID, otherUserID)
+
+	set, err := ds.existingChatIDs(ctx, userID, []uuid.UUID{ownChatID, foreignChatID, uuid.New()})
+	require.NoError(t, err)
+	require.Len(t, set, 1)
+	_, ok := set[ownChatID]
+	require.True(t, ok)
+
+	empty, err := ds.existingChatIDs(ctx, userID, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+func TestExistingPersonalityIDs(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	otherUserID := uuid.New()
+	createTestUser(t, ds, otherUserID)
+	ownPersonalityID := uuid.New()
+	createTestPersonality(t, ds, ownPersonalityID, userID)
+	foreignPersonalityID := uuid.New()
+	createTestPersonality(t, ds, foreignPersonalityID, otherUserID)
+
+	set, err := ds.existingPersonalityIDs(ctx, userID, []uuid.UUID{ownPersonalityID, foreignPersonalityID, uuid.New()})
+	require.NoError(t, err)
+	require.Len(t, set, 1)
+	_, ok := set[ownPersonalityID]
+	require.True(t, ok)
+
+	empty, err := ds.existingPersonalityIDs(ctx, userID, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+// --- ExportMemories ---
+
+func TestExportMemories_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+	chatID := uuid.New()
+	createTestChat(t, ds, chatID, userID)
+	personalityID := uuid.New()
+	createTestPersonality(t, ds, personalityID, userID)
+
+	_, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "thread memory", Level: models.MemoryLevelThread, ChatID: &chatID})
+	require.NoError(t, err)
+	_, err = ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "global memory", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+	_, err = ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "personality memory", Level: models.MemoryLevelPersonality, PinnedPersonalityID: &personalityID})
+	require.NoError(t, err)
+	// An inactive memory must be excluded from the export.
+	inactive, err := ds.CreateMemoryFromInput(ctx, userID, models.CreateMemoryInput{Content: "inactive memory", Level: models.MemoryLevelGlobal})
+	require.NoError(t, err)
+	inactiveStatus := models.MemoryStatusInactive
+	_, err = ds.UpdateMemory(ctx, userID, inactive.ID, models.MemoryPatch{Status: &inactiveStatus})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, ds.ExportMemories(ctx, userID, &buf))
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, f := range zr.File {
+		names[f.Name] = true
+	}
+	require.True(t, names["chat.json"])
+	require.True(t, names["user.json"])
+	require.True(t, names["personality-"+personalityID.String()+".json"])
+
+	readJSONL := func(name string) []models.MemoryRecord {
+		for _, f := range zr.File {
+			if f.Name != name {
+				continue
+			}
+			rc, err := f.Open()
+			require.NoError(t, err)
+			defer rc.Close()
+			dec := json.NewDecoder(rc)
+			var recs []models.MemoryRecord
+			for {
+				var rec models.MemoryRecord
+				if err := dec.Decode(&rec); err != nil {
+					break
+				}
+				recs = append(recs, rec)
+			}
+			return recs
+		}
+		return nil
+	}
+
+	chatRecs := readJSONL("chat.json")
+	require.Len(t, chatRecs, 1)
+	require.Equal(t, "thread memory", chatRecs[0].Content)
+	require.NotNil(t, chatRecs[0].ChatID)
+	require.Equal(t, chatID, *chatRecs[0].ChatID)
+
+	userRecs := readJSONL("user.json")
+	require.Len(t, userRecs, 1, "only the unpinned global memory belongs in user.json; the inactive one is excluded")
+	require.Equal(t, "global memory", userRecs[0].Content)
+
+	personalityRecs := readJSONL("personality-" + personalityID.String() + ".json")
+	require.Len(t, personalityRecs, 1)
+	require.Equal(t, "personality memory", personalityRecs[0].Content)
+}
+
+// --- GetRelatedMemories / GetRelatedSummaryMemories ---
+//
+// Both use PostgreSQL-only pgvector SQL (the "<->" distance operator embedded via
+// sql.ExprP/sql.Expr) to rank by vector distance. SQLite has no such operator, so these
+// tests can only exercise the tx/predicate setup and the error-propagation path — the
+// actual similarity ranking is covered indirectly by embeddingCosineRelevance's own tests
+// and is otherwise only verifiable against real Postgres. This documents that these two
+// functions are not fully unit-testable under the current sqlite harness.
+
+func TestGetRelatedMemories_PropagatesQueryError(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	_, err := ds.GetRelatedMemories(ctx, userID, uuid.New(), []float32{0.1, 0.2}, uuid.Nil)
+	require.Error(t, err, "sqlite does not support the pgvector '<->' operator memory.go embeds via sql.ExprP")
+}
+
+func TestGetRelatedSummaryMemories_PropagatesQueryError(t *testing.T) {
+	ctx := context.Background()
+	ds, cleanup := newMemoryTestDatastore(t)
+	defer cleanup()
+
+	userID := uuid.New()
+	createTestUser(t, ds, userID)
+
+	_, err := ds.GetRelatedSummaryMemories(ctx, userID, []float32{0.1, 0.2}, 0)
+	require.Error(t, err, "sqlite does not support the pgvector '<->' operator memory.go embeds via sql.ExprP")
+}


### PR DESCRIPTION
## Summary

Follow-up tranche on the same shared sqlite harness introduced in
oss/unit-tests-datastore (#15), continuing the datastore coverage push
past that PR's shortfall:

- `internal/datastore/memory.go`: 21 previously zero-coverage functions
  now covered (CRUD, batch create, pin/update, chat-summary upsert/get,
  export, related-memory lookup, and the pure-logic helpers). Two
  functions (`GetRelatedMemories`/`GetRelatedSummaryMemories`) rely on a
  PostgreSQL-only pgvector operator sqlite can't parse; their tests
  exercise the query setup and error path, with the shared similarity
  scoring covered directly via `embeddingCosineRelevance`.
- `internal/datastore/chatmessage.go`: all 15 previously zero-coverage
  functions now covered (CRUD, pagination/filters, generation-expression
  and checkpoint/context-breakdown setters). Along the way, replaced six
  pre-existing tests in `chatmessage_test.go` that only re-implemented
  filter-validation logic inline and never called into the package —
  they contributed nothing to this file's coverage despite existing.

`go-unit` coverage: 39.5% -> 42.1%.

Stacked on #15.

## Test plan

- [x] `go test ./internal/datastore/... -race` green
- [x] `gofmt -l` / `go vet` clean
- [x] `make test-ci` + `make coverage-summary` confirm 42.1%