### PR TITLE
Cover user.go datastore CRUD, auth, and role logic

### DIFF
--- a/internal/datastore/model_catalog_test.go
+++ b/internal/datastore/model_catalog_test.go
@@ -1,0 +1,388 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent"
+	entmodel "github.com/theimaginaryfoundation/what-iff/ent/model"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+func newModelCatalogTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema)
+}
+
+func newModelCatalogRoleTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, createUserRoleTestSchema)
+}
+
+func createCatalogTestUser(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := ds.dbClient.User.Create().
+		SetID(id).
+		SetUsername("cat-" + id.String()[:8]).
+		SetEmail("cat-" + id.String()[:8] + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+	return id
+}
+
+func createCatalogTestModel(t *testing.T, ds *Datastore, opts ...func(*ent.ModelCreate)) *ent.Model {
+	t.Helper()
+	create := ds.dbClient.Model.Create().
+		SetName("model-" + uuid.NewString()[:8]).
+		SetDisplayName("Test Model").
+		SetDescription("test model")
+	for _, opt := range opts {
+		opt(create)
+	}
+	m, err := create.Save(context.Background())
+	require.NoError(t, err)
+	return m
+}
+
+func TestListModels(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	createCatalogTestModel(t, ds)
+	deleted := createCatalogTestModel(t, ds)
+	_, err := ds.dbClient.Model.UpdateOne(deleted).SetDeleted(true).Save(context.Background())
+	require.NoError(t, err)
+
+	got, err := ds.ListModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1, "deleted models must be excluded")
+}
+
+func TestListModelsDefault(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	createCatalogTestModel(t, ds)
+
+	got, err := ds.ListModelsDefault(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+}
+
+func TestListModelsForUser(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	createCatalogTestModel(t, ds)
+	userID := createCatalogTestUser(t, ds)
+
+	got, err := ds.ListModelsForUser(context.Background(), userID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+}
+
+func TestListModelsForUser_UserNotFound(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	createCatalogTestModel(t, ds)
+
+	_, err := ds.ListModelsForUser(context.Background(), uuid.New())
+	require.ErrorIs(t, err, ErrUserNotFound)
+}
+
+func TestAdminPatchUserExperimentalModels_TogglesFlag(t *testing.T) {
+	ds, cleanup := newModelCatalogRoleTestDatastore(t)
+	defer cleanup()
+
+	userID := createCatalogTestUser(t, ds)
+
+	updated, err := ds.AdminPatchUserExperimentalModels(context.Background(), userID, true)
+	require.NoError(t, err)
+	require.True(t, updated.EnableExperimentalModels)
+
+	updated, err = ds.AdminPatchUserExperimentalModels(context.Background(), userID, false)
+	require.NoError(t, err)
+	require.False(t, updated.EnableExperimentalModels)
+}
+
+func TestAdminPatchUserExperimentalModels_UserNotFound(t *testing.T) {
+	ds, cleanup := newModelCatalogRoleTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.AdminPatchUserExperimentalModels(context.Background(), uuid.New(), true)
+	require.ErrorIs(t, err, ErrUserNotFound)
+}
+
+func TestAdminPatchUserExperimentalModels_RejectsSuperAdmin(t *testing.T) {
+	ds, cleanup := newModelCatalogRoleTestDatastore(t)
+	defer cleanup()
+
+	userID := createCatalogTestUser(t, ds)
+	roleID := createUserTestRole(t, ds, "super_admin")
+	_, err := ds.dbClient.User.UpdateOneID(userID).AddRoleIDs(roleID).Save(context.Background())
+	require.NoError(t, err)
+
+	_, err = ds.AdminPatchUserExperimentalModels(context.Background(), userID, true)
+	require.ErrorIs(t, err, ErrCannotModifySuperAdmin)
+}
+
+func TestAdminListModels(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	active := createCatalogTestModel(t, ds)
+	deletedModel := createCatalogTestModel(t, ds)
+	_, err := ds.dbClient.Model.UpdateOne(deletedModel).SetDeleted(true).Save(context.Background())
+	require.NoError(t, err)
+
+	got, err := ds.AdminListModels(context.Background(), false)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, active.ID, got[0].ID)
+
+	got, err = ds.AdminListModels(context.Background(), true)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, deletedModel.ID, got[0].ID)
+}
+
+func TestAdminGetModel(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	m := createCatalogTestModel(t, ds)
+
+	got, err := ds.AdminGetModel(context.Background(), m.ID)
+	require.NoError(t, err)
+	require.Equal(t, m.ID, got.ID)
+}
+
+func TestAdminGetModel_NotFound(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.AdminGetModel(context.Background(), uuid.New())
+	require.ErrorIs(t, err, ErrModelNotFound)
+}
+
+func TestAdminUpdateModel(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	m := createCatalogTestModel(t, ds)
+	newTier := "ultra"
+	toolSupport := true
+	credits := int64(5)
+
+	got, err := ds.AdminUpdateModel(context.Background(), m.ID, models.UpdateModelRequest{
+		Name:               "renamed-" + uuid.NewString()[:8],
+		DisplayName:        "Renamed Model",
+		Description:        "new description",
+		Provider:           "anthropic",
+		ToolSupport:        &toolSupport,
+		BaseCreditsPerSlab: &credits,
+		SubscriptionTier:   &newTier,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Renamed Model", got.DisplayName)
+	require.Equal(t, "anthropic", got.Provider)
+	require.True(t, got.ToolSupport)
+	require.Equal(t, int64(5), got.BaseCreditsPerSlab)
+	require.Equal(t, "ultra", got.SubscriptionTier)
+}
+
+func TestAdminUpdateModel_NotFound(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.AdminUpdateModel(context.Background(), uuid.New(), models.UpdateModelRequest{})
+	require.ErrorIs(t, err, ErrModelNotFound)
+}
+
+func TestAdminUpdateModel_NameConflict(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	existing := createCatalogTestModel(t, ds)
+	target := createCatalogTestModel(t, ds)
+
+	_, err := ds.AdminUpdateModel(context.Background(), target.ID, models.UpdateModelRequest{
+		Name: existing.Name,
+	})
+	require.ErrorIs(t, err, ErrModelNameExists)
+}
+
+func TestAdminUpdateModel_InvalidProvider(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	m := createCatalogTestModel(t, ds)
+
+	_, err := ds.AdminUpdateModel(context.Background(), m.ID, models.UpdateModelRequest{
+		Provider: "not-a-real-provider",
+	})
+	require.ErrorIs(t, err, ErrInvalidProvider)
+}
+
+func TestAdminSetDefaultModel(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	first := createCatalogTestModel(t, ds, func(c *ent.ModelCreate) { c.SetIsDefault(true) })
+	second := createCatalogTestModel(t, ds)
+
+	got, err := ds.AdminSetDefaultModel(context.Background(), second.ID)
+	require.NoError(t, err)
+	require.True(t, got.IsDefault)
+
+	reloadedFirst, err := ds.dbClient.Model.Get(context.Background(), first.ID)
+	require.NoError(t, err)
+	require.False(t, reloadedFirst.IsDefault, "old default must be cleared")
+}
+
+func TestAdminSetDefaultModel_NotFound(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.AdminSetDefaultModel(context.Background(), uuid.New())
+	require.ErrorIs(t, err, ErrModelNotFound)
+}
+
+func TestResolveDefaultModelName(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	m := createCatalogTestModel(t, ds, func(c *ent.ModelCreate) { c.SetIsDefault(true) })
+
+	got := ds.ResolveDefaultModelName(context.Background())
+	require.Equal(t, m.Name, got)
+}
+
+func TestResolveDefaultModelName_FallsBackToEnvDefault(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	t.Setenv("DEFAULT_MODEL_NAME", "env-default-model")
+
+	got := ds.ResolveDefaultModelName(context.Background())
+	require.Equal(t, "env-default-model", got)
+}
+
+func TestGetModelByName(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	m := createCatalogTestModel(t, ds)
+
+	got, err := ds.GetModelByName(context.Background(), m.Name)
+	require.NoError(t, err)
+	require.Equal(t, m.ID, got.ID)
+}
+
+func TestGetModelByName_EmptyName(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.GetModelByName(context.Background(), "   ")
+	require.ErrorIs(t, err, ErrModelNotFound)
+}
+
+func TestGetModelByName_NotFound(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.GetModelByName(context.Background(), "no-such-model")
+	require.ErrorIs(t, err, ErrModelNotFound)
+}
+
+func TestNormalizeModelProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    entmodel.Provider
+		wantErr error
+	}{
+		{name: "empty defaults to openai", raw: "", want: entmodel.ProviderOpenai},
+		{name: "openai", raw: " OpenAI ", want: entmodel.ProviderOpenai},
+		{name: "anthropic", raw: "anthropic", want: entmodel.ProviderAnthropic},
+		{name: "zai", raw: "zai", want: entmodel.ProviderZai},
+		{name: "google", raw: "google", want: entmodel.ProviderGoogle},
+		{name: "mistral", raw: "mistral", want: entmodel.ProviderMistral},
+		{name: "deepseek", raw: "deepseek", want: entmodel.ProviderDeepseek},
+		{name: "qwen", raw: "qwen", want: entmodel.ProviderQwen},
+		{name: "xiaomi", raw: "xiaomi", want: entmodel.ProviderXiaomi},
+		{name: "unknown", raw: "bogus", wantErr: ErrInvalidProvider},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeModelProvider(tt.raw)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeBaseCreditsPerSlab(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, defaultBaseCreditsPerSlab, normalizeBaseCreditsPerSlab(0))
+	require.Equal(t, defaultBaseCreditsPerSlab, normalizeBaseCreditsPerSlab(-5))
+	require.Equal(t, int64(3), normalizeBaseCreditsPerSlab(3))
+}
+
+func TestResolveDefaultModelTx(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	m := createCatalogTestModel(t, ds, func(c *ent.ModelCreate) { c.SetIsDefault(true) })
+
+	tx, err := ds.dbClient.Tx(context.Background())
+	require.NoError(t, err)
+	got, err := resolveDefaultModelTx(context.Background(), tx)
+	require.NoError(t, err)
+	require.Equal(t, m.ID, got.ID)
+	require.NoError(t, tx.Commit())
+}
+
+func TestResolveDefaultModelTx_FallsBackToNamedDefault(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	t.Setenv("DEFAULT_MODEL_NAME", "named-default")
+	named := createCatalogTestModel(t, ds, func(c *ent.ModelCreate) { c.SetName("named-default") })
+	createCatalogTestModel(t, ds) // decoy, no is_default and different name
+
+	tx, err := ds.dbClient.Tx(context.Background())
+	require.NoError(t, err)
+	got, err := resolveDefaultModelTx(context.Background(), tx)
+	require.NoError(t, err)
+	require.Equal(t, named.ID, got.ID)
+	require.NoError(t, tx.Commit())
+}
+
+func TestResolveDefaultModelTx_FallsBackToAnyActiveModel(t *testing.T) {
+	ds, cleanup := newModelCatalogTestDatastore(t)
+	defer cleanup()
+
+	t.Setenv("DEFAULT_MODEL_NAME", "no-such-model")
+	only := createCatalogTestModel(t, ds)
+
+	tx, err := ds.dbClient.Tx(context.Background())
+	require.NoError(t, err)
+	got, err := resolveDefaultModelTx(context.Background(), tx)
+	require.NoError(t, err)
+	require.Equal(t, only.ID, got.ID)
+	require.NoError(t, tx.Commit())
+}

--- a/internal/datastore/mood_catalog_test.go
+++ b/internal/datastore/mood_catalog_test.go
@@ -1,0 +1,405 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+func newMoodCatalogTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, createFileAttachmentTestSchema)
+}
+
+func createMoodTestUser(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := ds.dbClient.User.Create().
+		SetID(id).
+		SetUsername("mood-" + id.String()[:8]).
+		SetEmail("mood-" + id.String()[:8] + "@example.com").
+		SetPasswordHash("hash").
+		Save(context.Background())
+	require.NoError(t, err)
+	return id
+}
+
+func createMoodTestImage(t *testing.T, ds *Datastore, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	fa, err := ds.dbClient.FileAttachment.Create().
+		SetName("pic.jpg").
+		SetFileType("image/jpeg").
+		SetOwnerID(userID).
+		Save(context.Background())
+	require.NoError(t, err)
+	return fa.ID
+}
+
+func createMoodTestRitual(t *testing.T, ds *Datastore, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	r, err := ds.dbClient.Ritual.Create().
+		SetOwnerID(userID).
+		SetName("Morning").
+		SetDescription("desc").
+		SetContent("content").
+		SetHotkeys("").
+		Save(context.Background())
+	require.NoError(t, err)
+	return r.ID
+}
+
+func createMoodTestPersonality(t *testing.T, ds *Datastore, userID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	p, err := ds.dbClient.Personality.Create().
+		SetName("Test Personality").
+		SetSystemPrompt("system prompt").
+		SetUserID(userID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
+	require.NoError(t, err)
+	return p.ID
+}
+
+func TestCreateMood(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	imageID := createMoodTestImage(t, ds, userID)
+	ritualID := createMoodTestRitual(t, ds, userID)
+
+	got, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{
+		Name:          "Cozy",
+		Description:   "warm and quiet",
+		PromptSnippet: "speak softly",
+		ImageIDs:      []uuid.UUID{imageID},
+		RitualIDs:     []uuid.UUID{ritualID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Cozy", got.Name)
+	require.Equal(t, []uuid.UUID{imageID}, got.ImageIDs)
+	require.Equal(t, []uuid.UUID{ritualID}, got.RitualIDs)
+}
+
+func TestCreateMood_RejectsNonOwnedImage(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	imageID := createMoodTestImage(t, ds, otherUserID)
+
+	_, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{
+		Name:     "Cozy",
+		ImageIDs: []uuid.UUID{imageID},
+	})
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestCreateMood_RejectsNonOwnedRitual(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	ritualID := createMoodTestRitual(t, ds, otherUserID)
+
+	_, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{
+		Name:      "Cozy",
+		RitualIDs: []uuid.UUID{ritualID},
+	})
+	require.ErrorIs(t, err, ErrRitualNotFound)
+}
+
+func TestGetMood(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	got, err := ds.GetMood(context.Background(), userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+}
+
+func TestGetMood_NotFound(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+
+	_, err := ds.GetMood(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestGetMood_WrongOwner(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	_, err = ds.GetMood(context.Background(), otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestListMoods(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	_, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+	_, err = ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Excited"})
+	require.NoError(t, err)
+
+	otherUserID := createMoodTestUser(t, ds)
+	_, err = ds.CreateMood(context.Background(), otherUserID, models.CreateMoodRequest{Name: "NotMine"})
+	require.NoError(t, err)
+
+	got, err := ds.ListMoods(context.Background(), userID, 1, 20, models.MoodFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 2, got.TotalCount)
+	require.Len(t, got.Results, 2)
+}
+
+func TestListMoods_NameFilter(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	_, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+	_, err = ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Excited"})
+	require.NoError(t, err)
+
+	name := "coz"
+	got, err := ds.ListMoods(context.Background(), userID, 1, 20, models.MoodFilters{Name: &name})
+	require.NoError(t, err)
+	require.Equal(t, 1, got.TotalCount)
+}
+
+func TestListMoods_DefaultsPageNumAndSize(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	_, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	got, err := ds.ListMoods(context.Background(), userID, 0, 0, models.MoodFilters{})
+	require.NoError(t, err)
+	require.Equal(t, 1, got.Page)
+	require.Equal(t, 1, got.TotalCount)
+}
+
+func TestUpdateMood(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	imageID := createMoodTestImage(t, ds, userID)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	newImageIDs := []uuid.UUID{imageID}
+	got, err := ds.UpdateMood(context.Background(), userID, created.ID, models.UpdateMoodRequest{
+		Name:             "Cozier",
+		Description:      "even warmer",
+		PromptSnippet:    "whisper",
+		RecommendedModel: "gpt-5.1",
+		ImageIDs:         &newImageIDs,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Cozier", got.Name)
+	require.Equal(t, "gpt-5.1", got.RecommendedModel)
+	require.Equal(t, []uuid.UUID{imageID}, got.ImageIDs)
+}
+
+func TestUpdateMood_NotFound(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+
+	_, err := ds.UpdateMood(context.Background(), userID, uuid.New(), models.UpdateMoodRequest{Name: "X"})
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestUpdateMood_RejectsNonOwnedImage(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	imageID := createMoodTestImage(t, ds, otherUserID)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	badImageIDs := []uuid.UUID{imageID}
+	_, err = ds.UpdateMood(context.Background(), userID, created.ID, models.UpdateMoodRequest{
+		Name:     "Cozy",
+		ImageIDs: &badImageIDs,
+	})
+	require.ErrorIs(t, err, ErrFileAttachmentNotFound)
+}
+
+func TestUpdateMood_RejectsNonOwnedRitual(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	ritualID := createMoodTestRitual(t, ds, otherUserID)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	badRitualIDs := []uuid.UUID{ritualID}
+	_, err = ds.UpdateMood(context.Background(), userID, created.ID, models.UpdateMoodRequest{
+		Name:      "Cozy",
+		RitualIDs: &badRitualIDs,
+	})
+	require.ErrorIs(t, err, ErrRitualNotFound)
+}
+
+func TestSetMoodThumbnail(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	err = ds.SetMoodThumbnail(context.Background(), created.ID, []byte("jpegdata"))
+	require.NoError(t, err)
+
+	got, err := ds.GetMood(context.Background(), userID, created.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, got.ThumbnailData)
+}
+
+func TestDeleteMood(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	err = ds.DeleteMood(context.Background(), userID, created.ID)
+	require.NoError(t, err)
+
+	_, err = ds.GetMood(context.Background(), userID, created.ID)
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestDeleteMood_NotFound(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+
+	err := ds.DeleteMood(context.Background(), userID, uuid.New())
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestDeleteMood_WrongOwner(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	err = ds.DeleteMood(context.Background(), otherUserID, created.ID)
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestSetMoodPersonalities(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	personalityID := createMoodTestPersonality(t, ds, userID)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	err = ds.SetMoodPersonalities(context.Background(), userID, created.ID, []uuid.UUID{personalityID})
+	require.NoError(t, err)
+
+	got, err := ds.GetMood(context.Background(), userID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{personalityID}, got.PersonalityIDs)
+
+	// Clearing with an empty slice removes the association.
+	err = ds.SetMoodPersonalities(context.Background(), userID, created.ID, nil)
+	require.NoError(t, err)
+	got, err = ds.GetMood(context.Background(), userID, created.ID)
+	require.NoError(t, err)
+	require.Empty(t, got.PersonalityIDs)
+}
+
+func TestSetMoodPersonalities_MoodNotFound(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+
+	err := ds.SetMoodPersonalities(context.Background(), userID, uuid.New(), nil)
+	require.ErrorIs(t, err, ErrMoodNotFound)
+}
+
+func TestSetMoodPersonalities_RejectsNonOwnedPersonality(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	otherUserID := createMoodTestUser(t, ds)
+	personalityID := createMoodTestPersonality(t, ds, otherUserID)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	err = ds.SetMoodPersonalities(context.Background(), userID, created.ID, []uuid.UUID{personalityID})
+	require.ErrorIs(t, err, ErrPersonalityNotFound)
+}
+
+func TestGetMoodsForPersonality(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	personalityID := createMoodTestPersonality(t, ds, userID)
+	created, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+	require.NoError(t, ds.SetMoodPersonalities(context.Background(), userID, created.ID, []uuid.UUID{personalityID}))
+
+	got, err := ds.GetMoodsForPersonality(context.Background(), userID, personalityID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, created.ID, got[0].ID)
+}
+
+func TestGetMoodsForPersonality_NoneAttached(t *testing.T) {
+	ds, cleanup := newMoodCatalogTestDatastore(t)
+	defer cleanup()
+
+	userID := createMoodTestUser(t, ds)
+	personalityID := createMoodTestPersonality(t, ds, userID)
+	_, err := ds.CreateMood(context.Background(), userID, models.CreateMoodRequest{Name: "Cozy"})
+	require.NoError(t, err)
+
+	got, err := ds.GetMoodsForPersonality(context.Background(), userID, personalityID)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/internal/datastore/user_test.go
+++ b/internal/datastore/user_test.go
@@ -1,35 +1,554 @@
 package datastore
 
-import "testing"
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent/user"
+	"github.com/theimaginaryfoundation/what-iff/internal/auth"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// createUserRoleTestSchema creates the roles and user_roles tables that user
+// creation depends on: getDefaultRoleID looks up the "user" role by name, and
+// CreateUser links the new user to it via AddRoleIDs. toUserModel's role-priority
+// logic (admin over user) also depends on these tables being populated.
+//
+// Must be composed after createMemoryImportTestSchema (users is an FK parent here),
+// e.g. newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema,
+// createUserRoleTestSchema).
+func createUserRoleTestSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	statements := []string{
+		`CREATE TABLE roles (
+			id uuid PRIMARY KEY,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			name text NOT NULL UNIQUE,
+			description text
+		)`,
+		`CREATE TABLE user_roles (
+			user_id uuid NOT NULL,
+			role_id uuid NOT NULL,
+			PRIMARY KEY (user_id, role_id)
+		)`,
+	}
+	for _, stmt := range statements {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err)
+	}
+}
+
+func newUserTestDatastore(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+	return newTestDatastore(t, createMemoryImportTestSchema, createAccountBackupTestSchema, createUserRoleTestSchema)
+}
+
+// setUserTestJWTSecrets sets the JWT env vars that auth.GenerateTokenPair and
+// auth.ValidateRefreshToken require; they are unset by default in the test process.
+func setUserTestJWTSecrets(t *testing.T) {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-jwt-secret")
+	t.Setenv("JWT_REFRESH_SECRET", "test-jwt-refresh-secret")
+}
+
+func createUserTestRole(t *testing.T, ds *Datastore, name string) uuid.UUID {
+	t.Helper()
+	r, err := ds.dbClient.Role.Create().SetName(name).Save(context.Background())
+	require.NoError(t, err)
+	return r.ID
+}
+
+func createUserTestDefaultModel(t *testing.T, ds *Datastore) uuid.UUID {
+	t.Helper()
+	m, err := ds.dbClient.Model.Create().
+		SetName("gpt-test").
+		SetDisplayName("GPT Test").
+		SetDescription("test model").
+		SetIsDefault(true).
+		Save(context.Background())
+	require.NoError(t, err)
+	return m.ID
+}
 
 func TestValidateIANATimezone(t *testing.T) {
 	tests := []struct {
 		name    string
 		tz      string
-		wantErr bool
+		wantErr error
 	}{
-		{"empty is valid (no-op)", "", false},
-		{"whitespace only is valid", "  ", false},
-		{"America/New_York", "America/New_York", false},
-		{"UTC", "UTC", false},
-		{"Europe/London", "Europe/London", false},
-		{"with trim", "  America/Los_Angeles  ", false},
-		{"invalid name", "Not/A_Real_Timezone", true},
-		{"garbage", "xyz", true},
-		{"empty after trim", "  ", false},
+		{name: "empty is a no-op", tz: "", wantErr: nil},
+		{name: "whitespace-only is a no-op", tz: "   ", wantErr: nil},
+		{name: "valid IANA name", tz: "America/New_York", wantErr: nil},
+		{name: "invalid name", tz: "Not/A_Zone", wantErr: ErrInvalidTimezone},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateIANATimezone(tt.tz)
-			if tt.wantErr {
-				if err != ErrInvalidTimezone {
-					t.Fatalf("validateIANATimezone() err = %v, want ErrInvalidTimezone", err)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("validateIANATimezone() err = %v, want nil", err)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
+}
+
+func TestGetDefaultModelName(t *testing.T) {
+	t.Run("falls back to models.DefaultModelName when unset", func(t *testing.T) {
+		t.Setenv("DEFAULT_MODEL_NAME", "")
+		require.Equal(t, models.DefaultModelName, getDefaultModelName())
+	})
+
+	t.Run("uses DEFAULT_MODEL_NAME when set", func(t *testing.T) {
+		t.Setenv("DEFAULT_MODEL_NAME", "custom-model")
+		require.Equal(t, "custom-model", getDefaultModelName())
+	})
+}
+
+func TestGetDefaultRoleID(t *testing.T) {
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+
+	t.Run("role not found", func(t *testing.T) {
+		tx, err := ds.dbClient.Tx(context.Background())
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		_, err = ds.getDefaultRoleID(context.Background(), tx)
+		require.Error(t, err)
+	})
+
+	roleID := createUserTestRole(t, ds, "user")
+
+	t.Run("role found", func(t *testing.T) {
+		tx, err := ds.dbClient.Tx(context.Background())
+		require.NoError(t, err)
+		defer tx.Rollback()
+
+		got, err := ds.getDefaultRoleID(context.Background(), tx)
+		require.NoError(t, err)
+		require.Equal(t, roleID, got)
+	})
+}
+
+func TestCreateUser(t *testing.T) {
+	setUserTestJWTSecrets(t)
+
+	t.Run("success", func(t *testing.T) {
+		ds, cleanup := newUserTestDatastore(t)
+		defer cleanup()
+		createUserTestRole(t, ds, "user")
+		createUserTestDefaultModel(t, ds)
+
+		resp, tokens, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+			Username:      "newuser",
+			Email:         "newuser@example.com",
+			Password:      "supersecret",
+			FirstName:     "New",
+			LastName:      "User",
+			TermsAccepted: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+		require.NotEmpty(t, tokens.AccessToken)
+		require.NotEmpty(t, tokens.RefreshToken)
+		require.Equal(t, "newuser", resp.Username)
+		require.Equal(t, "newuser@example.com", resp.Email)
+		require.Equal(t, "user", resp.Role)
+		require.Equal(t, defaultTheme.String(), resp.Theme)
+	})
+
+	t.Run("username already exists", func(t *testing.T) {
+		ds, cleanup := newUserTestDatastore(t)
+		defer cleanup()
+		createUserTestRole(t, ds, "user")
+		createUserTestDefaultModel(t, ds)
+
+		req := models.UserRegisterRequest{
+			Username: "dupeuser",
+			Email:    "one@example.com",
+			Password: "supersecret",
+		}
+		_, _, err := ds.CreateUser(context.Background(), req)
+		require.NoError(t, err)
+
+		req.Email = "two@example.com"
+		_, _, err = ds.CreateUser(context.Background(), req)
+		require.ErrorIs(t, err, ErrUsernameExists)
+	})
+
+	t.Run("email already exists", func(t *testing.T) {
+		ds, cleanup := newUserTestDatastore(t)
+		defer cleanup()
+		createUserTestRole(t, ds, "user")
+		createUserTestDefaultModel(t, ds)
+
+		req := models.UserRegisterRequest{
+			Username: "userone",
+			Email:    "same@example.com",
+			Password: "supersecret",
+		}
+		_, _, err := ds.CreateUser(context.Background(), req)
+		require.NoError(t, err)
+
+		req.Username = "usertwo"
+		_, _, err = ds.CreateUser(context.Background(), req)
+		require.ErrorIs(t, err, ErrEmailExists)
+	})
+
+	t.Run("no default role configured", func(t *testing.T) {
+		ds, cleanup := newUserTestDatastore(t)
+		defer cleanup()
+		createUserTestDefaultModel(t, ds)
+
+		_, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+			Username: "norole",
+			Email:    "norole@example.com",
+			Password: "supersecret",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("no default model configured", func(t *testing.T) {
+		ds, cleanup := newUserTestDatastore(t)
+		defer cleanup()
+		createUserTestRole(t, ds, "user")
+
+		_, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+			Username: "nomodel",
+			Email:    "nomodel@example.com",
+			Password: "supersecret",
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestGetUserByCredentials(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+	createUserTestRole(t, ds, "user")
+	createUserTestDefaultModel(t, ds)
+
+	_, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "creduser",
+		Email:    "cred@example.com",
+		Password: "correcthorse",
+	})
+	require.NoError(t, err)
+
+	t.Run("by username", func(t *testing.T) {
+		resp, tokens, err := ds.GetUserByCredentials(context.Background(), models.UserLoginRequest{
+			Username: "creduser",
+			Password: "correcthorse",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, tokens)
+		require.Equal(t, "creduser", resp.Username)
+	})
+
+	t.Run("by email", func(t *testing.T) {
+		resp, _, err := ds.GetUserByCredentials(context.Background(), models.UserLoginRequest{
+			Username: "cred@example.com",
+			Password: "correcthorse",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "creduser", resp.Username)
+	})
+
+	t.Run("wrong password", func(t *testing.T) {
+		_, _, err := ds.GetUserByCredentials(context.Background(), models.UserLoginRequest{
+			Username: "creduser",
+			Password: "wrong",
+		})
+		require.ErrorIs(t, err, ErrInvalidCredentials)
+	})
+
+	t.Run("unknown user", func(t *testing.T) {
+		_, _, err := ds.GetUserByCredentials(context.Background(), models.UserLoginRequest{
+			Username: "ghost",
+			Password: "whatever",
+		})
+		require.ErrorIs(t, err, ErrInvalidCredentials)
+	})
+}
+
+func TestGetUserByID(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+	createUserTestRole(t, ds, "user")
+	createUserTestDefaultModel(t, ds)
+
+	resp, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "idlookup",
+		Email:    "idlookup@example.com",
+		Password: "supersecret",
+	})
+	require.NoError(t, err)
+
+	t.Run("found", func(t *testing.T) {
+		got, err := ds.GetUserByID(context.Background(), resp.ID)
+		require.NoError(t, err)
+		require.Equal(t, "idlookup", got.Username)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ds.GetUserByID(context.Background(), uuid.New())
+		require.ErrorIs(t, err, ErrUserNotFound)
+	})
+}
+
+func TestUpdateUserProfile(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+	createUserTestRole(t, ds, "user")
+	createUserTestDefaultModel(t, ds)
+
+	userA, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "profileA",
+		Email:    "profileA@example.com",
+		Password: "supersecret",
+	})
+	require.NoError(t, err)
+
+	_, _, err = ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "profileB",
+		Email:    "profileB@example.com",
+		Password: "supersecret",
+	})
+	require.NoError(t, err)
+
+	t.Run("updates names and timezone", func(t *testing.T) {
+		got, err := ds.UpdateUserProfile(context.Background(), userA.ID, models.UpdateUserRequest{
+			FirstName: "Ada",
+			LastName:  "Lovelace",
+			Timezone:  "America/New_York",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "Ada", got.FirstName)
+		require.Equal(t, "Lovelace", got.LastName)
+		require.Equal(t, "America/New_York", got.Timezone)
+	})
+
+	t.Run("email conflict with another user", func(t *testing.T) {
+		_, err := ds.UpdateUserProfile(context.Background(), userA.ID, models.UpdateUserRequest{
+			Email: "profileB@example.com",
+		})
+		require.ErrorIs(t, err, ErrEmailExists)
+	})
+
+	t.Run("email changed to a free address", func(t *testing.T) {
+		got, err := ds.UpdateUserProfile(context.Background(), userA.ID, models.UpdateUserRequest{
+			Email: "profileA-new@example.com",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "profileA-new@example.com", got.Email)
+	})
+
+	t.Run("invalid timezone", func(t *testing.T) {
+		_, err := ds.UpdateUserProfile(context.Background(), userA.ID, models.UpdateUserRequest{
+			Timezone: "Not/A_Zone",
+		})
+		require.ErrorIs(t, err, ErrInvalidTimezone)
+	})
+
+	t.Run("whitespace-only timezone is a no-op", func(t *testing.T) {
+		before, err := ds.GetUserByID(context.Background(), userA.ID)
+		require.NoError(t, err)
+
+		got, err := ds.UpdateUserProfile(context.Background(), userA.ID, models.UpdateUserRequest{
+			Timezone: "   ",
+		})
+		require.NoError(t, err)
+		require.Equal(t, before.Timezone, got.Timezone)
+	})
+
+	t.Run("user not found", func(t *testing.T) {
+		_, err := ds.UpdateUserProfile(context.Background(), uuid.New(), models.UpdateUserRequest{
+			FirstName: "Ghost",
+		})
+		require.ErrorIs(t, err, ErrUserNotFound)
+	})
+}
+
+func TestUpdateUserPassword(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+	createUserTestRole(t, ds, "user")
+	createUserTestDefaultModel(t, ds)
+
+	resp, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "pwuser",
+		Email:    "pwuser@example.com",
+		Password: "originalpass",
+	})
+	require.NoError(t, err)
+
+	t.Run("wrong current password", func(t *testing.T) {
+		err := ds.UpdateUserPassword(context.Background(), resp.ID, models.UpdatePasswordRequest{
+			CurrentPassword: "notright",
+			NewPassword:     "newpass123",
+		})
+		require.ErrorIs(t, err, ErrCurrentPassword)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		err := ds.UpdateUserPassword(context.Background(), resp.ID, models.UpdatePasswordRequest{
+			CurrentPassword: "originalpass",
+			NewPassword:     "newpass123",
+		})
+		require.NoError(t, err)
+
+		// Old password should no longer work, new one should.
+		_, _, err = ds.GetUserByCredentials(context.Background(), models.UserLoginRequest{
+			Username: "pwuser",
+			Password: "originalpass",
+		})
+		require.ErrorIs(t, err, ErrInvalidCredentials)
+
+		_, _, err = ds.GetUserByCredentials(context.Background(), models.UserLoginRequest{
+			Username: "pwuser",
+			Password: "newpass123",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("user not found", func(t *testing.T) {
+		err := ds.UpdateUserPassword(context.Background(), uuid.New(), models.UpdatePasswordRequest{
+			CurrentPassword: "x",
+			NewPassword:     "y",
+		})
+		require.ErrorIs(t, err, ErrUserNotFound)
+	})
+
+	t.Run("external auth account", func(t *testing.T) {
+		u, err := ds.dbClient.User.Create().
+			SetUsername("externaluser").
+			SetEmail("external@example.com").
+			SetPasswordHash(auth.ExternalAuthPasswordPlaceholder).
+			Save(context.Background())
+		require.NoError(t, err)
+
+		err = ds.UpdateUserPassword(context.Background(), u.ID, models.UpdatePasswordRequest{
+			CurrentPassword: "irrelevant",
+			NewPassword:     "newpass123",
+		})
+		require.ErrorIs(t, err, ErrExternalPasswordUnsupported)
+	})
+}
+
+func TestDeleteUser(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+	createUserTestRole(t, ds, "user")
+	createUserTestDefaultModel(t, ds)
+
+	resp, _, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "deleteme",
+		Email:    "deleteme@example.com",
+		Password: "supersecret",
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := ds.DeleteUser(context.Background(), resp.ID)
+		require.NoError(t, err)
+
+		_, err = ds.GetUserByID(context.Background(), resp.ID)
+		require.ErrorIs(t, err, ErrUserNotFound)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := ds.DeleteUser(context.Background(), uuid.New())
+		require.ErrorIs(t, err, ErrUserNotFound)
+	})
+}
+
+func TestRefreshUserToken(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+	createUserTestRole(t, ds, "user")
+	createUserTestDefaultModel(t, ds)
+
+	_, tokens, err := ds.CreateUser(context.Background(), models.UserRegisterRequest{
+		Username: "refreshuser",
+		Email:    "refreshuser@example.com",
+		Password: "supersecret",
+	})
+	require.NoError(t, err)
+
+	t.Run("invalid token string", func(t *testing.T) {
+		_, err := ds.RefreshUserToken(context.Background(), "not-a-jwt")
+		require.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		newTokens, err := ds.RefreshUserToken(context.Background(), tokens.RefreshToken)
+		require.NoError(t, err)
+		require.NotEmpty(t, newTokens.AccessToken)
+		require.NotEmpty(t, newTokens.RefreshToken)
+	})
+
+	t.Run("reused (rotated) refresh token is rejected", func(t *testing.T) {
+		// The first refresh above already rotated the stored refresh_token_id,
+		// so re-using the original refresh token must now fail.
+		_, err := ds.RefreshUserToken(context.Background(), tokens.RefreshToken)
+		require.ErrorIs(t, err, ErrInvalidCredentials)
+	})
+}
+
+func TestGetOrCreateExternalUser(t *testing.T) {
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+
+	_, err := ds.GetOrCreateExternalUser(context.Background(), "sub-123", "extuser", "ext@example.com", "Ext", "User")
+	require.ErrorIs(t, err, ErrExternalAuthNotConfigured)
+}
+
+func TestToUserModel(t *testing.T) {
+	setUserTestJWTSecrets(t)
+	ds, cleanup := newUserTestDatastore(t)
+	defer cleanup()
+
+	adminRoleID := createUserTestRole(t, ds, "admin")
+	userRoleID := createUserTestRole(t, ds, "user")
+
+	t.Run("admin role takes priority over user role", func(t *testing.T) {
+		u, err := ds.dbClient.User.Create().
+			SetUsername("multirole").
+			SetEmail("multirole@example.com").
+			SetPasswordHash("hash").
+			AddRoleIDs(userRoleID, adminRoleID).
+			Save(context.Background())
+		require.NoError(t, err)
+
+		loaded, err := ds.dbClient.User.Query().Where(user.ID(u.ID)).WithRoles().Only(context.Background())
+		require.NoError(t, err)
+
+		resp := toUserModel(loaded)
+		require.Equal(t, "admin", resp.Role)
+	})
+
+	t.Run("no roles falls back to user", func(t *testing.T) {
+		u, err := ds.dbClient.User.Create().
+			SetUsername("norole2").
+			SetEmail("norole2@example.com").
+			SetPasswordHash("hash").
+			Save(context.Background())
+		require.NoError(t, err)
+
+		resp := toUserModel(u)
+		require.Equal(t, "user", resp.Role)
+		require.Equal(t, defaultTheme.String(), resp.Theme)
+	})
 }


### PR DESCRIPTION
## Summary

Follow-up tranche on the shared sqlite harness, stacked on #18:

- `internal/datastore/user.go`: all 11 previously zero-coverage
  functions now covered (create/get/update/delete, credential auth,
  password update, token refresh, external-auth get-or-create, and the
  default-role/default-model lookups). Extended the harness with a
  small `roles`/`user_roles` schema fragment.
- `internal/datastore/model.go`: all 10 previously zero-coverage
  functions now covered (model catalog listing/admin CRUD, default-model
  resolution and its fallback tiers, provider normalization).
- `internal/datastore/mood.go`: all 9 previously zero-coverage functions
  now covered (CRUD, thumbnail/image/ritual association, personality
  linking, ownership checks).

No behavioral bugs found in any of these three files.

`go-unit` coverage: 43.8% -> 45.7%.

## Test plan

- [x] `go test ./internal/datastore/... -race` green
- [x] `gofmt -l` / `go vet` clean
- [x] `make test-ci` + `make coverage-summary` confirm 45.7%