### PR TITLE
Checkpoint 5: cover internal/agent (message, memory, MCP, providers)

### DIFF
--- a/internal/agent/agent_hooks_test.go
+++ b/internal/agent/agent_hooks_test.go
@@ -1,0 +1,28 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+func TestAgentTestHooks_AnySet(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, agentTestHooks{}.anySet())
+
+	require.True(t, agentTestHooks{
+		GetMemoriesOverride: func(ctx context.Context, userID, chatID, personalityID uuid.UUID, userMessage string) ([]string, error) {
+			return nil, nil
+		},
+	}.anySet())
+
+	require.True(t, agentTestHooks{
+		ImageRitualPersistImage: func(ctx context.Context, userID uuid.UUID, attachment *models.FileAttachment, imageBase64 string) error {
+			return nil
+		},
+	}.anySet())
+}

--- a/internal/agent/agentjob_run_test.go
+++ b/internal/agent/agentjob_run_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/middleware"
+	"go.uber.org/zap"
+)
+
+// --- HandleAgentJobPromptAsync / HandleWelcomeMessagePromptAsync / handleEphemeralPromptAsync ---
+
+func TestHandleAgentJobPromptAsync_NoUserIDInContextReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	resp, err := a.HandleAgentJobPromptAsync(context.Background(), uuid.New(), "hi", nil, nil)
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "user ID not found in context")
+}
+
+func TestHandleWelcomeMessagePromptAsync_NoUserIDInContextReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	resp, err := a.HandleWelcomeMessagePromptAsync(context.Background(), uuid.New(), "hi", nil, nil)
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "user ID not found in context")
+}
+
+func TestHandleAgentJobPromptAsync_EmptyPromptReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	ctx := context.WithValue(context.Background(), middleware.UserIDKey, uuid.New())
+	resp, err := a.HandleAgentJobPromptAsync(ctx, uuid.New(), "", nil, nil)
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "prompt is required")
+}
+
+func TestHandleAgentJobPromptAsync_CreateJobErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO .*jobs.*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	ctx := context.WithValue(context.Background(), middleware.UserIDKey, uuid.New())
+	resp, err := a.HandleAgentJobPromptAsync(ctx, uuid.New(), "hi", nil, nil)
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "failed to create background job")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Note: the success path (CreateJob succeeding, background goroutine running) is not
+// covered here. datastore.CreateJob's post-insert re-query loads the owner edge via
+// WithOwner(), and toJobModel dereferences it unconditionally — reproducing that with
+// go-sqlmock means faking a join across jobs and users tables, which is exactly the kind
+// of fragile, schema-shaped mock the coverage-push guidance says to skip. The datastore
+// package's own job_test.go covers CreateJob's happy path against a real in-memory
+// schema; that's the right place for it, not here via a second mock stack.
+
+// --- HandleAgentJobPrompt / HandleEphemeralPromptSync / handleEphemeralPrompt ---
+
+func TestHandleEphemeralPromptSync_NoUserIDInContextReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	msg, err := a.HandleEphemeralPromptSync(context.Background(), uuid.New(), "hi", nil, nil)
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "user ID not found in context")
+}
+
+func TestHandleAgentJobPrompt_NoUserIDInContextReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	msg, err := a.HandleAgentJobPrompt(context.Background(), uuid.New(), "hi", nil, nil, nil, nil)
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "user ID not found in context")
+}
+
+func TestHandleEphemeralPromptSync_EmptyPromptReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	ctx := context.WithValue(context.Background(), middleware.UserIDKey, uuid.New())
+	msg, err := a.HandleEphemeralPromptSync(ctx, uuid.New(), "", nil, nil)
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "prompt is required")
+}
+
+func TestHandleEphemeralPromptSync_PrepareChatContextErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	// GetChat (inside prepareChatContext) fails, which handleEphemeralPrompt returns
+	// directly without further wrapping.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	ctx := context.WithValue(context.Background(), middleware.UserIDKey, uuid.New())
+	msg, err := a.HandleEphemeralPromptSync(ctx, uuid.New(), "hi", nil, nil)
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "failed to get chat")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/agentjob_schedule_test.go
+++ b/internal/agent/agentjob_schedule_test.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// ParseAgentJobSchedule is a thin wrapper over schedule.Parse. The cheapest
+// reachable branch is schedule.Parse's own empty-input guard, which fires
+// before any provider call, so a zero-value Agent (nil OpenAIProvider) is
+// sufficient here.
+func TestParseAgentJobSchedule_EmptyInputReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	_, err := a.ParseAgentJobSchedule(context.Background(), uuid.New(), "   ", "UTC", time.Now())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "schedule_input is required")
+}

--- a/internal/agent/chatname_test.go
+++ b/internal/agent/chatname_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// --- mockChatName ---
+
+func TestMockChatName(t *testing.T) {
+	t.Parallel()
+	longMsg := strings.Repeat("a", 50)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty string", "", "Mock Chat"},
+		{"whitespace only collapses to empty", "   \t\n  ", "Mock Chat"},
+		{"short message returned as-is", "hello   there  friend", "hello there friend"},
+		{"long message truncated with ellipsis", longMsg, longMsg[:40] + "…"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, mockChatName(tc.in))
+		})
+	}
+}
+
+// --- generateChatName ---
+
+func TestGenerateChatName_MockModeReturnsDeterministicName(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop(), mockLLM: true}
+	got, err := a.generateChatName(context.Background(), "hello world")
+	require.NoError(t, err)
+	require.Equal(t, "hello world", got)
+}
+
+func TestGenerateChatName_LocalModeReturnsDeterministicName(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop(), localLLM: true}
+	got, err := a.generateChatName(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, "Mock Chat", got)
+}
+
+func TestGenerateChatName_ProviderErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.generateChatName(context.Background(), "hi")
+	require.Error(t, err)
+}
+
+func TestGenerateChatName_SuccessReturnsOutputText(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", "My New Chat"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got, err := a.generateChatName(context.Background(), "hi")
+	require.NoError(t, err)
+	require.Equal(t, "My New Chat", got)
+}

--- a/internal/agent/compaction_event_log_coverage_test.go
+++ b/internal/agent/compaction_event_log_coverage_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// --- beginCompactionEvent ---
+
+func TestBeginCompactionEvent_NilChatCtxReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	got := a.beginCompactionEvent(context.Background(), uuid.New(), nil, nil, uuid.New(), "openai", "checkpoint", uuid.New(), "scratch", true)
+	require.Nil(t, got)
+}
+
+func TestBeginCompactionEvent_CreateErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin().WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{}}
+	got := a.beginCompactionEvent(context.Background(), uuid.New(), chatCtx, nil, uuid.New(), "openai", "checkpoint", uuid.Nil, "scratch", true)
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- finishCompactionEvent ---
+
+func TestFinishCompactionEvent_NilEventIDIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.finishCompactionEvent(context.Background(), uuid.New(), nil, "summary")
+	})
+}
+
+func TestFinishCompactionEvent_ErrorIsLoggedNotPanicked(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin().WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	eventID := uuid.New()
+	require.NotPanics(t, func() {
+		a.finishCompactionEvent(context.Background(), uuid.New(), &eventID, "summary")
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/conversation_summary_test.go
+++ b/internal/agent/conversation_summary_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -132,4 +133,15 @@ func TestBuildCheckpointSummaryParams_RequiresSource(t *testing.T) {
 
 	_, err := buildCheckpointSummaryParams(uuid.New(), "", checkpointSummarySource{})
 	require.Error(t, err)
+}
+
+// summarizeConversationForCheckpoint's cheapest branch is its own nil-provider
+// guard, which fires before chatCtx is dereferenced.
+func TestSummarizeConversationForCheckpoint_NilProviderReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	_, err := a.summarizeConversationForCheckpoint(context.Background(), uuid.New(), nil, checkpointSummarySource{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "OpenAIProvider is nil")
 }

--- a/internal/agent/expression_generation_test.go
+++ b/internal/agent/expression_generation_test.go
@@ -1,10 +1,15 @@
 package agent
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
 )
 
 func TestBuildExpressionPickCatalog_alwaysIncludesLabels(t *testing.T) {
@@ -41,3 +46,137 @@ func TestParseExpressionPickPayload_invalidJSON(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// --- expressionPickStructuredOutputFormat ---
+
+func TestExpressionPickStructuredOutputFormat(t *testing.T) {
+	t.Parallel()
+	out := expressionPickStructuredOutputFormat()
+	require.NotNil(t, out.Format.OfJSONSchema)
+	require.Equal(t, "ExpressionPortraitPick", out.Format.OfJSONSchema.Name)
+}
+
+// --- PickGenerationExpression ---
+
+func TestPickGenerationExpression_ListExpressionsErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	// ensureUserOwnsPersonality's exists-check fails, so ListPersonalityExpressions returns
+	// ErrPersonalityNotFound before ever reaching the personality_expression query.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	id, reasoning, err := a.PickGenerationExpression(context.Background(), uuid.New(), uuid.New(), nil, "hi", "hello there")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "list expressions")
+	require.Nil(t, id)
+	require.Empty(t, reasoning)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPickGenerationExpression_NoSlotsReturnsNilWithoutError(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	// SQLite's Exist() lowers to "SELECT id ... LIMIT 1" rather than a boolean EXISTS(...)
+	// projection, so a matching row (any id) signals the personality is owned.
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New().String()))
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "expression_key"}))
+	mock.ExpectCommit()
+
+	a := newTestAgent(ds)
+	id, reasoning, err := a.PickGenerationExpression(context.Background(), uuid.New(), uuid.New(), nil, "hi", "hello there")
+	require.NoError(t, err)
+	require.Nil(t, id)
+	require.Empty(t, reasoning)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func personalityExpressionRows(key string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "created_at", "updated_at", "expression_key", "label", "personality_expressions", "personality_expression_image"}).
+		AddRow(uuid.New().String(), time.Now(), time.Now(), key, nil, uuid.New().String(), nil)
+}
+
+// TestPickGenerationExpression_StandaloneSuccessMatchesKey exercises the nil-inferenceModelCtx
+// (standalone prompt) branch end to end: ListPersonalityExpressions succeeds with one slot, the
+// OpenAI call returns a structured pick matching that slot's key, and the returned id/reasoning
+// come from the matched slot.
+func TestPickGenerationExpression_StandaloneSuccessMatchesKey(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New().String()))
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(personalityExpressionRows("happy"))
+	mock.ExpectCommit()
+
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"expression_key\":\"happy\",\"reasoning\":\"Warm tone.\"}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), ds: ds, OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	id, reasoning, err := a.PickGenerationExpression(context.Background(), uuid.New(), uuid.New(), nil, "hi", "hello there")
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	require.Equal(t, "Warm tone.", reasoning)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPickGenerationExpression_UnknownKeyReturnsNil covers a classifier pick that doesn't match
+// any configured slot: no id, no error, just a debug log.
+func TestPickGenerationExpression_UnknownKeyReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New().String()))
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(personalityExpressionRows("happy"))
+	mock.ExpectCommit()
+
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"expression_key\":\"nonexistent\",\"reasoning\":\"n/a\"}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), ds: ds, OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	id, reasoning, err := a.PickGenerationExpression(context.Background(), uuid.New(), uuid.New(), nil, "hi", "hello there")
+	require.NoError(t, err)
+	require.Nil(t, id)
+	require.Empty(t, reasoning)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPickGenerationExpression_ProviderErrorReturnsNilWithoutError documents that a classifier
+// call failure is swallowed (logged) rather than propagated — callers get "no portrait" instead
+// of an error.
+func TestPickGenerationExpression_ProviderErrorReturnsNilWithoutError(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New().String()))
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(personalityExpressionRows("happy"))
+	mock.ExpectCommit()
+
+	a := &Agent{logger: zap.NewNop(), ds: ds, OpenAIProvider: newHTTPTestOpenAIProvider("http://127.0.0.1:0")}
+	id, reasoning, err := a.PickGenerationExpression(context.Background(), uuid.New(), uuid.New(), nil, "hi", "hello there")
+	require.NoError(t, err)
+	require.Nil(t, id)
+	require.Empty(t, reasoning)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/expression_grid_generation_test.go
+++ b/internal/agent/expression_grid_generation_test.go
@@ -2,12 +2,16 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"image"
 	"image/color"
 	"image/png"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
 )
 
 func TestSlicePNGGrid3x3_NineCells(t *testing.T) {
@@ -96,4 +100,62 @@ func TestCapExpressionReferenceImage(t *testing.T) {
 	got, mime = capExpressionReferenceImage(large, "image/jpeg")
 	require.Nil(t, got)
 	require.Equal(t, "", mime)
+}
+
+func TestGenerateDefaultExpressionGrid_NotConfigured(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	uid, pid := uuid.New(), uuid.New()
+
+	// Nil agent, nil ds, and nil OpenAIProvider all hit the same "not configured" guard.
+	_, err := (&Agent{}).GenerateDefaultExpressionGrid(ctx, uid, pid)
+	require.ErrorContains(t, err, "agent not configured")
+
+	_, err = (&Agent{ds: &datastore.Datastore{}}).GenerateDefaultExpressionGrid(ctx, uid, pid)
+	require.ErrorContains(t, err, "agent not configured")
+}
+
+func TestGenerateDefaultExpressionGrid_MockBackendDisabled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	uid, pid := uuid.New(), uuid.New()
+
+	a := &Agent{
+		ds:             &datastore.Datastore{},
+		OpenAIProvider: &provider.OpenAIProvider{},
+		mockLLM:        true,
+	}
+	_, err := a.GenerateDefaultExpressionGrid(ctx, uid, pid)
+	require.ErrorContains(t, err, "disabled under LLM_BACKEND=mock/local")
+}
+
+func TestGenerateDefaultExpressionGrid_FileStoreNotConfigured(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	uid, pid := uuid.New(), uuid.New()
+
+	a := &Agent{
+		ds:             &datastore.Datastore{},
+		OpenAIProvider: &provider.OpenAIProvider{},
+	}
+	_, err := a.GenerateDefaultExpressionGrid(ctx, uid, pid)
+	require.ErrorContains(t, err, "file store not configured")
+}
+
+func TestInferExpressionGridLikeness_EmptyInputs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	a := &Agent{}
+	out, err := a.inferExpressionGridLikeness(ctx, "", nil, "")
+	require.NoError(t, err)
+	require.Equal(t, "", out)
+}
+
+func TestUploadPersonalityExpressionCell_EmptyPNG(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	uid, pid := uuid.New(), uuid.New()
+	a := &Agent{}
+	err := a.uploadPersonalityExpressionCell(ctx, uid, pid, "happy", nil)
+	require.ErrorContains(t, err, "empty cell png")
 }

--- a/internal/agent/expression_grid_job_test.go
+++ b/internal/agent/expression_grid_job_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// EnqueueExpressionGridJob's cheapest branch is its own agent-not-configured
+// guard, which fires before any datastore or background work.
+func TestEnqueueExpressionGridJob_NilDatastoreReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	job, err := a.EnqueueExpressionGridJob(context.Background(), uuid.New(), uuid.New())
+	require.Nil(t, job)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "agent not configured")
+}

--- a/internal/agent/first_chat_onboarding_prompt_test.go
+++ b/internal/agent/first_chat_onboarding_prompt_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildFirstChatGreetingPrompt(t *testing.T) {
+	t.Parallel()
+	prompt := BuildFirstChatGreetingPrompt()
+	require.Contains(t, prompt, "very first assistant message")
+	require.Contains(t, prompt, "Tools currently available to this assistant:")
+	require.Contains(t, prompt, "web_search")
+}
+
+func TestBuildFirstChatToolLines(t *testing.T) {
+	t.Parallel()
+	lines := buildFirstChatToolLines()
+	require.NotEmpty(t, lines)
+	// The web search tool is always included as the first entry.
+	require.True(t, strings.HasPrefix(lines[0], "- `"))
+}
+
+func TestCompactToolDescription(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "No description available.", compactToolDescription(""))
+	require.Equal(t, "No description available.", compactToolDescription("   "))
+	require.Equal(t, "Do the thing.", compactToolDescription("Do   the\nthing.  Extra detail that should be dropped."))
+	require.Equal(t, "single line no period", compactToolDescription("single line no period"))
+}

--- a/internal/agent/generate_image_tool_test.go
+++ b/internal/agent/generate_image_tool_test.go
@@ -1,0 +1,251 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// newNoRetryTestOpenAIProvider builds a provider whose client never retries, so
+// per-request success/failure sequencing in tests is deterministic.
+func newNoRetryTestOpenAIProvider(baseURL string) *provider.OpenAIProvider {
+	client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(baseURL), option.WithMaxRetries(0))
+	return provider.NewOpenAIProvider(nil, &client, nil, nil)
+}
+
+// --- marshalGenerateImageToolResult ---
+
+func TestMarshalGenerateImageToolResult_RoundTrips(t *testing.T) {
+	t.Parallel()
+	out, err := marshalGenerateImageToolResult(generateImageToolResult{Success: true, Prompt: "a cat"})
+	require.NoError(t, err)
+	var got generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.True(t, got.Success)
+	require.Equal(t, "a cat", got.Prompt)
+}
+
+// --- clampGenerateImageCount ---
+
+func TestClampGenerateImageCount(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want int
+	}{
+		{-1, 1},
+		{0, 1},
+		{1, 1},
+		{4, 4},
+		{5, 4},
+		{100, 4},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, clampGenerateImageCount(tc.in))
+	}
+}
+
+// --- parseGenerateImageQuality ---
+
+func TestParseGenerateImageQuality(t *testing.T) {
+	t.Parallel()
+	low := "low"
+	medium := "MEDIUM"
+	high := " high "
+	empty := ""
+	bogus := "ultra"
+
+	cases := []struct {
+		name    string
+		in      *string
+		want    provider.ImageQuality
+		wantErr bool
+	}{
+		{"nil defaults to low", nil, provider.ImageQualityLow, false},
+		{"empty defaults to low", &empty, provider.ImageQualityLow, false},
+		{"low", &low, provider.ImageQualityLow, false},
+		{"medium case-insensitive", &medium, provider.ImageQualityMedium, false},
+		{"high trimmed", &high, provider.ImageQualityHigh, false},
+		{"invalid", &bogus, provider.ImageQualityLow, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseGenerateImageQuality(tc.in)
+			require.Equal(t, tc.want, got)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- generateImageTool ---
+
+func imagesGenerateJSONServer(handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
+}
+
+func imagesSuccessBody(b64 string) string {
+	return `{"created":1,"data":[{"b64_json":"` + b64 + `"}]}`
+}
+
+func TestGenerateImageTool_InvalidArgsJSONReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	out, atts, err := a.generateImageTool(context.Background(), &models.Chat{}, []byte("not json"))
+	require.NoError(t, err)
+	require.Nil(t, atts)
+	var result generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "invalid arguments")
+}
+
+func TestGenerateImageTool_EmptyPromptReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	args, err := json.Marshal(generateImageToolArgs{Prompt: "   "})
+	require.NoError(t, err)
+	out, atts, err := a.generateImageTool(context.Background(), &models.Chat{}, args)
+	require.NoError(t, err)
+	require.Nil(t, atts)
+	var result generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Equal(t, "prompt is required", result.Error)
+}
+
+func TestGenerateImageTool_InvalidQualityReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	badQuality := "ultra"
+	args, err := json.Marshal(generateImageToolArgs{Prompt: "a cat", Quality: &badQuality})
+	require.NoError(t, err)
+	out, atts, err := a.generateImageTool(context.Background(), &models.Chat{}, args)
+	require.NoError(t, err)
+	require.Nil(t, atts)
+	var result generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "invalid quality")
+}
+
+func TestGenerateImageTool_SuccessSingleImage(t *testing.T) {
+	t.Parallel()
+	srv := imagesGenerateJSONServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(imagesSuccessBody("aGVsbG8=")))
+	})
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	prefix := "my prefix/weird\\name"
+	args, err := json.Marshal(generateImageToolArgs{Prompt: "a cat", FilenamePrefix: &prefix})
+	require.NoError(t, err)
+
+	out, atts, err := a.generateImageTool(context.Background(), &models.Chat{UserID: uuid.New(), ID: uuid.New()}, args)
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+	require.Equal(t, "image/png", atts[0].FileType)
+	require.Contains(t, atts[0].Name, "my_prefix_weird_name")
+
+	var result generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.True(t, result.Success)
+	require.Equal(t, 1, result.Count)
+	require.Len(t, result.Images, 1)
+}
+
+func TestGenerateImageTool_AllRequestsFailReturnsToolError(t *testing.T) {
+	t.Parallel()
+	srv := imagesGenerateJSONServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newNoRetryTestOpenAIProvider(srv.URL)}
+	args, err := json.Marshal(generateImageToolArgs{Prompt: "a cat"})
+	require.NoError(t, err)
+
+	out, atts, err := a.generateImageTool(context.Background(), &models.Chat{UserID: uuid.New(), ID: uuid.New()}, args)
+	require.Error(t, err)
+	require.Empty(t, out)
+	require.Nil(t, atts)
+	require.Contains(t, err.Error(), "failed to generate image")
+}
+
+func TestGenerateImageTool_SafetyViolationPersistsEventAndReturnsAssistantMessage(t *testing.T) {
+	t.Parallel()
+	srv := imagesGenerateJSONServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":"moderation_blocked","message":"rejected by the safety system"}}`))
+	})
+	defer srv.Close()
+
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO .*safety_violation_events.*").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL), ds: ds}
+	args, err := json.Marshal(generateImageToolArgs{Prompt: "a cat"})
+	require.NoError(t, err)
+
+	chat := &models.Chat{UserID: uuid.New(), ID: uuid.New(), Name: "chat name"}
+	out, atts, err := a.generateImageTool(context.Background(), chat, args)
+	require.NoError(t, err)
+	require.Nil(t, atts)
+
+	var result generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Equal(t, safetyViolationAssistantMessage, result.Error)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGenerateImageTool_PartialFailureReportsCountsInResult(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	srv := imagesGenerateJSONServer(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(imagesSuccessBody("aGVsbG8=")))
+	})
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newNoRetryTestOpenAIProvider(srv.URL)}
+	count := 2
+	args, err := json.Marshal(generateImageToolArgs{Prompt: "a cat", Count: &count})
+	require.NoError(t, err)
+
+	out, atts, err := a.generateImageTool(context.Background(), &models.Chat{UserID: uuid.New(), ID: uuid.New()}, args)
+	require.NoError(t, err)
+	require.Len(t, atts, 1)
+
+	var result generateImageToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.True(t, result.Success)
+	require.Equal(t, 2, result.Count)
+	require.Contains(t, result.Error, "some requests failed")
+}

--- a/internal/agent/generate_personality_test.go
+++ b/internal/agent/generate_personality_test.go
@@ -1,0 +1,20 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// GeneratePersonality's cheapest branch is the deliberate mock/local-mode
+// denial, which fires before any OpenAI call is built.
+func TestGeneratePersonality_MockModeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{mockLLM: true}
+	result, err := a.GeneratePersonality(context.Background(), map[string]string{"q": "a"})
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "personality generation is disabled")
+}

--- a/internal/agent/image_ritual_test.go
+++ b/internal/agent/image_ritual_test.go
@@ -265,3 +265,15 @@ func TestHandleImageGenerateRitual_MockMode_PersistsFixturePNG(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, cfg.Width, 0)
 }
+
+// persistImageRitualAttachment's cheapest branch is its own
+// file-store-not-configured guard, which fires before any base64 decode or
+// datastore call.
+func TestPersistImageRitualAttachment_NilFileStoreReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	attachment := &models.FileAttachment{ID: uuid.New(), Name: "image.png", FileType: "image/png"}
+	err := a.persistImageRitualAttachment(context.Background(), uuid.New(), attachment, "irrelevant")
+	require.ErrorContains(t, err, "file store is not configured")
+}

--- a/internal/agent/job_phase_test.go
+++ b/internal/agent/job_phase_test.go
@@ -1,0 +1,202 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// --- advanceChatJobStatus ---
+
+func TestAdvanceChatJobStatus_NilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NoError(t, a.advanceChatJobStatus(context.Background(), nil, models.JobStatusExpressionComplete))
+}
+
+func TestAdvanceChatJobStatus_UpdateErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New(), Status: models.JobStatusProcessing}
+	err := a.advanceChatJobStatus(context.Background(), job, models.JobStatusExpressionComplete)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "update job status")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- persistInferencePhase ---
+
+func TestPersistInferencePhase_NilChatJobReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	err := a.persistInferencePhase(context.Background(), nil, &models.ChatMessage{}, nil, nil, nil, &models.ChatMessage{}, false)
+	require.ErrorContains(t, err, "chatJob is nil")
+}
+
+func TestPersistInferencePhase_NilChatMessageReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	err := a.persistInferencePhase(context.Background(), &models.Job{}, nil, nil, nil, nil, &models.ChatMessage{}, false)
+	require.ErrorContains(t, err, "chatMessage is nil")
+}
+
+func TestPersistInferencePhase_NilAgentMessageReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	err := a.persistInferencePhase(context.Background(), &models.Job{}, &models.ChatMessage{}, nil, nil, nil, nil, false)
+	require.ErrorContains(t, err, "agentMessage is nil")
+}
+
+func TestPersistInferencePhase_UpdateJobErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New(), Status: models.JobStatusProcessing}
+	err := a.persistInferencePhase(context.Background(), job, &models.ChatMessage{}, nil, nil, nil, &models.ChatMessage{ID: uuid.New()}, false)
+	require.ErrorContains(t, err, "failed to update job")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- persistUserTurnAndChatAfterInference ---
+
+func TestPersistUserTurnAndChatAfterInference_SkipsUserTurnUpdatesTriesChatUpdate(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	// persistUserTurnUpdate is false, so only the chat-continuity branch runs;
+	// UpdateChat's exists-check reports the chat missing, which the function
+	// only logs (best-effort), so no panic and no error surfaces.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	require.NotPanics(t, func() {
+		a.persistUserTurnAndChatAfterInference(context.Background(), uuid.New(), &models.ChatMessage{}, &models.Chat{ID: uuid.New()}, nil, &provider.GenerateResponse{ID: "r1", CreatedAt: 1}, false)
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPersistUserTurnAndChatAfterInference_NilResultSkipsBothUpdates(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.persistUserTurnAndChatAfterInference(context.Background(), uuid.New(), &models.ChatMessage{}, &models.Chat{}, nil, nil, true)
+	})
+}
+
+func TestPersistUserTurnAndChatAfterInference_NilChatMessageAndChatAreNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.persistUserTurnAndChatAfterInference(context.Background(), uuid.New(), nil, nil, nil, &provider.GenerateResponse{ID: "r1"}, true)
+	})
+}
+
+// --- applyExpressionPhase ---
+
+func TestApplyExpressionPhase_NilChatCtxNilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	err := a.applyExpressionPhase(context.Background(), uuid.New(), nil, nil, nil, "hi", &models.ChatMessage{})
+	require.NoError(t, err)
+}
+
+func TestApplyExpressionPhase_NilChatCtxAdvancesJob(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New(), Status: models.JobStatusProcessing}
+	err := a.applyExpressionPhase(context.Background(), uuid.New(), job, nil, nil, "hi", &models.ChatMessage{})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplyExpressionPhase_DisabledExpressionsNilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{chat: &models.Chat{}, expressionsEnabled: false}
+	err := a.applyExpressionPhase(context.Background(), uuid.New(), nil, chatCtx, nil, "hi", &models.ChatMessage{})
+	require.NoError(t, err)
+}
+
+func TestApplyExpressionPhase_NonVendorLLMNilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop(), mockLLM: true}
+	chatCtx := &chatContext{chat: &models.Chat{}, expressionsEnabled: true}
+	err := a.applyExpressionPhase(context.Background(), uuid.New(), nil, chatCtx, nil, "hi", &models.ChatMessage{})
+	require.NoError(t, err)
+}
+
+func TestApplyExpressionPhase_NilPersonalityIDSkipsPickerAndAdvances(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New(), Status: models.JobStatusProcessing}
+	chatCtx := &chatContext{chat: &models.Chat{PersonalityID: uuid.Nil}, expressionsEnabled: true}
+	err := a.applyExpressionPhase(context.Background(), uuid.New(), job, chatCtx, &provider.ModelContext{}, "hi", &models.ChatMessage{ID: uuid.New(), Message: "reply"})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- advanceJobInferenceComplete ---
+
+func TestAdvanceJobInferenceComplete_NilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NoError(t, a.advanceJobInferenceComplete(context.Background(), nil, uuid.New()))
+}
+
+func TestAdvanceJobInferenceComplete_UpdateErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New(), Status: models.JobStatusProcessing}
+	err := a.advanceJobInferenceComplete(context.Background(), job, uuid.New())
+	require.ErrorContains(t, err, "failed to update job")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/mcp_tools_coverage_test.go
+++ b/internal/agent/mcp_tools_coverage_test.go
@@ -1,0 +1,182 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	agenttools "github.com/theimaginaryfoundation/what-iff/internal/agent/tools"
+)
+
+// --- claudeFunctionTools / openAIChatCompletionFunctionTools / geminiFunctionTools ---
+
+func TestClaudeFunctionTools_BuildsOneToolPerSpec(t *testing.T) {
+	t.Parallel()
+	specs := []agenttools.FunctionToolSpec{
+		{Name: "web_search", Description: "search the web", Properties: map[string]any{"query": map[string]any{"type": "string"}}, Required: []string{"query"}},
+	}
+	out := claudeFunctionTools(specs)
+	require.Len(t, out, 1)
+}
+
+func TestClaudeFunctionTools_EmptyInputReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+	out := claudeFunctionTools(nil)
+	require.Empty(t, out)
+}
+
+func TestOpenAIChatCompletionFunctionTools_BuildsOneToolPerSpec(t *testing.T) {
+	t.Parallel()
+	specs := []agenttools.FunctionToolSpec{
+		{Name: "recall", Description: "recall a memory", Properties: map[string]any{"id": map[string]any{"type": "string"}}, Required: []string{"id"}},
+		{Name: "list", Description: "list things"},
+	}
+	out := openAIChatCompletionFunctionTools(specs)
+	require.Len(t, out, 2)
+}
+
+func TestGeminiFunctionTools_DelegatesToOpenAIChatCompletionFunctionTools(t *testing.T) {
+	t.Parallel()
+	specs := []agenttools.FunctionToolSpec{
+		{Name: "web_search", Description: "search the web"},
+	}
+	out := geminiFunctionTools(specs)
+	require.Len(t, out, 1)
+}
+
+// --- getSubagentMCPTools / getSubagentClaudeMCPConfig ---
+
+func TestGetSubagentMCPTools_NoRitualIDsReturnsNilWithoutDsCall(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.Nil(t, a.getSubagentMCPTools(context.Background(), uuid.New(), nil, "gpt-5.4"))
+}
+
+func TestGetSubagentMCPTools_ListRitualMCPServersErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	got := a.getSubagentMCPTools(context.Background(), uuid.New(), []uuid.UUID{uuid.New()}, "gpt-5.4")
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSubagentMCPTools_EmptyServerListReturnsEmptyTools(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	a := newTestAgent(ds)
+	got := a.getSubagentMCPTools(context.Background(), uuid.New(), []uuid.UUID{uuid.New()}, "gpt-5.4")
+	require.Empty(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSubagentClaudeMCPConfig_NoRitualIDsReturnsNilWithoutDsCall(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.Nil(t, a.getSubagentClaudeMCPConfig(context.Background(), uuid.New(), nil))
+}
+
+func TestGetSubagentClaudeMCPConfig_ListRitualMCPServersErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	got := a.getSubagentClaudeMCPConfig(context.Background(), uuid.New(), []uuid.UUID{uuid.New()})
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- getChatMCPServers ---
+
+func TestGetChatMCPServers_ChatServersLoadFailsReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	got := a.getChatMCPServers(context.Background(), uuid.New(), uuid.New(), nil)
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetChatMCPServers_NoRitualIDsReturnsChatServersOnly(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New())) // chat exists
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))                    // no mcp servers
+	mock.ExpectCommit()
+
+	a := newTestAgent(ds)
+	got := a.getChatMCPServers(context.Background(), uuid.New(), uuid.New(), nil)
+	require.Empty(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetChatMCPServers_RitualServersLoadFailureIsLoggedAndIgnored(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New())) // chat exists
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))                    // no chat mcp servers
+	mock.ExpectCommit()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel) // ritual servers query fails
+
+	a := newTestAgent(ds)
+	got := a.getChatMCPServers(context.Background(), uuid.New(), uuid.New(), []uuid.UUID{uuid.New()})
+	require.Empty(t, got, "ritual server load failure falls back to the (empty) chat server list")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- getChatMCPTools / getChatClaudeMCPConfig ---
+
+func TestGetChatMCPTools_ChatServersLoadFailureYieldsNoTools(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	got := a.getChatMCPTools(context.Background(), uuid.New(), uuid.New(), nil, "gpt-5.4")
+	require.Empty(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetChatClaudeMCPConfig_ChatServersLoadFailureYieldsNilConfig(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	got := a.getChatClaudeMCPConfig(context.Background(), uuid.New(), uuid.New(), nil)
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/memory_coverage_test.go
+++ b/internal/agent/memory_coverage_test.go
@@ -1,0 +1,218 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// --- memoryExtractionSchemaMapForClaude ---
+
+func TestMemoryExtractionSchemaMapForClaude_ReturnsNonEmptyMap(t *testing.T) {
+	t.Parallel()
+	out := memoryExtractionSchemaMapForClaude()
+	require.NotEmpty(t, out)
+	require.Contains(t, out, "properties")
+}
+
+// --- extractMemoriesWithScratchpadDelta ---
+
+func TestExtractMemoriesWithScratchpadDelta_NilResponseIDIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.extractMemoriesWithScratchpadDelta(context.Background(), uuid.New(), uuid.New(), nil, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}}, nil)
+	})
+}
+
+func TestExtractMemoriesWithScratchpadDelta_ProviderErrorLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	respID := "resp_123"
+	require.NotPanics(t, func() {
+		a.extractMemoriesWithScratchpadDelta(context.Background(), uuid.New(), uuid.New(), &respID, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}}, nil)
+	})
+}
+
+func TestExtractMemoriesWithScratchpadDelta_UnmarshalErrorLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", "not valid json"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	respID := "resp_123"
+	require.NotPanics(t, func() {
+		a.extractMemoriesWithScratchpadDelta(context.Background(), uuid.New(), uuid.New(), &respID, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}}, nil)
+	})
+}
+
+func TestExtractMemoriesWithScratchpadDelta_SuccessWithNoMemoriesIsNoOpDownstream(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"memories\":[]}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	respID := "resp_123"
+	require.NotPanics(t, func() {
+		a.extractMemoriesWithScratchpadDelta(context.Background(), uuid.New(), uuid.New(), &respID, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}, memories: []string{"m1"}}, nil)
+	})
+}
+
+// --- extractMemoriesWithScratchpadDeltaClaude ---
+
+func newHTTPTestClaudeProvider(baseURL string) *provider.ClaudeProvider {
+	return provider.NewClaudeProviderWithBaseURL("test-key", baseURL, nil, nil)
+}
+
+func claudeMessageTextJSONBody(id, text string) string {
+	return `{"id":"` + id + `","type":"message","role":"assistant","model":"test-model",` +
+		`"content":[{"type":"text","text":"` + text + `"}],"stop_reason":"end_turn","stop_sequence":null,` +
+		`"usage":{"input_tokens":5,"output_tokens":7}}`
+}
+
+func TestExtractMemoriesWithScratchpadDeltaClaude_NilProviderReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	err := a.extractMemoriesWithScratchpadDeltaClaude(context.Background(), uuid.New(), uuid.New(),
+		&provider.ModelContext{}, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}}, nil)
+	require.ErrorContains(t, err, "ClaudeProvider is nil")
+}
+
+func TestExtractMemoriesWithScratchpadDeltaClaude_ProviderErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), ClaudeProvider: newHTTPTestClaudeProvider(srv.URL)}
+	err := a.extractMemoriesWithScratchpadDeltaClaude(context.Background(), uuid.New(), uuid.New(),
+		&provider.ModelContext{}, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}}, nil)
+	require.ErrorContains(t, err, "Claude memory extraction failed")
+}
+
+func TestExtractMemoriesWithScratchpadDeltaClaude_SuccessWithNoMemoriesIsNoOpDownstream(t *testing.T) {
+	t.Parallel()
+	body := claudeMessageTextJSONBody("msg_1", `{\"memories\":[]}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), ClaudeProvider: newHTTPTestClaudeProvider(srv.URL)}
+	err := a.extractMemoriesWithScratchpadDeltaClaude(context.Background(), uuid.New(), uuid.New(),
+		&provider.ModelContext{}, &provider.ModelContext{}, &chatContext{chat: &models.Chat{}, memories: []string{"m1"}}, nil)
+	require.NoError(t, err)
+}
+
+// --- getMemoryQuery ---
+
+func TestGetMemoryQuery_ProviderErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.getMemoryQuery(context.Background(), uuid.New(), "instructions", "user message")
+	require.Error(t, err)
+}
+
+func TestGetMemoryQuery_UnmarshalErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", "not valid json"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.getMemoryQuery(context.Background(), uuid.New(), "instructions", "user message")
+	require.Error(t, err)
+}
+
+func TestGetMemoryQuery_SuccessParsesQuery(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"query\":\"likes Go\",\"should_enrich\":true}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got, err := a.getMemoryQuery(context.Background(), uuid.New(), "instructions", "user message")
+	require.NoError(t, err)
+	require.True(t, got.ShouldEnrich)
+	require.Equal(t, "likes Go", got.Query)
+}
+
+// --- getMemories ---
+
+func TestGetMemories_GetUserByIDErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	_, _, err := a.getMemories(context.Background(), uuid.New(), uuid.New(), uuid.New(), "hello")
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- compactMemoriesFromCheckpoint ---
+
+func TestCompactMemoriesFromCheckpoint_NoCandidatesIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.compactMemoriesFromCheckpoint(context.Background(), uuid.New(), uuid.New(), uuid.New(),
+			&provider.ModelContext{}, &chatContext{chat: &models.Chat{}}, nil, nil)
+	})
+}
+
+func TestCompactMemoriesFromCheckpoint_NilChatCtxIsHandled(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.compactMemoriesFromCheckpoint(context.Background(), uuid.New(), uuid.New(), uuid.New(),
+			&provider.ModelContext{}, nil, nil, nil)
+	})
+}
+
+// --- applyMemoryCompactionPlan ---
+
+func TestApplyMemoryCompactionPlan_EmptyPlanIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.applyMemoryCompactionPlan(context.Background(), uuid.New(), uuid.New(), uuid.New(), memoryCompactionPlan{}, nil)
+	})
+}
+
+func TestApplyMemoryCompactionPlan_LinkWithTooFewMembersIsSkipped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	// No mock expectations: a single existing ID and no new members is < 2 total, so the
+	// link is skipped before any datastore call is made.
+	a := newTestAgent(ds)
+	plan := memoryCompactionPlan{
+		Links: []memoryLinkPlan{
+			{ExistingIDs: []uuid.UUID{uuid.New()}},
+		},
+	}
+	require.NotPanics(t, func() {
+		a.applyMemoryCompactionPlan(context.Background(), uuid.New(), uuid.New(), uuid.New(), plan, nil)
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/memory_merge_infer_test.go
+++ b/internal/agent/memory_merge_infer_test.go
@@ -1,12 +1,16 @@
 package agent
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
 )
 
 // TestSalvageMemoryMergeGroups_Truncated pins the truncation safety net: a grouping response cut off
@@ -289,4 +293,173 @@ func TestPlanMemoryCompaction_LinkAllNewMembers(t *testing.T) {
 	require.Len(t, plan.Links, 1)
 	require.Empty(t, plan.Links[0].ExistingIDs)
 	require.Len(t, plan.Links[0].NewMembers, 2)
+}
+
+// --- formatMemoryMergeCandidateList ---
+
+func TestFormatMemoryMergeCandidateList(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	candidates := []memoryMergeCandidate{
+		{Content: "Prefers dark mode", Scope: "User", MemoryID: &id},
+		{Content: "Drinks tea", Scope: "Chat", IsNew: true},
+	}
+	out := formatMemoryMergeCandidateList(candidates)
+	require.Contains(t, out, "0. Prefers dark mode [memory_id="+id.String()+"] [scope=User]")
+	require.Contains(t, out, "1. Drinks tea [new] [scope=Chat]")
+}
+
+func TestFormatMemoryMergeCandidateList_Empty(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", formatMemoryMergeCandidateList(nil))
+}
+
+// --- fallbackExactMergeGroups ---
+
+func TestFallbackExactMergeGroups_Empty(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, fallbackExactMergeGroups(nil))
+}
+
+func TestFallbackExactMergeGroups_GroupsExactDuplicates(t *testing.T) {
+	t.Parallel()
+	candidates := []memoryMergeCandidate{
+		{Content: "Likes tea", Scope: "User", Confidence: models.MemoryConfidenceMedium},
+		{Content: "likes tea", Scope: "User", Confidence: models.MemoryConfidenceLow},
+		{Content: "Different fact", Scope: "User", Confidence: models.MemoryConfidenceHigh},
+	}
+	groups := fallbackExactMergeGroups(candidates)
+	require.Len(t, groups, 2, "case-insensitive duplicate content collapses to one group")
+	for _, g := range groups {
+		if len(g.MemberIndices) == 2 {
+			require.Equal(t, models.MemoryConfidenceLow, g.Confidence, "lowest-ranked confidence wins")
+		}
+	}
+}
+
+// --- inferMemoryMergeGroupsOpenAI ---
+
+func TestInferMemoryMergeGroupsOpenAI_NilProviderReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	_, err := a.inferMemoryMergeGroupsOpenAI(context.Background(), uuid.New(), "", nil)
+	require.ErrorContains(t, err, "OpenAIProvider is nil")
+}
+
+func TestInferMemoryMergeGroupsOpenAI_ProviderErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	candidates := []memoryMergeCandidate{{Content: "Likes tea", Scope: "User"}}
+	_, err := a.inferMemoryMergeGroupsOpenAI(context.Background(), uuid.New(), "persona", candidates)
+	require.Error(t, err)
+}
+
+func TestInferMemoryMergeGroupsOpenAI_TruncatedJSONIsSalvaged(t *testing.T) {
+	t.Parallel()
+	raw := `{\"groups\":[{\"member_indices\":[0],\"relation\":\"merge\",\"canonical_content\":\"\",\"scope\":\"User\",\"confidence\":\"medium\"},{\"member_indices\":[1],\"relation\":\"merge\",\"canonical_content\":\"never fini`
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", raw))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	candidates := []memoryMergeCandidate{
+		{Content: "Likes tea", Scope: "User"},
+		{Content: "Likes coffee", Scope: "User"},
+	}
+	groups, err := a.inferMemoryMergeGroupsOpenAI(context.Background(), uuid.New(), "", candidates)
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "only the complete group survives salvage")
+}
+
+func TestInferMemoryMergeGroupsOpenAI_UnparsableNonJSONReturnsError(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", "not valid json at all"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.inferMemoryMergeGroupsOpenAI(context.Background(), uuid.New(), "persona", nil)
+	require.ErrorContains(t, err, "parse memory merge grouping")
+}
+
+func TestInferMemoryMergeGroupsOpenAI_SuccessParsesGroups(t *testing.T) {
+	t.Parallel()
+	raw := `{\"groups\":[{\"member_indices\":[0,1],\"relation\":\"merge\",\"canonical_content\":\"Likes tea\",\"scope\":\"User\",\"confidence\":\"medium\"}]}`
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", raw))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	candidates := []memoryMergeCandidate{
+		{Content: "Likes tea", Scope: "User"},
+		{Content: "Likes tea a lot", Scope: "User"},
+	}
+	groups, err := a.inferMemoryMergeGroupsOpenAI(context.Background(), uuid.New(), "", candidates)
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	require.Equal(t, []int{0, 1}, groups[0].MemberIndices)
+}
+
+// --- inferMemoryMergeGroups ---
+
+func TestInferMemoryMergeGroups_ZeroOrOneCandidateUsesFallback(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.Nil(t, a.inferMemoryMergeGroups(context.Background(), uuid.New(), "", nil))
+
+	candidates := []memoryMergeCandidate{{Content: "Solo fact", Scope: "User"}}
+	groups := a.inferMemoryMergeGroups(context.Background(), uuid.New(), "", candidates)
+	require.Len(t, groups, 1)
+	require.Equal(t, "Solo fact", groups[0].CanonicalContent)
+}
+
+func TestInferMemoryMergeGroups_ProviderErrorFallsBackToExact(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	candidates := []memoryMergeCandidate{
+		{Content: "Likes tea", Scope: "User"},
+		{Content: "likes tea", Scope: "User"},
+	}
+	groups := a.inferMemoryMergeGroups(context.Background(), uuid.New(), "", candidates)
+	require.Len(t, groups, 1, "exact-content fallback collapses the duplicate pair")
+}
+
+func TestInferMemoryMergeGroups_EmptyGroupsFallsBackToExact(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"groups\":[]}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	candidates := []memoryMergeCandidate{
+		{Content: "Likes tea", Scope: "User"},
+		{Content: "Likes coffee", Scope: "User"},
+	}
+	groups := a.inferMemoryMergeGroups(context.Background(), uuid.New(), "", candidates)
+	require.Len(t, groups, 2, "distinct facts fall back to two singleton exact-merge groups")
+}
+
+func TestInferMemoryMergeGroups_SuccessFiltersAndBackfillsAndCovers(t *testing.T) {
+	t.Parallel()
+	// Group covers only index 0 with an empty canonical_content singleton; index 1 (a distinct
+	// candidate) is left uncovered by the model and must be picked up by the completeness net.
+	raw := `{\"groups\":[{\"member_indices\":[0],\"relation\":\"merge\",\"canonical_content\":\"\",\"scope\":\"User\",\"confidence\":\"medium\"}]}`
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", raw))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	candidates := []memoryMergeCandidate{
+		{Content: "Likes tea", Scope: "User"},
+		{Content: "Likes coffee", Scope: "User"},
+	}
+	groups := a.inferMemoryMergeGroups(context.Background(), uuid.New(), "", candidates)
+	require.Len(t, groups, 2)
+	require.Equal(t, "Likes tea", groups[0].CanonicalContent, "empty singleton canonical is backfilled from its member")
+	require.Equal(t, "Likes coffee", groups[1].CanonicalContent, "the model-omitted candidate is covered by the completeness net")
 }

--- a/internal/agent/message_context_builder_test.go
+++ b/internal/agent/message_context_builder_test.go
@@ -260,3 +260,20 @@ func TestMessageContextBuilder_LoadHistoryOverride_UsedAndNotReversed(t *testing
 	require.Equal(t, "first", msgs[0].Message)
 	require.Equal(t, "second", msgs[1].Message)
 }
+
+// fetchRecentMessages is best-effort: a datastore error must not propagate,
+// it must surface as an empty slice so callers can keep composing context.
+func TestFetchRecentMessages_DatastoreErrorReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	b := &messageContextBuilder{ds: ds, telemetry: &telemetry.Telemetry{Logger: zap.NewNop()}}
+
+	// No sqlmock expectations are configured, so the underlying query fails
+	// immediately, exercising the error/best-effort-empty-slice branch.
+	msgs := b.fetchRecentMessages(context.Background(), uuid.New(), uuid.New(), nil, 10, models.ChatMessageFilters{}, "test")
+	require.NotNil(t, msgs)
+	require.Empty(t, msgs)
+}

--- a/internal/agent/message_coverage_test.go
+++ b/internal/agent/message_coverage_test.go
@@ -1,0 +1,634 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
+	"github.com/theimaginaryfoundation/what-iff/internal/metering"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"github.com/theimaginaryfoundation/what-iff/internal/telemetry"
+	"go.uber.org/zap"
+)
+
+var errCoverageTestSentinel = errors.New("boom")
+
+// --- withCallPath ---
+
+func TestWithCallPath_AttachesCallPath(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	ctx := a.withCallPath(context.Background(), telemetry.CallPathUserChat)
+	require.Equal(t, telemetry.CallPathUserChat, telemetry.CallPathFromContext(ctx))
+}
+
+// --- registerRunningJobCancel / unregisterRunningJobCancel / CancelJob ---
+
+func newCancelTestAgent() *Agent {
+	return &Agent{
+		logger:            zap.NewNop(),
+		runningJobCancels: make(map[uuid.UUID]runningJobCancel),
+	}
+}
+
+func TestRegisterRunningJobCancel_IgnoresZeroValues(t *testing.T) {
+	t.Parallel()
+	a := newCancelTestAgent()
+
+	a.registerRunningJobCancel(uuid.Nil, uuid.New(), func() {})
+	require.Empty(t, a.runningJobCancels)
+
+	a.registerRunningJobCancel(uuid.New(), uuid.Nil, func() {})
+	require.Empty(t, a.runningJobCancels)
+
+	a.registerRunningJobCancel(uuid.New(), uuid.New(), nil)
+	require.Empty(t, a.runningJobCancels)
+}
+
+func TestRegisterUnregisterRunningJobCancel_RoundTrip(t *testing.T) {
+	t.Parallel()
+	a := newCancelTestAgent()
+	jobID, userID := uuid.New(), uuid.New()
+
+	a.registerRunningJobCancel(jobID, userID, func() {})
+	require.Len(t, a.runningJobCancels, 1)
+
+	a.unregisterRunningJobCancel(uuid.Nil)
+	require.Len(t, a.runningJobCancels, 1, "nil job id must be a no-op")
+
+	a.unregisterRunningJobCancel(jobID)
+	require.Empty(t, a.runningJobCancels)
+}
+
+func TestCancelJob_NilIDsReturnUnauthorized(t *testing.T) {
+	t.Parallel()
+	a := newCancelTestAgent()
+
+	err := a.CancelJob(context.Background(), uuid.Nil, uuid.New())
+	require.ErrorIs(t, err, datastore.ErrUnauthorized)
+
+	err = a.CancelJob(context.Background(), uuid.New(), uuid.Nil)
+	require.ErrorIs(t, err, datastore.ErrUnauthorized)
+}
+
+func TestCancelJob_UnknownJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := newCancelTestAgent()
+
+	err := a.CancelJob(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, err)
+}
+
+func TestCancelJob_WrongOwnerReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+	a := newCancelTestAgent()
+	jobID, ownerID := uuid.New(), uuid.New()
+	a.registerRunningJobCancel(jobID, ownerID, func() {})
+
+	err := a.CancelJob(context.Background(), uuid.New(), jobID)
+	require.ErrorIs(t, err, datastore.ErrUnauthorized)
+}
+
+func TestCancelJob_OwnerCancelsAndRemainsRegistered(t *testing.T) {
+	t.Parallel()
+	a := newCancelTestAgent()
+	jobID, ownerID := uuid.New(), uuid.New()
+	called := false
+	a.registerRunningJobCancel(jobID, ownerID, func() { called = true })
+
+	err := a.CancelJob(context.Background(), ownerID, jobID)
+	require.NoError(t, err)
+	require.True(t, called, "cancel func must be invoked")
+}
+
+// --- ChunkPipeline / FileStore trivial accessors ---
+
+func TestChunkPipelineAndFileStore_ReturnConfiguredFields(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.Nil(t, a.ChunkPipeline())
+	require.Nil(t, a.FileStore())
+}
+
+// --- RecordFileUpload / recordCounter / recordTime / recordCountHistogram no-telemetry guards ---
+
+func TestRecordFileUpload_NoopWithNilTelemetry(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.RecordFileUpload(context.Background(), "image/png", "success")
+	})
+}
+
+func TestRecordTime_NoopWithNilTelemetry(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.NotPanics(t, func() {
+		a.recordTime(context.Background(), "some_metric", 0)
+	})
+}
+
+func TestRecordCounter_NoopWithNilTelemetry(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.NotPanics(t, func() {
+		a.recordCounter(context.Background(), "some_counter", 1)
+	})
+}
+
+func TestRecordCountHistogram_NoopWithNilTelemetry(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.NotPanics(t, func() {
+		a.recordCountHistogram(context.Background(), "some_histogram", 1)
+	})
+}
+
+func TestRecordTime_NoopWithNilMetrics(t *testing.T) {
+	t.Parallel()
+	a := &Agent{telemetry: &telemetry.Telemetry{}}
+	require.NotPanics(t, func() {
+		a.recordTime(context.Background(), "some_metric", 0)
+		a.recordCounter(context.Background(), "some_counter", 1)
+		a.recordCountHistogram(context.Background(), "some_histogram", 1)
+	})
+}
+
+// --- mergedRitualIDsForTools / mergeRitualSets ---
+
+func TestMergedRitualIDsForTools_NilChatMessageUsesMoodOnly(t *testing.T) {
+	t.Parallel()
+	moodRitual := uuid.New()
+	mood := &models.Mood{RitualIDs: []uuid.UUID{moodRitual}}
+
+	got := mergedRitualIDsForTools(nil, mood)
+	require.Equal(t, []uuid.UUID{moodRitual}, got)
+}
+
+func TestMergedRitualIDsForTools_CombinesMessageAndMoodRituals(t *testing.T) {
+	t.Parallel()
+	msgRitualID := uuid.New()
+	moodRitualID := uuid.New()
+	chatMessage := &models.ChatMessage{
+		Rituals: []*models.Ritual{{ID: msgRitualID}},
+	}
+	mood := &models.Mood{RitualIDs: []uuid.UUID{moodRitualID}}
+
+	got := mergedRitualIDsForTools(chatMessage, mood)
+	require.ElementsMatch(t, []uuid.UUID{msgRitualID, moodRitualID}, got)
+}
+
+func TestMergeRitualSets_NoExtraReturnsBase(t *testing.T) {
+	t.Parallel()
+	base := []*models.Ritual{{ID: uuid.New()}}
+	got := mergeRitualSets(base, nil)
+	require.Equal(t, base, got)
+}
+
+func TestMergeRitualSets_DedupesAndSkipsNils(t *testing.T) {
+	t.Parallel()
+	shared := uuid.New()
+	onlyExtra := uuid.New()
+	base := []*models.Ritual{{ID: shared}, nil}
+	extra := []*models.Ritual{{ID: shared}, {ID: onlyExtra}, nil}
+
+	got := mergeRitualSets(base, extra)
+	require.Len(t, got, 2)
+	ids := []uuid.UUID{got[0].ID, got[1].ID}
+	require.ElementsMatch(t, []uuid.UUID{shared, onlyExtra}, ids)
+}
+
+// --- hasImageAttachmentsWithoutFileID ---
+
+func TestHasImageAttachmentsWithoutFileID(t *testing.T) {
+	t.Parallel()
+
+	fid := "file-1"
+	blank := ""
+	cases := []struct {
+		name string
+		atts []*models.FileAttachment
+		want bool
+	}{
+		{"empty", nil, false},
+		{"nil entry skipped", []*models.FileAttachment{nil}, false},
+		{"non-image ignored", []*models.FileAttachment{{FileType: "application/pdf"}}, false},
+		{"image with file id", []*models.FileAttachment{{FileType: "image/png", FileID: &fid}}, false},
+		{"image without file id", []*models.FileAttachment{{FileType: "image/png"}}, true},
+		{"image with blank file id", []*models.FileAttachment{{FileType: "image/png", FileID: &blank}}, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, hasImageAttachmentsWithoutFileID(tc.atts))
+		})
+	}
+}
+
+// --- isFirstCheckpoint / maxTurnsBeforeCheckpoint ---
+
+func TestIsFirstCheckpoint(t *testing.T) {
+	t.Parallel()
+	require.True(t, isFirstCheckpoint(&chatContext{chat: &models.Chat{CheckpointSummary: ""}}))
+	require.False(t, isFirstCheckpoint(&chatContext{chat: &models.Chat{CheckpointSummary: "summary so far"}}))
+}
+
+func TestMaxTurnsBeforeCheckpoint(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, checkpointMaxAssistantMessagesSinceStart,
+		maxTurnsBeforeCheckpoint(&chatContext{chat: &models.Chat{}}))
+	require.Equal(t, checkpointMaxAssistantMessagesSinceSummary,
+		maxTurnsBeforeCheckpoint(&chatContext{chat: &models.Chat{CheckpointSummary: "x"}}))
+}
+
+// --- newJobDraftDeltaBuffer / HandleDelta / Flush / persist ---
+
+func TestNewJobDraftDeltaBuffer_NilInputsReturnEmptyBuffer(t *testing.T) {
+	t.Parallel()
+
+	b := newJobDraftDeltaBuffer(nil, nil, zap.NewNop(), nil, 96, time.Second)
+	require.Nil(t, b.ds)
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b2 := newJobDraftDeltaBuffer(nil, nil, zap.NewNop(), job, 96, time.Second)
+	require.Nil(t, b2.ds, "nil datastore keeps buffer inert even with a valid job")
+}
+
+func TestNewJobDraftDeltaBuffer_DefaultsInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(nil, ds, zap.NewNop(), job, 0, 0)
+	require.NotNil(t, b.ds)
+	require.Equal(t, 1, b.minChunkChars)
+	require.Equal(t, 250*time.Millisecond, b.maxWait)
+	require.NotNil(t, b.persistParent, "nil persistParent should default to Background")
+}
+
+func TestJobDraftDeltaBuffer_HandleDelta_NilOrEmptyDeltaIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var nilBuf *jobDraftDeltaBuffer
+	require.NotPanics(t, func() { nilBuf.HandleDelta("hi") })
+	require.NotPanics(t, func() { nilBuf.Flush() })
+
+	emptyDSBuf := &jobDraftDeltaBuffer{}
+	require.NotPanics(t, func() { emptyDSBuf.HandleDelta("hi") })
+	require.NotPanics(t, func() { emptyDSBuf.Flush() })
+
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(context.Background(), ds, zap.NewNop(), job, 96, time.Hour)
+	b.HandleDelta("")
+	require.Empty(t, b.allText)
+}
+
+func TestJobDraftDeltaBuffer_HandleDelta_FlushesOnMinChars(t *testing.T) {
+	t.Parallel()
+
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE .*jobs.*draft_deltas.*").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(context.Background(), ds, zap.NewNop(), job, 3, time.Hour)
+
+	b.HandleDelta("hi") // below threshold, no flush yet
+	require.Equal(t, "hi", b.pending)
+
+	b.HandleDelta("!") // now >= 3 chars, triggers flush
+	require.Empty(t, b.pending)
+	require.Equal(t, "hi!", b.allText)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestJobDraftDeltaBuffer_HandleDelta_FlushesOnMaxWait(t *testing.T) {
+	t.Parallel()
+
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE .*jobs.*draft_deltas.*").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(context.Background(), ds, zap.NewNop(), job, 999, time.Millisecond)
+	b.lastFlush = time.Now().Add(-time.Hour) // force maxWait to have elapsed
+
+	b.HandleDelta("x")
+	require.Empty(t, b.pending, "elapsed maxWait should force a flush even under minChunkChars")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestJobDraftDeltaBuffer_Flush_NoOpWhenPendingEmpty(t *testing.T) {
+	t.Parallel()
+
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(context.Background(), ds, zap.NewNop(), job, 96, time.Hour)
+	b.Flush()
+	require.NoError(t, mock.ExpectationsWereMet(), "no exec expected when nothing pending")
+}
+
+func TestJobDraftDeltaBuffer_Flush_PersistsPending(t *testing.T) {
+	t.Parallel()
+
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE .*jobs.*draft_deltas.*").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(context.Background(), ds, zap.NewNop(), job, 999, time.Hour)
+	b.HandleDelta("partial") // stays pending (below min chars, maxWait not elapsed)
+	require.Equal(t, "partial", b.pending)
+
+	b.Flush()
+	require.Empty(t, b.pending)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestJobDraftDeltaBuffer_Persist_LogsErrorButDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE .*jobs.*draft_deltas.*").
+		WillReturnError(errCoverageTestSentinel)
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+	b := newJobDraftDeltaBuffer(context.Background(), ds, zap.NewNop(), job, 96, time.Hour)
+	require.NotPanics(t, func() { b.persist("chunk") })
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- assertUserCanRunChatModel ---
+
+func TestAssertUserCanRunChatModel_NilDsOrChatOrNonExperimentalIsAllowed(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	// ds == nil short-circuits.
+	require.NoError(t, a.assertUserCanRunChatModel(context.Background(), uuid.New(), &models.Chat{ModelID: uuid.New()}, "openai"))
+
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+	a2 := newTestAgent(ds)
+
+	// parentChat == nil short-circuits.
+	require.NoError(t, a2.assertUserCanRunChatModel(context.Background(), uuid.New(), nil, "openai"))
+
+	// Every currently-known provider is non-experimental (see
+	// models.IsExperimentalModelRecord), so this always returns nil today even
+	// with a non-nil chat carrying a ModelID. This documents that the
+	// experimental-gating branch below the early return is currently dead code.
+	require.NoError(t, a2.assertUserCanRunChatModel(context.Background(), uuid.New(), &models.Chat{ModelID: uuid.New()}, "openai"))
+}
+
+func TestAssertUserCanRunChatModel_ZeroModelIDIsAllowed(t *testing.T) {
+	t.Parallel()
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+	a := newTestAgent(ds)
+
+	require.NoError(t, a.assertUserCanRunChatModel(context.Background(), uuid.New(), &models.Chat{}, "openai"))
+}
+
+// --- resolvePersonalityName ---
+
+func TestResolvePersonalityName_NilPersonalityIDReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.Equal(t, "", a.resolvePersonalityName(context.Background(), uuid.New(), uuid.Nil))
+}
+
+func TestResolvePersonalityName_LookupErrorReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	got := a.resolvePersonalityName(context.Background(), uuid.New(), uuid.New())
+	require.Equal(t, "", got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- updateJobStatus ---
+
+func TestUpdateJobStatus_ReturnsWrappedErrorOnFailure(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	userID, jobID := uuid.New(), uuid.New()
+	job := &models.Job{ID: jobID, UserID: userID, JobType: JobTypeChatMessage, Status: models.JobStatusPending}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	err := a.updateJobStatus(context.Background(), job, models.JobStatusProcessing)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to update job status")
+}
+
+// --- setJobStatusFailed ---
+
+func TestSetJobStatusFailed_NilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.setJobStatusFailed(context.Background(), nil, errCoverageTestSentinel)
+	})
+}
+
+func TestSetJobStatusFailed_LogsAndReturnsWhenUpdateJobFails(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	userID, jobID := uuid.New(), uuid.New()
+	job := &models.Job{ID: jobID, UserID: userID, JobType: JobTypeChatMessage, Status: models.JobStatusProcessing}
+
+	// UpdateJob's authorization Exist() check reports the job missing, so
+	// UpdateJob fails fast and setJobStatusFailed must return without touching
+	// draft deltas or the user message (no further mock expectations set).
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	a.setJobStatusFailed(context.Background(), job, errCoverageTestSentinel)
+	// job left unmodified since UpdateJob never succeeded.
+	require.Equal(t, models.JobStatusProcessing, job.Status)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- setJobStatusFailedWithPartial ---
+
+func TestSetJobStatusFailedWithPartial_NilJobOrCauseIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	require.NotPanics(t, func() {
+		a.setJobStatusFailedWithPartial(context.Background(), nil, &models.ChatMessage{}, &chatContext{}, errCoverageTestSentinel)
+		a.setJobStatusFailedWithPartial(context.Background(), &models.Job{}, &models.ChatMessage{}, &chatContext{}, nil)
+	})
+}
+
+func TestSetJobStatusFailedWithPartial_NilUserMessageFallsBackToSetJobStatusFailed(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New(), JobType: JobTypeChatMessage, Status: models.JobStatusProcessing}
+
+	// setJobStatusFailedWithPartial falls back to setJobStatusFailed when
+	// userMessage is nil, whose UpdateJob call fails its Exist() authorization
+	// check here, so no further mock expectations are required.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	require.NotPanics(t, func() {
+		a.setJobStatusFailedWithPartial(context.Background(), job, nil, &chatContext{}, errCoverageTestSentinel)
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- recordToolCalls / recordModelContextSegmentEstimates / recordToolDefinitionEstimate ---
+
+func TestRecordToolCalls_NoopWithNilTelemetry(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.NotPanics(t, func() {
+		a.recordToolCalls(context.Background(), []*models.ToolCall{
+			{ToolName: "web_search"},
+			{ToolName: "recall", ToolError: "boom"},
+		})
+	})
+}
+
+func TestRecordModelContextSegmentEstimates_NilGuards(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.NotPanics(t, func() {
+		a.recordModelContextSegmentEstimates(context.Background(), nil)
+	})
+
+	a2 := &Agent{telemetry: &telemetry.Telemetry{}}
+	require.NotPanics(t, func() {
+		a2.recordModelContextSegmentEstimates(context.Background(), &provider.ModelContext{})
+	})
+}
+
+func TestRecordToolDefinitionEstimate_NilGuards(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	require.NotPanics(t, func() {
+		a.recordToolDefinitionEstimate(nil, "anything")
+		a.recordToolDefinitionEstimate(&provider.ModelContext{}, nil)
+	})
+}
+
+// --- persistContextBreakdown ---
+
+func TestPersistContextBreakdown_NilAgentMessageIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.persistContextBreakdown(context.Background(), uuid.New(), nil, &chatContext{}, &provider.ModelContext{}, nil)
+	})
+}
+
+// --- runCheckpointClaude nil guards ---
+
+func TestRunCheckpointClaude_NilAgentMessageOrModelContextIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+
+	require.NotPanics(t, func() {
+		a.runCheckpointClaude(context.Background(), uuid.New(), chatMessage, nil, &chatContext{chat: &models.Chat{}}, 1, &provider.ModelContext{}, "reason")
+		a.runCheckpointClaude(context.Background(), uuid.New(), chatMessage, &models.ChatMessage{}, &chatContext{chat: &models.Chat{}}, 1, nil, "reason")
+	})
+}
+
+// --- loadMoodRituals ---
+
+func TestLoadMoodRituals_NilOrEmptyMoodReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	require.Nil(t, a.loadMoodRituals(context.Background(), uuid.New(), nil))
+	require.Nil(t, a.loadMoodRituals(context.Background(), uuid.New(), &models.Mood{}))
+}
+
+// --- StartSummaryMemoryBackfill ---
+
+func TestStartSummaryMemoryBackfill_RunsInBackgroundWithoutPanicking(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	require.NotPanics(t, func() {
+		a.StartSummaryMemoryBackfill(context.Background())
+	})
+	// memoryTool is nil, so the background goroutine's BackfillSummaryMemories
+	// call returns immediately (Skipped++); give it a moment to finish logging
+	// before the test process exits, since it races with nothing else here.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// --- setJobStatusCancelledWithPartial ---
+
+func TestSetJobStatusCancelledWithPartial_NilJobOrUserMessageReturnsNilNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	id, err := a.setJobStatusCancelledWithPartial(context.Background(), nil, &models.ChatMessage{}, nil)
+	require.NoError(t, err)
+	require.Nil(t, id)
+
+	id, err = a.setJobStatusCancelledWithPartial(context.Background(), &models.Job{}, nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, id)
+}
+
+// --- recordCancelledChatUsage ---
+
+func TestRecordCancelledChatUsage_NilArgsAreNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	require.NotPanics(t, func() {
+		a.recordCancelledChatUsage(context.Background(), nil, &models.ChatMessage{}, &chatContext{}, nil, metering.Decision{}, errCoverageTestSentinel, nil)
+		a.recordCancelledChatUsage(context.Background(), &models.Job{}, nil, &chatContext{}, nil, metering.Decision{}, errCoverageTestSentinel, nil)
+		a.recordCancelledChatUsage(context.Background(), &models.Job{}, &models.ChatMessage{}, nil, nil, metering.Decision{}, errCoverageTestSentinel, nil)
+	})
+}

--- a/internal/agent/message_generation_coverage_test.go
+++ b/internal/agent/message_generation_coverage_test.go
@@ -1,0 +1,338 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// errServer returns an httptest server that answers every request with a 400,
+// so any adapter routed through it fails fast on the wire (no successful
+// generation, so no downstream ds.CreateChatMessage call is ever reached).
+func errServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+}
+
+func baseChatCtxForGeneration(model, modelProvider string) *chatContext {
+	return &chatContext{
+		chat:          &models.Chat{ToolsEnabled: false},
+		model:         model,
+		modelProvider: modelProvider,
+	}
+}
+
+// --- generateAssistantForMessageOpenAI ---
+
+func TestGenerateAssistantForMessageOpenAI_AdapterErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := errServer(t)
+	defer srv.Close()
+
+	a := &Agent{
+		logger:         zap.NewNop(),
+		OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL),
+	}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("gpt-5.1", "openai")
+
+	_, _, err := a.generateAssistantForMessageOpenAI(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "OpenAI agent loop failed")
+}
+
+// --- generateAssistantForMessageClaude ---
+
+func TestGenerateAssistantForMessageClaude_NoProviderReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("claude-haiku-4-5", "anthropic")
+
+	_, _, err := a.generateAssistantForMessageClaude(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "ANTHROPIC_API_KEY is not configured")
+}
+
+func TestGenerateAssistantForMessageClaude_AdapterErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := errServer(t)
+	defer srv.Close()
+
+	a := &Agent{
+		logger:         zap.NewNop(),
+		ClaudeProvider: newHTTPTestClaudeProvider(srv.URL),
+	}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("claude-haiku-4-5", "anthropic")
+
+	_, _, err := a.generateAssistantForMessageClaude(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "Claude agent loop failed")
+}
+
+// --- generateAssistantForMessageGemini ---
+
+func TestGenerateAssistantForMessageGemini_NoProviderReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("gemini-3.5", "google")
+
+	_, _, err := a.generateAssistantForMessageGemini(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "GEMINI_API_KEY is not configured")
+}
+
+func TestGenerateAssistantForMessageGemini_AdapterErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := errServer(t)
+	defer srv.Close()
+
+	a := &Agent{
+		logger:         zap.NewNop(),
+		GeminiProvider: provider.NewGeminiProvider("gemini-key", srv.URL, nil, nil),
+	}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("gemini-3.5", "google")
+
+	_, _, err := a.generateAssistantForMessageGemini(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "Gemini agent loop failed")
+}
+
+// --- generateAssistantForMessageLocal ---
+
+func TestGenerateAssistantForMessageLocal_NoProviderReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("local-model", "local")
+
+	_, _, err := a.generateAssistantForMessageLocal(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "no local model server is configured")
+}
+
+func TestGenerateAssistantForMessageLocal_AdapterErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := errServer(t)
+	defer srv.Close()
+
+	a := &Agent{
+		logger:        zap.NewNop(),
+		LocalProvider: provider.NewLocalProvider(srv.URL, nil, nil),
+		localLLMModel: "local-model",
+	}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("local-model", "local")
+
+	_, _, err := a.generateAssistantForMessageLocal(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "local model agent loop failed")
+}
+
+// --- generateAssistantForMessageOpenAIChatCompletions ---
+
+func TestGenerateAssistantForMessageOpenAIChatCompletions_NoProviderReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("mistral-large-latest", "mistral")
+
+	_, _, err := a.generateAssistantForMessageOpenAIChatCompletions(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "MISTRAL_API_KEY is not configured")
+}
+
+func TestGenerateAssistantForMessageOpenAIChatCompletions_AdapterErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := errServer(t)
+	defer srv.Close()
+
+	a := &Agent{
+		logger:          zap.NewNop(),
+		MistralProvider: provider.NewMistralProvider("mistral-key", srv.URL, nil, nil),
+	}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("mistral-large-latest", "mistral")
+
+	_, _, err := a.generateAssistantForMessageOpenAIChatCompletions(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.Error(t, err)
+}
+
+// --- dispatchAssistantGeneration routing ---
+
+func TestDispatchAssistantGeneration_RoutesMockLLM(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop(), mockLLM: true}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New(), Message: "hi"}
+	chatCtx := baseChatCtxForGeneration("mock-model", "openai")
+
+	_, _, err := a.dispatchAssistantGeneration(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDispatchAssistantGeneration_RoutesLocalLLM(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop(), localLLM: true}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("local-model", "local")
+
+	_, _, err := a.dispatchAssistantGeneration(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "no local model server is configured")
+}
+
+func TestDispatchAssistantGeneration_RoutesGemini(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("gemini-3.5", string(models.ModelProviderGoogle))
+
+	_, _, err := a.dispatchAssistantGeneration(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "GEMINI_API_KEY is not configured")
+}
+
+func TestDispatchAssistantGeneration_RoutesOpenAIChatCompletions(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("mistral-large-latest", string(models.ModelProviderMistral))
+
+	_, _, err := a.dispatchAssistantGeneration(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "MISTRAL_API_KEY is not configured")
+}
+
+func TestDispatchAssistantGeneration_RoutesClaude(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("claude-haiku-4-5", string(models.ModelProviderAnthropic))
+
+	_, _, err := a.dispatchAssistantGeneration(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "ANTHROPIC_API_KEY is not configured")
+}
+
+func TestDispatchAssistantGeneration_RoutesOpenAIDefault(t *testing.T) {
+	t.Parallel()
+	srv := errServer(t)
+	defer srv.Close()
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := baseChatCtxForGeneration("gpt-5.1", string(models.ModelProviderOpenAI))
+
+	_, _, err := a.dispatchAssistantGeneration(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, &provider.ModelContext{})
+	require.ErrorContains(t, err, "OpenAI agent loop failed")
+}
+
+// --- generateAssistantForMessageMock / runGeneration / generateAssistantForMessage / saveAgentResponse ---
+
+// TestGenerateAssistantForMessageMock_SaveFailurePropagates drives the mock adapter through
+// the real runGeneration -> saveAgentResponse pipeline. The mock adapter always succeeds at
+// "generation" (it has no failure injection point), so the only way to reach an error return
+// without a full ent/sqlmock happy-path chain is to make the final persistence step
+// (ds.CreateChatMessage) fail. This still exercises generateAssistantForMessage,
+// dispatchAssistantGeneration's mock branch, generateAssistantForMessageMock, runGeneration
+// (draft buffer, tool-call merge, personality/mood resolution), and saveAgentResponse's error
+// wrapping in one pass.
+func TestGenerateAssistantForMessageMock_SaveFailurePropagates(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop(), mockLLM: true}
+	chatJob := &models.Job{UserID: uuid.New()} // zero ID keeps the draft buffer inert (no DB writes for deltas)
+	chatMessage := &models.ChatMessage{ChatID: uuid.New(), Message: "hello"}
+	chatCtx := baseChatCtxForGeneration("mock-model", "openai")
+
+	agentMessage, result, err := a.generateAssistantForMessage(context.Background(), uuid.New(), chatJob, chatMessage, chatCtx, &provider.ModelContext{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to save mock agent response")
+	require.Nil(t, agentMessage)
+	require.Nil(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestGenerateAssistantForMessageMock_ImageRitualBranch proves that a chat message carrying
+// the image-generate system ritual routes to handleImageGenerateRitual instead of the normal
+// mock-adapter echo pipeline, even under mock mode. Uses the same test-hook seam as
+// TestHandleImageGenerateRitual_MockMode_PersistsFixturePNG so no real datastore is needed.
+func TestGenerateAssistantForMessageMock_ImageRitualBranch(t *testing.T) {
+	t.Parallel()
+	chatID := uuid.New()
+	a := &Agent{logger: zap.NewNop(), mockLLM: true, testHooks: agentTestHooks{
+		ImageRitualCreateChatMessage: func(_ context.Context, _ uuid.UUID, cm models.ChatMessage) (*models.ChatMessage, error) {
+			return &models.ChatMessage{ID: uuid.New(), ChatID: chatID, Message: cm.Message, Origin: cm.Origin, ToolCalls: cm.ToolCalls}, nil
+		},
+		ImageRitualCreateFileAttachment: func(_ context.Context, _ uuid.UUID, fa models.FileAttachment) (*models.FileAttachment, error) {
+			return &models.FileAttachment{ID: uuid.New(), Name: fa.Name, FileType: fa.FileType}, nil
+		},
+		ImageRitualPersistImage: func(_ context.Context, _ uuid.UUID, _ *models.FileAttachment, _ string) error {
+			return nil
+		},
+	}}
+	chatMessage := &models.ChatMessage{
+		ChatID:  chatID,
+		Message: "draw a fox",
+		Rituals: []*models.Ritual{{ID: SystemRitualIDImageGenerate}},
+	}
+	chatCtx := &chatContext{model: models.DefaultModelName, chat: &models.Chat{ID: chatID}}
+	mc := &provider.ModelContext{}
+	mc.Append(provider.SegmentKindUserMessage, provider.RoleUser, "context", false)
+
+	agentMessage, result, err := a.generateAssistantForMessageMock(context.Background(), uuid.New(), &models.Job{}, chatMessage, chatCtx, mc)
+	require.NoError(t, err)
+	require.NotNil(t, agentMessage)
+	require.NotNil(t, result)
+	require.Contains(t, result.Text, "draw a fox")
+}
+
+// --- saveAgentResponse ---
+
+func TestSaveAgentResponse_CreateChatMessageErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop()}
+	result := &provider.GenerateResponse{ID: "resp_1", Text: "hi"}
+
+	msg, err := a.saveAgentResponse(context.Background(), uuid.New(), uuid.New(), result, nil, nil, "gpt-5.1", "", nil)
+	require.Nil(t, msg)
+	require.ErrorContains(t, err, "failed to create chat message")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- openAIResponseParamsForChat ---
+
+func TestOpenAIResponseParamsForChat_ToolsDisabled(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{
+		chat:  &models.Chat{ToolsEnabled: false},
+		model: "gpt-5.1",
+	}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+
+	params := a.openAIResponseParamsForChat(context.Background(), chatCtx, uuid.New(), chatMessage, &provider.ModelContext{})
+	require.Equal(t, "gpt-5.1", string(params.Model))
+	require.False(t, bool(params.ParallelToolCalls.Value))
+	require.Empty(t, params.Tools)
+	require.Empty(t, params.Include)
+}

--- a/internal/agent/message_orchestration_coverage_test.go
+++ b/internal/agent/message_orchestration_coverage_test.go
@@ -1,0 +1,219 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/metering"
+	"github.com/theimaginaryfoundation/what-iff/internal/middleware"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// --- loadImageBytesForClaude ---
+
+func TestLoadImageBytesForClaude_NoAttachmentsReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+
+	got := a.loadImageBytesForClaude(context.Background(), uuid.New(), chatMessage)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+}
+
+// --- HandleUserMessage ---
+
+func TestHandleUserMessage_NoUserIDInContextReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	resp, err := a.HandleUserMessage(context.Background(), models.ChatMessage{})
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "user ID not found in context")
+}
+
+func TestHandleUserMessage_CreateChatMessageErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop()}
+	userID := uuid.New()
+	ctx := context.WithValue(context.Background(), middleware.UserIDKey, userID)
+
+	resp, err := a.HandleUserMessage(ctx, models.ChatMessage{ChatID: uuid.New(), Message: "hi"})
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "failed to create chat message")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- RetryUserChatMessage ---
+
+func TestRetryUserChatMessage_NoUserIDInContextReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+
+	resp, err := a.RetryUserChatMessage(context.Background(), uuid.New(), uuid.New())
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "user ID not found in context")
+}
+
+func TestRetryUserChatMessage_GetChatMessageErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop()}
+	userID := uuid.New()
+	ctx := context.WithValue(context.Background(), middleware.UserIDKey, userID)
+
+	resp, err := a.RetryUserChatMessage(ctx, uuid.New(), uuid.New())
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- handleUserMessage ---
+
+func TestHandleUserMessage_UpdateJobStatusFailureReturnsEarly(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	// First exist-check failure drives updateJobStatus's UpdateJob call to fail.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+	// setJobStatusFailed's own UpdateJob call also fails its exist check, so it
+	// logs and returns without touching draft deltas or the user message.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop()}
+	chatJob := &models.Job{ID: uuid.New(), UserID: uuid.New(), JobType: JobTypeChatMessage, Status: models.JobStatusPending}
+	chatMessage := &models.ChatMessage{ID: uuid.New(), ChatID: uuid.New()}
+
+	msg, err := a.handleUserMessage(context.Background(), chatJob, chatMessage)
+	require.Nil(t, msg)
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- prepareChatContext ---
+
+func TestPrepareChatContext_GetChatErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+
+	got, err := a.prepareChatContext(context.Background(), uuid.New(), chatMessage)
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "failed to get chat")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- runUserChatPostInferencePhases ---
+
+func TestRunUserChatPostInferencePhases_NilJobIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.runUserChatPostInferencePhases(context.Background(), nil, &models.ChatMessage{}, &models.ChatMessage{}, &chatContext{}, &provider.ModelContext{}, metering.Decision{})
+	})
+}
+
+func TestRunUserChatPostInferencePhases_TerminalJobSkipsPhases(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatJob := &models.Job{ID: uuid.New(), UserID: uuid.New(), Status: models.JobStatusFailed}
+	require.NotPanics(t, func() {
+		a.runUserChatPostInferencePhases(context.Background(), chatJob, &models.ChatMessage{}, &models.ChatMessage{}, &chatContext{}, &provider.ModelContext{}, metering.Decision{})
+	})
+
+	chatJob.Status = models.JobStatusCancelled
+	require.NotPanics(t, func() {
+		a.runUserChatPostInferencePhases(context.Background(), chatJob, &models.ChatMessage{}, &models.ChatMessage{}, &chatContext{}, &provider.ModelContext{}, metering.Decision{})
+	})
+}
+
+// --- finalizeChat / postMessageProcessing ---
+
+// TestFinalizeChat_NonDefaultNameSkipsRenameAndChecksMockMode drives finalizeChat with a
+// non-default chat name (skipping generateChatName) into postMessageProcessing under mock
+// mode, which records usage and then returns before any checkpoint-related datastore calls
+// (checkpointing needs real provider calls and is deliberately skipped under mock/local LLM
+// backends). No datastore mocking is needed since NoopMeter.Record and the mock-mode early
+// return never touch a.ds.
+func TestFinalizeChat_NonDefaultNameSkipsRenameAndChecksMockMode(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop(), mockLLM: true, meter: metering.NoopMeter{Logger: zap.NewNop()}}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New(), Message: "hi"}
+	agentMessage := &models.ChatMessage{ID: uuid.New()}
+	chatCtx := &chatContext{
+		chat:  &models.Chat{Name: "Not Default", ID: uuid.New()},
+		model: "mock-model",
+	}
+
+	require.NotPanics(t, func() {
+		a.finalizeChat(context.Background(), uuid.New(), chatMessage, agentMessage, chatCtx, &provider.ModelContext{}, metering.Decision{Allowed: true})
+	})
+}
+
+// --- runCheckpointOpenAI ---
+
+func TestRunCheckpointOpenAI_NilAgentMessageIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := &chatContext{chat: &models.Chat{}}
+
+	require.NotPanics(t, func() {
+		a.runCheckpointOpenAI(context.Background(), uuid.New(), chatMessage, nil, chatCtx, 1, &provider.ModelContext{}, "reason")
+	})
+}
+
+func TestRunCheckpointOpenAI_EmptyResponseIDIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatMessage := &models.ChatMessage{ChatID: uuid.New()}
+	chatCtx := &chatContext{chat: &models.Chat{}}
+	empty := ""
+	agentMessage := &models.ChatMessage{ID: uuid.New(), ResponseID: &empty}
+
+	require.NotPanics(t, func() {
+		a.runCheckpointOpenAI(context.Background(), uuid.New(), chatMessage, agentMessage, chatCtx, 1, &provider.ModelContext{}, "reason")
+	})
+}
+
+// --- persistCheckpointSummary ---
+
+func TestPersistCheckpointSummary_DatastoreErrorReturnsFalse(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := &Agent{ds: ds, logger: zap.NewNop()} // memoryTool nil skips the embedding/upsert step entirely.
+	ok := a.persistCheckpointSummary(context.Background(), uuid.New(), uuid.New(), "summary text", 3, "OpenAI", uuid.New())
+	require.False(t, ok)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/message_sync_test.go
+++ b/internal/agent/message_sync_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// HandleUserMessageSync's cheapest branch is the missing-user-in-context
+// guard, which fires before any datastore call.
+func TestHandleUserMessageSync_NoUserInContextReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	msg, err := a.HandleUserMessageSync(context.Background(), models.ChatMessage{})
+	require.Nil(t, msg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "user ID not found in context")
+}

--- a/internal/agent/mood_context_coverage_test.go
+++ b/internal/agent/mood_context_coverage_test.go
@@ -1,0 +1,284 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// --- resolveActiveMood ---
+
+func TestResolveActiveMood_NoActiveMoodManualPolicyReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{chat: &models.Chat{IsAutoMood: false}}
+	got := a.resolveActiveMood(context.Background(), uuid.New(), chatCtx, "hi", uuid.New())
+	require.Nil(t, got)
+}
+
+func TestResolveActiveMood_AutoPolicyNoPersonalityReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{chat: &models.Chat{IsAutoMood: true, PersonalityID: uuid.Nil}}
+	got := a.resolveActiveMood(context.Background(), uuid.New(), chatCtx, "hi", uuid.New())
+	require.Nil(t, got)
+}
+
+func TestResolveActiveMood_AutoPolicyGetMoodsErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{IsAutoMood: true, PersonalityID: uuid.New()}}
+	got := a.resolveActiveMood(context.Background(), uuid.New(), chatCtx, "hi", uuid.New())
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveActiveMood_AutoPolicyNoMoodsReturnsNil(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{IsAutoMood: true, PersonalityID: uuid.New()}}
+	got := a.resolveActiveMood(context.Background(), uuid.New(), chatCtx, "hi", uuid.New())
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveActiveMood_ActiveMoodGetErrorClearFailsReturnsNilAfterLoggingBoth(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	moodID := uuid.New()
+
+	// GetMood fails (first SELECT), then SetChatActiveMood's chat lookup also fails
+	// (second SELECT), so the stale active mood cannot be cleared; chat.ActiveMoodID
+	// stays set but autoPolicy is false, so resolveActiveMood returns nil.
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{IsAutoMood: false, ActiveMoodID: &moodID}}
+	got := a.resolveActiveMood(context.Background(), uuid.New(), chatCtx, "hi", uuid.New())
+	require.Nil(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- isFirstUserMessageInChat ---
+
+func TestIsFirstUserMessageInChat_ListErrorReturnsFalse(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	got := a.isFirstUserMessageInChat(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	require.False(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- autoSelectMood ---
+
+func TestAutoSelectMood_NilProviderReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	got := a.autoSelectMood(context.Background(), []*models.Mood{{ID: uuid.New()}}, "hi")
+	require.Nil(t, got)
+}
+
+func TestAutoSelectMood_NonVendorLLMReturnsNil(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("provider must not be called in mock mode")
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), mockLLM: true, OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got := a.autoSelectMood(context.Background(), []*models.Mood{{ID: uuid.New()}}, "hi")
+	require.Nil(t, got)
+}
+
+func TestAutoSelectMood_ProviderErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got := a.autoSelectMood(context.Background(), []*models.Mood{{ID: uuid.New()}}, "hi")
+	require.Nil(t, got)
+}
+
+func TestAutoSelectMood_ParseErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", "not json"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got := a.autoSelectMood(context.Background(), []*models.Mood{{ID: uuid.New()}}, "hi")
+	require.Nil(t, got)
+}
+
+func TestAutoSelectMood_SuccessReturnsMatchingMood(t *testing.T) {
+	t.Parallel()
+	moodID := uuid.New()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"mood_id\":\"`+moodID.String()+`\"}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	moods := []*models.Mood{{ID: uuid.New()}, {ID: moodID, Name: "Match"}}
+	got := a.autoSelectMood(context.Background(), moods, "hi")
+	require.NotNil(t, got)
+	require.Equal(t, "Match", got.Name)
+}
+
+func TestAutoSelectMood_SuccessNoMatchingMoodReturnsNil(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", `{\"mood_id\":\"`+uuid.New().String()+`\"}`))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got := a.autoSelectMood(context.Background(), []*models.Mood{{ID: uuid.New()}}, "hi")
+	require.Nil(t, got)
+}
+
+// --- persistActiveMood ---
+
+func TestPersistActiveMood_ErrorIsLoggedNotPanicked(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	require.NotPanics(t, func() {
+		a.persistActiveMood(context.Background(), uuid.New(), uuid.New(), &models.Mood{ID: uuid.New()})
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- listMoodsTool ---
+
+func TestListMoodsTool_ErrorReturnsErrorJSON(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{UserID: uuid.New(), PersonalityID: uuid.New()}}
+	out, err := a.listMoodsTool(context.Background(), chatCtx, nil)
+	require.NoError(t, err)
+	var result listMoodsResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "failed to list modes")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- changeMoodTool ---
+
+func TestChangeMoodTool_InvalidArgsJSONReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{chat: &models.Chat{}}
+	out, err := a.changeMoodTool(context.Background(), chatCtx, []byte("not json"))
+	require.NoError(t, err)
+	var result changeMoodResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "invalid arguments")
+}
+
+func TestChangeMoodTool_MissingModeIDReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{chat: &models.Chat{}}
+	args, err := json.Marshal(changeMoodArgs{})
+	require.NoError(t, err)
+	out, err := a.changeMoodTool(context.Background(), chatCtx, args)
+	require.NoError(t, err)
+	var result changeMoodResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Equal(t, "mode_id is required", result.Error)
+}
+
+func TestChangeMoodTool_LegacyMoodIDFallback(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{UserID: uuid.New()}}
+	args, err := json.Marshal(changeMoodArgs{MoodID: uuid.New().String()})
+	require.NoError(t, err)
+	out, err := a.changeMoodTool(context.Background(), chatCtx, args)
+	require.NoError(t, err)
+	var result changeMoodResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "mode not found")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestChangeMoodTool_InvalidModeIDReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	chatCtx := &chatContext{chat: &models.Chat{}}
+	args, err := json.Marshal(changeMoodArgs{ModeID: "not-a-uuid"})
+	require.NoError(t, err)
+	out, err := a.changeMoodTool(context.Background(), chatCtx, args)
+	require.NoError(t, err)
+	var result changeMoodResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "invalid mode_id")
+}
+
+func TestChangeMoodTool_ModeNotFoundReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{chat: &models.Chat{UserID: uuid.New()}}
+	args, err := json.Marshal(changeMoodArgs{ModeID: uuid.New().String()})
+	require.NoError(t, err)
+	out, err := a.changeMoodTool(context.Background(), chatCtx, args)
+	require.NoError(t, err)
+	var result changeMoodResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "mode not found")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- activeMoodID ---
+
+func TestActiveMoodID_NonNilMoodReturnsPointerToID(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	got := activeMoodID(&models.Mood{ID: id})
+	require.NotNil(t, got)
+	require.Equal(t, id, *got)
+}

--- a/internal/agent/personality_generation_job_test.go
+++ b/internal/agent/personality_generation_job_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// EnqueuePersonalityGenerationJob's cheapest branch is its own
+// agent-not-configured guard, which fires before any datastore call.
+func TestEnqueuePersonalityGenerationJob_NilDatastoreReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	job, err := a.EnqueuePersonalityGenerationJob(context.Background(), uuid.New(), uuid.New())
+	require.Nil(t, job)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "agent not configured")
+}

--- a/internal/agent/personality_media_job_run_test.go
+++ b/internal/agent/personality_media_job_run_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// runPersonalityMediaJob's cheapest branch is the missing-user-in-context
+// guard. It attempts to mark the job failed via the datastore before
+// returning; no sqlmock expectations are configured, so that update also
+// fails, exercising the "failed to mark failed" log path too. The function
+// has no return value, so this test only asserts it does not panic and
+// completes (i.e. both guard branches are reached without needing a real DB).
+func TestRunPersonalityMediaJob_MissingUserInContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	a := newTestAgent(ds)
+	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
+
+	// context.Background() carries no user ID, so CopyUserToIDContext fails
+	// immediately inside runPersonalityMediaJob, before work() is ever called.
+	a.runPersonalityMediaJob(context.Background(), job, func(context.Context) (uuid.UUID, error) {
+		t.Fatal("work must not run when the user is missing from context")
+		return uuid.Nil, nil
+	})
+}

--- a/internal/agent/personality_portrait_generation_test.go
+++ b/internal/agent/personality_portrait_generation_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// GeneratePersonalityPortraitImage's cheapest branch is the documented
+// image-style-none guard, which fires before the agent-configuration check.
+func TestGeneratePersonalityPortraitImage_NoneStyleReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	attachment, err := a.GeneratePersonalityPortraitImage(context.Background(), uuid.New(), "a prompt", models.ImageStyleNone)
+	require.Nil(t, attachment)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "portrait generation skipped")
+}

--- a/internal/agent/personality_portrait_job_test.go
+++ b/internal/agent/personality_portrait_job_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// EnqueuePersonalityPortraitJob's cheapest branch is its own
+// agent-not-configured guard, which fires before the system-prompt check or
+// any datastore call.
+func TestEnqueuePersonalityPortraitJob_NilDatastoreReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	job, err := a.EnqueuePersonalityPortraitJob(context.Background(), uuid.New(), uuid.New(), "a system prompt", "auto")
+	require.Nil(t, job)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "agent not configured")
+}

--- a/internal/agent/provider/claude_adapter_beta_call_test.go
+++ b/internal/agent/provider/claude_adapter_beta_call_test.go
@@ -75,6 +75,36 @@ func TestClaudeAdapter_BetaMode_Call_APIErrorIsWrapped(t *testing.T) {
 	require.Nil(t, toolUses)
 }
 
+// TestClaudeAdapter_BetaMode_StreamingTextResponse exercises betaMessagesNewStreaming and
+// CallBetaWithRetryStreaming end to end via the SSE path (claudeSSEServer), which the plain
+// (non-beta) TestClaudeAdapter_SetTextDeltaHandlerEnablesStreaming test already covers for the
+// non-beta message stream.
+func TestClaudeAdapter_BetaMode_StreamingTextResponse(t *testing.T) {
+	events := []struct{ event, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"bmsg_stream","type":"message","role":"assistant","model":"test-model","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" beta"}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	}
+	srv := claudeSSEServer(t, events)
+	defer srv.Close()
+
+	a := newTestClaudeMCPAdapter(srv.URL)
+	var deltas []string
+	a.SetTextDeltaHandler(func(d string) { deltas = append(deltas, d) })
+
+	resp, toolUses, err := a.Call(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, toolUses)
+	require.Equal(t, []string{"Hi", " beta"}, deltas)
+	require.Equal(t, "Hi beta", resp.Text)
+	require.Equal(t, int64(10), resp.InputTokens)
+	require.Equal(t, int64(5), resp.OutputTokens)
+}
+
 func TestClaudeAdapter_BetaMode_AppendToolResults_FoldsIntoNextCall(t *testing.T) {
 	var lastBody string
 	callCount := 0

--- a/internal/agent/provider/claude_test.go
+++ b/internal/agent/provider/claude_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
 )
 
 func TestUnmarshalClaudeTextJSON(t *testing.T) {
@@ -247,4 +249,49 @@ func TestCallClaudeWithRetry_StopsRetryAfterDeltaEmission(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, 1, attempts, "must not retry once any delta has been emitted")
+}
+
+func TestAnthropicStreamUsage_ApplyBeta(t *testing.T) {
+	t.Parallel()
+
+	// Native usage already populated: stream-observed fallback values must not override it.
+	usage := anthropic.BetaUsage{InputTokens: 1200, CacheReadInputTokens: 800, OutputTokens: 50}
+	anthropicStreamUsage{inputTokens: 9999, outputTokens: 300}.applyBeta(&usage)
+	require.Equal(t, int64(2000), anthropicBetaUsageInputTokens(usage))
+	require.Equal(t, int64(50), anthropicBetaUsageOutputTokens(usage))
+
+	// Zero native usage: stream-observed fallback fills both fields.
+	var empty anthropic.BetaUsage
+	anthropicStreamUsage{inputTokens: 4200, outputTokens: 900}.applyBeta(&empty)
+	require.Equal(t, int64(4200), anthropicBetaUsageInputTokens(empty))
+	require.Equal(t, int64(900), anthropicBetaUsageOutputTokens(empty))
+
+	// Nil usage must not panic.
+	require.NotPanics(t, func() {
+		anthropicStreamUsage{inputTokens: 1, outputTokens: 1}.applyBeta(nil)
+	})
+}
+
+func TestClaudeProvider_CountTokens(t *testing.T) {
+	t.Parallel()
+
+	c := NewClaudeProviderWithBaseURL("test-key", "http://127.0.0.1:0", nil, nil)
+	n, err := c.CountTokens("hello world")
+	require.NoError(t, err)
+	require.Positive(t, n)
+}
+
+func TestClaudeProvider_SelectCarryOverTurns(t *testing.T) {
+	t.Parallel()
+
+	c := NewClaudeProviderWithBaseURL("test-key", "http://127.0.0.1:0", nil, nil)
+	now := time.Now()
+	recent := []*models.ChatMessage{
+		{Origin: models.MessageOriginAssistant, Message: "reply", SentAt: now},
+		{Origin: models.MessageOriginUser, Message: "question", SentAt: now.Add(-time.Second)},
+	}
+	turns := c.SelectCarryOverTurns(recent, 5, 1000)
+	require.Len(t, turns, 1)
+	require.Equal(t, "question", turns[0][0].Message)
+	require.Equal(t, "reply", turns[0][1].Message)
 }

--- a/internal/agent/provider/fileattachment_coverage_test.go
+++ b/internal/agent/provider/fileattachment_coverage_test.go
@@ -1,0 +1,255 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	entsql "entgo.io/ent/dialect/sql"
+
+	"entgo.io/ent/dialect"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/ent"
+	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
+	"github.com/theimaginaryfoundation/what-iff/internal/utils"
+	"go.uber.org/zap"
+)
+
+// newFileAttachmentTestDatastore builds a Datastore backed by go-sqlmock, mirroring the
+// agent package's own testsupport helper (internal/agent/testsupport_test.go), which this
+// package does not otherwise have a copy of.
+func newFileAttachmentTestDatastore(t *testing.T) (*datastore.Datastore, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	drv := entsql.OpenDB(dialect.SQLite, db)
+	client := ent.NewClient(ent.Driver(drv))
+	ds, err := datastore.NewDatastore(client, db, zap.NewNop(), "12345678901234567890123456789012", nil)
+	require.NoError(t, err)
+	return ds, mock, func() {
+		_ = client.Close()
+	}
+}
+
+// --- UploadFileAttachment ---
+
+func TestUploadFileAttachment_Success(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"file-123","object":"file","bytes":10,"created_at":1,"filename":"a.txt","purpose":"user_data","status":"processed"}`))
+	}))
+	defer srv.Close()
+
+	a := newTestOpenAIProvider(srv.URL)
+	id, err := a.UploadFileAttachment(context.Background(), uuid.New(), nil, strings.NewReader("hello"), "a.txt", utils.FileTypeInfo{ContentType: "text/plain"})
+	require.NoError(t, err)
+	require.Equal(t, "file-123", id)
+}
+
+func TestUploadFileAttachment_ErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := newTestOpenAIProvider(srv.URL)
+	_, err := a.UploadFileAttachment(context.Background(), uuid.New(), nil, strings.NewReader("hello"), "a.txt", utils.FileTypeInfo{ContentType: "text/plain"})
+	require.Error(t, err)
+}
+
+// --- DeleteFileAttachment ---
+
+func TestDeleteFileAttachment_Success(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"file-123","object":"file","deleted":true}`))
+	}))
+	defer srv.Close()
+
+	a := newTestOpenAIProvider(srv.URL)
+	err := a.DeleteFileAttachment(context.Background(), "file-123")
+	require.NoError(t, err)
+}
+
+func TestDeleteFileAttachment_ErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := newTestOpenAIProvider(srv.URL)
+	err := a.DeleteFileAttachment(context.Background(), "file-123")
+	require.Error(t, err)
+}
+
+// --- SaveMessageAttachments ---
+
+func TestSaveMessageAttachments_NoMatchingOutputTypeIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := newTestOpenAIProvider("http://unused.invalid")
+	resp := &responses.Response{Output: []responses.ResponseOutputItemUnion{{Type: "reasoning"}}}
+	err := a.SaveMessageAttachments(context.Background(), uuid.New(), uuid.New(), resp)
+	require.NoError(t, err)
+}
+
+func TestSaveMessageAttachments_ImageGenerationCallDispatchesToSaveImageAttachment(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+
+	// CreateFileAttachment's user-exists check fails fast (not found), so
+	// saveImageAttachment logs and returns without needing a fileStore.
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := NewOpenAIProvider(ds, nil, nil, nil)
+	var respObj responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{"output":[{"type":"image_generation_call","id":"img_1","result":"aGVsbG8="}]}`), &respObj))
+
+	err := a.SaveMessageAttachments(context.Background(), uuid.New(), uuid.New(), &respObj)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSaveMessageAttachments_MessageContentDispatchesToProcessAnnotations(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := newTestOpenAIProvider(srv.URL)
+	var respObj responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{"output":[{"type":"message","content":[{"type":"output_text","text":"hi","annotations":[`+
+		`{"type":"container_file_citation","container_id":"c1","file_id":"f1","filename":"notes.txt","start_index":0,"end_index":1}]}]}]}`), &respObj))
+
+	// The annotation dispatches to saveInterpreterAttachment, whose Containers.Files.Content.Get
+	// call fails against the 400-returning server; the function logs and returns.
+	err := a.SaveMessageAttachments(context.Background(), uuid.New(), uuid.New(), &respObj)
+	require.NoError(t, err)
+}
+
+// --- processAnnotations ---
+
+func TestProcessAnnotations_NonMatchingTypeIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := newTestOpenAIProvider("http://unused.invalid")
+	var annotation responses.ResponseOutputTextAnnotationUnion
+	require.NoError(t, json.Unmarshal([]byte(`{"type":"url_citation","url":"https://example.com","title":"x"}`), &annotation))
+
+	require.NotPanics(t, func() {
+		a.processAnnotations(context.Background(), uuid.New(), uuid.New(), []responses.ResponseOutputTextAnnotationUnion{annotation})
+	})
+}
+
+// --- saveInterpreterAttachment ---
+
+func TestSaveInterpreterAttachment_ContainerGetErrorLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// No-retry client: a 500 would otherwise trigger the SDK's default retry
+	// backoff, slowing this test down for no coverage benefit.
+	client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(srv.URL), option.WithMaxRetries(0))
+	a := NewOpenAIProvider(nil, &client, nil, nil)
+	annotation := responses.ResponseOutputTextAnnotationContainerFileCitation{
+		ContainerID: "c1",
+		FileID:      "f1",
+		Filename:    "notes.txt",
+	}
+	require.NotPanics(t, func() {
+		a.saveInterpreterAttachment(context.Background(), uuid.New(), uuid.New(), annotation)
+	})
+}
+
+func TestSaveInterpreterAttachment_UnsupportedFileTypeLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("file bytes"))
+	}))
+	defer srv.Close()
+
+	a := newTestOpenAIProvider(srv.URL)
+	annotation := responses.ResponseOutputTextAnnotationContainerFileCitation{
+		ContainerID: "c1",
+		FileID:      "f1",
+		Filename:    "notes.xyz", // unsupported extension per utils.GetFileType
+	}
+	require.NotPanics(t, func() {
+		a.saveInterpreterAttachment(context.Background(), uuid.New(), uuid.New(), annotation)
+	})
+}
+
+func TestSaveInterpreterAttachment_CreateFileAttachmentErrorLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("file bytes"))
+	}))
+	defer srv.Close()
+
+	ds, mock, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(srv.URL))
+	a := NewOpenAIProvider(ds, &client, nil, nil)
+	annotation := responses.ResponseOutputTextAnnotationContainerFileCitation{
+		ContainerID: "c1",
+		FileID:      "f1",
+		Filename:    "notes.txt",
+	}
+	require.NotPanics(t, func() {
+		a.saveInterpreterAttachment(context.Background(), uuid.New(), uuid.New(), annotation)
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- saveImageAttachment ---
+
+func TestSaveImageAttachment_CreateFileAttachmentErrorLogsAndReturns(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newFileAttachmentTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectRollback()
+
+	a := NewOpenAIProvider(ds, nil, nil, nil)
+	var image responses.ResponseOutputItemImageGenerationCall
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"img_1","type":"image_generation_call","result":"aGVsbG8=","status":"completed"}`), &image))
+
+	require.NotPanics(t, func() {
+		a.saveImageAttachment(context.Background(), uuid.New(), uuid.New(), image)
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- saveInterpreterAttachments ---
+
+func TestSaveInterpreterAttachments_NoAnnotationsIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := newTestOpenAIProvider("http://unused.invalid")
+	require.NotPanics(t, func() {
+		a.saveInterpreterAttachments(context.Background(), uuid.New(), uuid.New(), []responses.ResponseOutputMessageContentUnion{{Type: "output_text", Text: "hi"}})
+	})
+}

--- a/internal/agent/provider/gemini_test.go
+++ b/internal/agent/provider/gemini_test.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/shared"
 	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
 )
 
 func TestBuildGeminiParams_ModelAndMessages(t *testing.T) {
@@ -85,4 +87,38 @@ func TestBuildGeminiParams_RendersToolResultAttachmentAndPortrait(t *testing.T) 
 	require.Equal(t, "attached: report.pdf", p.Messages[1].OfUser.Content.OfString.Value)
 	require.Equal(t, ExpressionPortraitVisualReferenceCaption, p.Messages[2].OfUser.Content.OfArrayOfContentParts[0].OfText.Text)
 	require.Equal(t, "follow up", p.Messages[3].OfUser.Content.OfString.Value)
+}
+
+func TestExtractGeminiText_AliasesExtractChatCompletionText(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, ExtractGeminiText(nil))
+
+	resp := &openai.ChatCompletion{
+		Choices: []openai.ChatCompletionChoice{{
+			Message: openai.ChatCompletionMessage{Content: "  hello gemini  "},
+		}},
+	}
+	require.Equal(t, "hello gemini", ExtractGeminiText(resp))
+}
+
+func TestGeminiProvider_CountTokens(t *testing.T) {
+	t.Parallel()
+	c := &GeminiProvider{tokenCounter: NewTokenCounter()}
+	n, err := c.CountTokens("hello world")
+	require.NoError(t, err)
+	require.Positive(t, n)
+}
+
+func TestGeminiProvider_SelectCarryOverTurns(t *testing.T) {
+	t.Parallel()
+	c := &GeminiProvider{tokenCounter: NewTokenCounter()}
+	now := time.Now()
+	recent := []*models.ChatMessage{
+		{Origin: models.MessageOriginAssistant, Message: "reply", SentAt: now},
+		{Origin: models.MessageOriginUser, Message: "question", SentAt: now.Add(-time.Second)},
+	}
+	turns := c.SelectCarryOverTurns(recent, 5, 1000)
+	require.Len(t, turns, 1)
+	require.Equal(t, "question", turns[0][0].Message)
+	require.Equal(t, "reply", turns[0][1].Message)
 }

--- a/internal/agent/provider/openai_test.go
+++ b/internal/agent/provider/openai_test.go
@@ -2,12 +2,16 @@ package provider
 
 import (
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/openai/openai-go/v3/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
 )
 
 // Test helper functions for processResponseOutput
@@ -361,4 +365,65 @@ The future of AI development looks promising with continued investment and resea
 	for i := 0; i < b.N; i++ {
 		testProcessResponseOutput(content)
 	}
+}
+
+// responseWithOutputText builds a *responses.Response whose OutputText() returns text, so
+// ProcessResponseOutput (and therefore dedupeParagraphs) can be exercised directly instead of via
+// the standalone testProcessResponseOutput reimplementation above.
+func responseWithOutputText(t *testing.T, text string) *responses.Response {
+	t.Helper()
+	quoted, err := json.Marshal(text)
+	require.NoError(t, err)
+	raw := `{"id":"resp_1","object":"response","created_at":1,"model":"test","status":"completed",` +
+		`"output":[{"type":"message","id":"m1","role":"assistant","status":"completed","content":[{"type":"output_text","text":` + string(quoted) + `}]}]}`
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+	return &resp
+}
+
+// TestProcessResponseOutput_RealResponse_Dedupes exercises the actual ProcessResponseOutput /
+// dedupeParagraphs path (not the standalone reimplementation used by the other tests in this
+// file) against a real *responses.Response, so the production dedup logic itself is covered.
+func TestProcessResponseOutput_RealResponse_Dedupes(t *testing.T) {
+	t.Parallel()
+	content := "This is a unique paragraph about artificial intelligence, long enough to pass the short-message threshold.\n\n" +
+		"This is a unique paragraph about artificial intelligence, long enough to pass the short-message threshold.\n\n" +
+		"This is a second, different paragraph that is also long enough to matter for the test."
+	resp := responseWithOutputText(t, content)
+
+	got := ProcessResponseOutput(resp)
+	require.Equal(t, 1, strings.Count(got, "artificial intelligence"), "exact duplicate paragraph must be folded to one copy")
+	require.Contains(t, got, "second, different paragraph")
+}
+
+func TestProcessResponseOutput_RealResponse_ShortContentPassesThrough(t *testing.T) {
+	t.Parallel()
+	resp := responseWithOutputText(t, "short")
+	require.Equal(t, "short", ProcessResponseOutput(resp))
+}
+
+func TestDedupeParagraphs_PreservesEmptyParagraphsAndDedupes(t *testing.T) {
+	t.Parallel()
+	in := []string{"Same content here.", "", "Same   content  here.", "Different."}
+	out := dedupeParagraphs(in)
+	require.Equal(t, []string{"Same content here.", "", "Different."}, out)
+}
+
+func TestDedupeParagraphs_Empty(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, dedupeParagraphs(nil))
+}
+
+func TestOpenAIProvider_SelectCarryOverTurns(t *testing.T) {
+	t.Parallel()
+	c := &OpenAIProvider{tokenCounter: NewTokenCounter()}
+	now := time.Now()
+	recent := []*models.ChatMessage{
+		{Origin: models.MessageOriginAssistant, Message: "reply", SentAt: now},
+		{Origin: models.MessageOriginUser, Message: "question", SentAt: now.Add(-time.Second)},
+	}
+	turns := c.SelectCarryOverTurns(recent, 5, 1000)
+	require.Len(t, turns, 1)
+	require.Equal(t, "question", turns[0][0].Message)
+	require.Equal(t, "reply", turns[0][1].Message)
 }

--- a/internal/agent/provider/safety_violation_test.go
+++ b/internal/agent/provider/safety_violation_test.go
@@ -132,3 +132,20 @@ func TestParseSafetyViolationErrorFallsBackToTheMessage(t *testing.T) {
 		require.Equal(t, tc.want, v.Provider, tc.text)
 	}
 }
+
+func TestSafetyViolationError_Error(t *testing.T) {
+	t.Parallel()
+
+	var nilErr *SafetyViolationError
+	require.Equal(t, "safety violation", nilErr.Error())
+
+	require.Equal(t, "safety violation", (&SafetyViolationError{}).Error())
+
+	require.Equal(t, "safety violation", (&SafetyViolationError{
+		Violation: &SafetyViolation{ProviderMessage: "   "},
+	}).Error())
+
+	require.Equal(t, "request was blocked", (&SafetyViolationError{
+		Violation: &SafetyViolation{ProviderMessage: "  request was blocked  "},
+	}).Error())
+}

--- a/internal/agent/recall_distill_test.go
+++ b/internal/agent/recall_distill_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecallDistiller_Distill_Unavailable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	var nilDistiller *recallDistiller
+	_, err := nilDistiller.Distill(ctx, "q", "m")
+	require.ErrorContains(t, err, "OpenAIProvider unavailable")
+
+	d := newRecallDistiller(nil)
+	_, err = d.Distill(ctx, "q", "m")
+	require.ErrorContains(t, err, "OpenAIProvider unavailable")
+
+	d = newRecallDistiller(&Agent{})
+	_, err = d.Distill(ctx, "q", "m")
+	require.ErrorContains(t, err, "OpenAIProvider unavailable")
+}

--- a/internal/agent/rituals_coverage_test.go
+++ b/internal/agent/rituals_coverage_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// EnrichUserMessageWithRituals's cheapest reachable branch is the datastore
+// error path (GetRitualsByIDs failing), which returns the original message
+// unchanged alongside the error. Uses the internal (package agent) ds field
+// directly, unlike rituals_test.go which is package agent_test.
+func TestEnrichUserMessageWithRituals_DatastoreErrorReturnsOriginalMessage(t *testing.T) {
+	t.Parallel()
+
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	a := newTestAgent(ds)
+	msg := &models.ChatMessage{Message: "hello", Rituals: []*models.Ritual{{ID: uuid.New()}}}
+
+	// A non-empty ritual ID list forces GetRitualsByIDs past its own
+	// empty-list early return and into the transaction/query path. No
+	// sqlmock expectations are configured there, so it fails immediately.
+	got, err := a.EnrichUserMessageWithRituals(context.Background(), uuid.New(), msg)
+	require.Error(t, err)
+	require.Equal(t, "hello", got)
+	require.Equal(t, "hello", msg.Message)
+}

--- a/internal/agent/safety_violation_test.go
+++ b/internal/agent/safety_violation_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// handleSafetyViolation's cheapest branch is its own nil-violation guard,
+// which fires before chatMessage/chatCtx are dereferenced.
+func TestHandleSafetyViolation_NilViolationReturnsError(t *testing.T) {
+	t.Parallel()
+
+	a := &Agent{}
+	msg, resp, err := a.handleSafetyViolation(context.Background(), uuid.New(), nil, nil, nil)
+	require.Nil(t, msg)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "safety violation details missing")
+}

--- a/internal/agent/scratchpad_coverage_test.go
+++ b/internal/agent/scratchpad_coverage_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// --- updateScratchpad ---
+
+func TestUpdateScratchpad_NilResponseIDReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	_, err := a.updateScratchpad(context.Background(), uuid.New(), nil, &chatContext{chat: &models.Chat{}})
+	require.ErrorContains(t, err, "response ID is nil")
+}
+
+func TestUpdateScratchpad_GetPersonalityErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	respID := "resp_1"
+	_, err := a.updateScratchpad(context.Background(), uuid.New(), &respID, &chatContext{chat: &models.Chat{}})
+	require.ErrorContains(t, err, "failed to get personality by ID")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- summarizeScratchpad ---
+
+func TestSummarizeScratchpad_NilResponseIDReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	_, err := a.summarizeScratchpad(context.Background(), uuid.New(), nil, &chatContext{chat: &models.Chat{}}, "text")
+	require.ErrorContains(t, err, "response ID is nil")
+}
+
+func TestSummarizeScratchpad_NoPersonalityReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	respID := "resp_1"
+	_, err := a.summarizeScratchpad(context.Background(), uuid.New(), &respID, &chatContext{chat: &models.Chat{PersonalityID: uuid.Nil}}, "text")
+	require.ErrorContains(t, err, "not available without a personality")
+}
+
+// --- updateScratchpadClaude ---
+
+func TestUpdateScratchpadClaude_GetPersonalityErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	_, err := a.updateScratchpadClaude(context.Background(), uuid.New(), &chatContext{chat: &models.Chat{}}, &provider.ModelContext{})
+	require.ErrorContains(t, err, "failed to get personality by ID")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- summarizeScratchpadClaude ---
+
+func TestSummarizeScratchpadClaude_ProviderErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.summarizeScratchpadClaude(context.Background(), uuid.New(), "text")
+	require.ErrorContains(t, err, "failed to summarize Claude scratchpad")
+}
+
+// --- scratchpadPromptOrDefault ---
+
+func TestScratchpadPromptOrDefault_NilPersonalityReturnsDefault(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, scratchpadUpdatePrompt, scratchpadPromptOrDefault(nil))
+}

--- a/internal/agent/subagent_tools_coverage_test.go
+++ b/internal/agent/subagent_tools_coverage_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// --- parseSkillIDs ---
+
+func TestParseSkillIDs(t *testing.T) {
+	t.Parallel()
+	valid := uuid.New()
+	got := parseSkillIDs([]string{valid.String(), "  ", "not-a-uuid", ""})
+	require.Equal(t, []uuid.UUID{valid}, got)
+}
+
+func TestParseSkillIDs_EmptyInputReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+	got := parseSkillIDs(nil)
+	require.Empty(t, got)
+}
+
+// --- optionalUUIDString ---
+
+func TestOptionalUUIDString(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", optionalUUIDString(uuid.Nil))
+	id := uuid.New()
+	require.Equal(t, id.String(), optionalUUIDString(id))
+}
+
+// --- marshalSubagentToolResult ---
+
+func TestMarshalSubagentToolResult_MarshalErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	_, err := marshalSubagentToolResult(make(chan int))
+	require.Error(t, err)
+}
+
+// --- findModelByID ---
+
+func TestFindModelByID_NilDatastoreReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	_, err := a.findModelByID(context.Background(), uuid.New())
+	require.Error(t, err)
+}
+
+// --- callSubagentModel ---
+
+func TestCallSubagentModel_OpenAIChatCompletionsAPIUnsupported(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	// Gemini models route through the OpenAI-compatible chat-completions API,
+	// which subagent calls do not support.
+	out, err := a.callSubagentModel(context.Background(), uuid.New(), "gemini-3.5-flash", buildSubagentModelContext("", "", "hi"), nil)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.Contains(t, err.Error(), "not yet supported")
+}
+
+func TestCallSubagentModel_ZAIProviderMissing(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	out, err := a.callSubagentModel(context.Background(), uuid.New(), "glm-5.2", buildSubagentModelContext("", "", "hi"), nil)
+	require.Error(t, err)
+	require.Nil(t, out)
+	require.Contains(t, err.Error(), "ZAI_API_KEY")
+}
+
+// --- runSubagentTool ---
+
+func TestRunSubagentTool_InvalidArgsJSONReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	chatCtx := &chatContext{chat: &models.Chat{}}
+	out, err := a.runSubagentTool(context.Background(), chatCtx, []byte("not json"))
+	require.NoError(t, err)
+	var result runSubagentToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "invalid arguments")
+}
+
+func TestRunSubagentTool_InvalidPersonalityIDReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	chatCtx := &chatContext{model: "gpt-5-mini", chat: &models.Chat{}}
+	out, err := a.runSubagentTool(context.Background(), chatCtx, []byte(`{"message":"hi","personality_id":"not-a-uuid"}`))
+	require.NoError(t, err)
+	var result runSubagentToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Equal(t, "personality_id must be a valid UUID", result.Error)
+}
+
+func TestRunSubagentTool_PersonalityLookupErrorReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+	mock.ExpectRollback()
+
+	a := newTestAgent(ds)
+	chatCtx := &chatContext{model: "gpt-5-mini", chat: &models.Chat{UserID: uuid.New()}}
+	out, err := a.runSubagentTool(context.Background(), chatCtx, []byte(`{"message":"hi","personality_id":"`+uuid.New().String()+`"}`))
+	require.NoError(t, err)
+	var result runSubagentToolResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	require.False(t, result.Success)
+	require.Contains(t, result.Error, "failed to get personality")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/agent/thread_rehydration_coverage_test.go
+++ b/internal/agent/thread_rehydration_coverage_test.go
@@ -1,0 +1,427 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/middleware"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// newHTTPTestOpenAIProvider builds a real *provider.OpenAIProvider whose client talks to an
+// httptest server, so summarizeText/extractMemoriesFromTranscript can be exercised end to end
+// without a live OpenAI dependency.
+func newHTTPTestOpenAIProvider(baseURL string) *provider.OpenAIProvider {
+	client := openai.NewClient(option.WithAPIKey("test-key"), option.WithBaseURL(baseURL))
+	return provider.NewOpenAIProvider(nil, &client, nil, nil)
+}
+
+// jsonResponsesServer starts an httptest server that always answers the Responses API with body.
+func jsonResponsesServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// responseTextJSONBody builds a minimal Responses API JSON body carrying a single output_text.
+func responseTextJSONBody(id, text string) string {
+	return `{"id":"` + id + `","object":"response","created_at":1,"model":"test","status":"completed",` +
+		`"output":[{"type":"message","id":"m1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"` + text + `"}]}],` +
+		`"usage":{"input_tokens":5,"output_tokens":7,"total_tokens":12}}`
+}
+
+// expectJobStatusUpdateNotFound mocks the exists-check inside UpdateJobStatus failing (job not
+// found/unauthorized), which is the simplest way to make UpdateJobStatus return an error from
+// this package's tests without also having to model the full update+owner-load+commit chain.
+// runThreadRehydration/failRehydration only log a warning on this error, so it never changes the
+// outcome under test.
+//
+// The exists-check goes through job.HasOwnerWith(user.ID(...)), which ent/entsql compiles to a
+// query that scans the job id (UUID) column to determine whether any row matched, not a bool
+// projection - zero rows is how "not found" is expressed here.
+func expectJobStatusUpdateNotFound(mock sqlmock.Sqlmock) {
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+}
+
+// --- isRehydrationInFlight ---
+
+func TestIsRehydrationInFlight(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{models.RehydrationStateNone, false},
+		{models.RehydrationStatePending, true},
+		{models.RehydrationStateProcessing, true},
+		{models.RehydrationStateReady, false},
+		{models.RehydrationStateFailed, false},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, isRehydrationInFlight(tc.state), "state=%q", tc.state)
+	}
+}
+
+// --- WaitForThreadRehydration ---
+
+func TestWaitForThreadRehydration_GetStateErrorReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	a.WaitForThreadRehydration(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitForThreadRehydration_NotInFlightReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"rehydration_state"}).AddRow(models.RehydrationStateReady))
+
+	a := newTestAgent(ds)
+	a.WaitForThreadRehydration(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitForThreadRehydration_ContextCancelledReturnsPromptly(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"rehydration_state"}).AddRow(models.RehydrationStatePending))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	a := newTestAgent(ds)
+	done := make(chan struct{})
+	go func() {
+		a.WaitForThreadRehydration(ctx, uuid.New(), uuid.New())
+		close(done)
+	}()
+
+	// Give the initial (synchronous, mock-backed) state read time to complete and enter the
+	// poll/select loop before cancelling, so this exercises the ctx.Done() case rather than the
+	// initial-read error path (already covered by GetStateErrorReturnsImmediately above).
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForThreadRehydration did not return promptly after context cancellation")
+	}
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitForThreadRehydration_PollSettlesToReady(t *testing.T) {
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"rehydration_state"}).AddRow(models.RehydrationStatePending))
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"rehydration_state"}).AddRow(models.RehydrationStateReady))
+
+	a := newTestAgent(ds)
+	start := time.Now()
+	a.WaitForThreadRehydration(context.Background(), uuid.New(), uuid.New())
+	require.Less(t, time.Since(start), 10*time.Second, "should settle on the first poll tick, not time out")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWaitForThreadRehydration_PollChatNotFoundReturnsPromptly(t *testing.T) {
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"rehydration_state"}).AddRow(models.RehydrationStatePending))
+	// Second poll: zero rows -> ent.IsNotFound -> ErrChatNotFound -> gate returns immediately
+	// instead of continuing to poll.
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"rehydration_state"}))
+
+	a := newTestAgent(ds)
+	start := time.Now()
+	a.WaitForThreadRehydration(context.Background(), uuid.New(), uuid.New())
+	require.Less(t, time.Since(start), 10*time.Second)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- EnqueueThreadRehydration ---
+
+func ctxWithUser(userID uuid.UUID) context.Context {
+	return context.WithValue(context.Background(), middleware.UserIDKey, userID)
+}
+
+func TestEnqueueThreadRehydration_MissingUserInContextIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.EnqueueThreadRehydration(context.Background(), uuid.New(), uuid.New())
+	})
+}
+
+func TestEnqueueThreadRehydration_SetStateFailsReturnsWithoutCreatingJob(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnError(errCoverageTestSentinel)
+
+	a := newTestAgent(ds)
+	userID := uuid.New()
+	require.NotPanics(t, func() {
+		a.EnqueueThreadRehydration(ctxWithUser(userID), userID, uuid.New())
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- failRehydration ---
+
+func TestFailRehydration_LogsBothFailuresWithoutPanicking(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnError(errCoverageTestSentinel)
+	expectJobStatusUpdateNotFound(mock)
+
+	a := newTestAgent(ds)
+	require.NotPanics(t, func() {
+		a.failRehydration(context.Background(), uuid.New(), uuid.New(), uuid.New(), "boom reason")
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- runThreadRehydration ---
+
+func expectGetChatMessagesForSummarySuccess(mock sqlmock.Sqlmock, msgs []models.ChatMessage) {
+	mock.ExpectQuery("SELECT .*").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	rows := sqlmock.NewRows([]string{"message", "origin", "sent_at"})
+	for _, m := range msgs {
+		rows.AddRow(m.Message, string(m.Origin), m.SentAt)
+	}
+	mock.ExpectQuery("SELECT .*").WillReturnRows(rows)
+}
+
+func TestRunThreadRehydration_LoadMessagesFailureCallsFailRehydration(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	expectJobStatusUpdateNotFound(mock)                                           // mark processing (best-effort, ignored on failure)
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnResult(sqlmock.NewResult(0, 1)) // mark processing
+	mock.ExpectQuery("SELECT .*").WillReturnError(errCoverageTestSentinel)        // GetChatMessagesForSummary owns-check fails
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnResult(sqlmock.NewResult(0, 1)) // failRehydration: mark failed
+	expectJobStatusUpdateNotFound(mock)                                           // failRehydration: job status update
+
+	a := newTestAgent(ds)
+	require.NotPanics(t, func() {
+		a.runThreadRehydration(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRunThreadRehydration_ShortThreadMarksReadyWithoutSummarizing(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	msgs := []models.ChatMessage{
+		{Message: "hi", Origin: models.MessageOriginUser, SentAt: base},
+		{Message: "hello", Origin: models.MessageOriginAssistant, SentAt: base.Add(time.Minute)},
+	}
+
+	expectJobStatusUpdateNotFound(mock)                                           // mark processing
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnResult(sqlmock.NewResult(0, 1)) // mark processing state
+	expectGetChatMessagesForSummarySuccess(mock, msgs)
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnResult(sqlmock.NewResult(0, 1)) // mark ready (short thread)
+	expectJobStatusUpdateNotFound(mock)                                           // complete job
+
+	a := newTestAgent(ds) // OpenAIProvider/memoryTool nil -> extractAndStoreImportedMemories is a no-op
+	require.NotPanics(t, func() {
+		a.runThreadRehydration(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRunThreadRehydration_LongThreadMockLLMUsesDeterministicSummary(t *testing.T) {
+	t.Parallel()
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	msgs := turnMsgs(10) // 10 user turns, keepTurns default (5) -> needs summarization
+
+	expectJobStatusUpdateNotFound(mock)                                           // mark processing
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnResult(sqlmock.NewResult(0, 1)) // mark processing state
+	expectGetChatMessagesForSummarySuccess(mock, msgs)
+	mock.ExpectExec("UPDATE .*chats.*").WillReturnResult(sqlmock.NewResult(0, 1)) // SetImportedThreadRehydrated
+	expectJobStatusUpdateNotFound(mock)                                           // complete job
+
+	a := newTestAgent(ds)
+	a.mockLLM = true // nonVendorLLM() -> deterministic fake summary, no OpenAIProvider needed
+	require.NotPanics(t, func() {
+		a.runThreadRehydration(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- summarizeText ---
+
+func TestSummarizeText_NoProviderConfiguredReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	_, err := a.summarizeText(context.Background(), uuid.New(), "instructions", "input", 100)
+	require.ErrorContains(t, err, "no summarization provider configured")
+}
+
+func TestSummarizeText_SuccessReturnsTrimmedOutput(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_1", "  a tidy summary  "))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	got, err := a.summarizeText(context.Background(), uuid.New(), "instructions", "input", 100)
+	require.NoError(t, err)
+	require.Equal(t, "a tidy summary", got)
+}
+
+func TestSummarizeText_EmptyOutputReturnsError(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_2", "   "))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.summarizeText(context.Background(), uuid.New(), "instructions", "input", 100)
+	require.ErrorContains(t, err, "empty summary")
+}
+
+func TestSummarizeText_ProviderErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.summarizeText(context.Background(), uuid.New(), "instructions", "input", 100)
+	require.ErrorContains(t, err, "openai summarize")
+}
+
+// --- summarizeImportedThread ---
+
+func TestSummarizeImportedThread_EmptyTranscriptReturnsError(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	_, err := a.summarizeImportedThread(context.Background(), uuid.New(), []models.ChatMessage{{Message: "   "}})
+	require.ErrorContains(t, err, "empty transcript")
+}
+
+func TestSummarizeImportedThread_SinglePassUnderCharBudget(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_3", "short thread summary"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	msgs := turnMsgs(2)
+	got, err := a.summarizeImportedThread(context.Background(), uuid.New(), msgs)
+	require.NoError(t, err)
+	require.Equal(t, "short thread summary", got)
+}
+
+func TestSummarizeImportedThread_MapReduceForLongTranscript(t *testing.T) {
+	t.Parallel()
+	srv := jsonResponsesServer(t, responseTextJSONBody("resp_4", "rolled-up summary"))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	// One oversized message forces buildTranscript() past rehydrationSinglePassChars, exercising the
+	// chunk map + rollup-reduce path (chunkMessagesByChars + multiple summarizeText calls).
+	msgs := []models.ChatMessage{
+		{Message: strings.Repeat("x", rehydrationSinglePassChars+1), Origin: models.MessageOriginUser},
+	}
+	got, err := a.summarizeImportedThread(context.Background(), uuid.New(), msgs)
+	require.NoError(t, err)
+	require.Equal(t, "rolled-up summary", got)
+}
+
+// --- extractMemoriesFromTranscript ---
+
+func TestExtractMemoriesFromTranscript_EmptyTranscriptReturnsNil(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	mems, err := a.extractMemoriesFromTranscript(context.Background(), uuid.New(), "   ")
+	require.NoError(t, err)
+	require.Nil(t, mems)
+}
+
+func TestExtractMemoriesFromTranscript_SuccessParsesMemories(t *testing.T) {
+	t.Parallel()
+	body := responseTextJSONBody("resp_5", `{\"memories\":[{\"content\":\"likes Go\",\"scope\":\"User\",\"confidence\":\"high\"}]}`)
+	srv := jsonResponsesServer(t, body)
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	mems, err := a.extractMemoriesFromTranscript(context.Background(), uuid.New(), "User: I like Go.")
+	require.NoError(t, err)
+	require.Len(t, mems, 1)
+	require.Equal(t, "likes Go", mems[0].Content)
+}
+
+func TestExtractMemoriesFromTranscript_ProviderErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider(srv.URL)}
+	_, err := a.extractMemoriesFromTranscript(context.Background(), uuid.New(), "User: hi")
+	require.ErrorContains(t, err, "openai memory extraction")
+}
+
+// --- extractAndStoreImportedMemories ---
+
+func TestExtractAndStoreImportedMemories_NilProviderOrMemoryToolIsNoOp(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	require.NotPanics(t, func() {
+		a.extractAndStoreImportedMemories(context.Background(), uuid.New(), uuid.New(), turnMsgs(2))
+	})
+}
+
+func TestExtractAndStoreImportedMemories_MockLLMSkipsExtraction(t *testing.T) {
+	t.Parallel()
+	// memoryTool is nil, but that guard is checked before nonVendorLLM(); use a provider so the
+	// nonVendorLLM() skip itself is what's under test (no HTTP call should occur since there is no
+	// server to receive one).
+	a := &Agent{logger: zap.NewNop(), OpenAIProvider: newHTTPTestOpenAIProvider("http://127.0.0.1:0"), mockLLM: true}
+	require.NotPanics(t, func() {
+		a.extractAndStoreImportedMemories(context.Background(), uuid.New(), uuid.New(), turnMsgs(2))
+	})
+}

--- a/internal/agent/tools/create_memory_test.go
+++ b/internal/agent/tools/create_memory_test.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// CreateMemoryTool's cheapest branch is the invalid-JSON-args guard, which
+// fires before any embedding call or datastore access, so ds/oaiClient can
+// stay nil.
+func TestCreateMemoryTool_InvalidArgsReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+
+	tool := &VectorStoreMemoryTool{logger: zap.NewNop()}
+	chat := &models.Chat{ID: uuid.New(), UserID: uuid.New()}
+
+	out, err := tool.CreateMemoryTool(context.Background(), chat, []byte(`not json`))
+	require.NoError(t, err)
+	require.Contains(t, out, "invalid arguments")
+	require.Contains(t, out, `"success":false`)
+}

--- a/internal/agent/tools/list_test.go
+++ b/internal/agent/tools/list_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -353,6 +354,79 @@ func TestListMCPServersScopedToChat(t *testing.T) {
 	if res.Items[0].Status != "error: auth failed" || res.Items[0].URL != "https://mcp.example" {
 		t.Fatalf("unexpected mcp item: %+v", res.Items[0])
 	}
+}
+
+func TestListPersonalities(t *testing.T) {
+	now := time.Now()
+	store := &fakeListStore{pers: []*models.Personality{
+		{ID: uuid.New(), Name: "Ada", UpdatedAt: now},
+	}}
+	res := runList(t, newTestListTool(store), `{"kind":"personalities"}`)
+	if res.Kind != listKindPersonalities || res.Count != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.Items[0].Name != "Ada" || res.Items[0].UpdatedAt == "" {
+		t.Fatalf("unexpected personality item: %+v", res.Items[0])
+	}
+	if store.lastPageNum != 1 {
+		t.Fatalf("expected default page 1, got %d", store.lastPageNum)
+	}
+}
+
+func TestListPersonalitiesStoreError(t *testing.T) {
+	store := &erroringListStore{}
+	res := runList(t, newTestListTool(store), `{"kind":"personalities"}`)
+	if res.Error == "" {
+		t.Fatalf("expected error from store failure, got %+v", res)
+	}
+}
+
+func TestListSkills(t *testing.T) {
+	store := &fakeListStore{rituals: []*models.Ritual{
+		{ID: uuid.New(), Name: "Standup", Description: "daily sync"},
+	}}
+	res := runList(t, newTestListTool(store), `{"kind":"skills"}`)
+	if res.Kind != listKindSkills || res.Count != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.Items[0].Name != "Standup" || res.Items[0].Description != "daily sync" {
+		t.Fatalf("unexpected skill item: %+v", res.Items[0])
+	}
+}
+
+func TestListSkillsStoreError(t *testing.T) {
+	store := &erroringListStore{}
+	res := runList(t, newTestListTool(store), `{"kind":"skills"}`)
+	if res.Error == "" {
+		t.Fatalf("expected error from store failure, got %+v", res)
+	}
+}
+
+// erroringListStore fails every call, for exercising the fail() paths of each listX helper.
+type erroringListStore struct{}
+
+var errListStoreBoom = errors.New("boom")
+
+func (e *erroringListStore) ListModels(_ context.Context) ([]*models.Model, error) {
+	return nil, errListStoreBoom
+}
+func (e *erroringListStore) ListPersonalities(_ context.Context, _ uuid.UUID, _, _ int, _ models.PersonalityFilters) (*models.PaginatedResponse, error) {
+	return nil, errListStoreBoom
+}
+func (e *erroringListStore) ListRituals(_ context.Context, _ uuid.UUID, _, _ int, _ models.RitualFilters) (*models.PaginatedResponse, error) {
+	return nil, errListStoreBoom
+}
+func (e *erroringListStore) ListFileAttachments(_ context.Context, _ uuid.UUID, _, _ int, _ models.FileAttachmentFilters) (*models.PaginatedResponse, error) {
+	return nil, errListStoreBoom
+}
+func (e *erroringListStore) ListChats(_ context.Context, _ uuid.UUID, _, _ int, _ models.ChatFilters) (*models.PaginatedResponse, error) {
+	return nil, errListStoreBoom
+}
+func (e *erroringListStore) ListAgentJobs(_ context.Context, _ uuid.UUID, _, _ int, _ models.AgentJobFilters) (*models.PaginatedResponse, error) {
+	return nil, errListStoreBoom
+}
+func (e *erroringListStore) ListChatMCPServers(_ context.Context, _, _ uuid.UUID) ([]*models.MCPServer, error) {
+	return nil, errListStoreBoom
 }
 
 func TestListFilesPersonalityScopeWithoutPersonality(t *testing.T) {

--- a/internal/agent/tools/memory_test.go
+++ b/internal/agent/tools/memory_test.go
@@ -1,0 +1,36 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateEmbedding is a thin wrapper over embedding.CreateEmbedding. The
+// cheapest reachable branch is the underlying API-error path: point the
+// client at a server that always answers 400 so the call fails fast with no
+// real network egress.
+func TestCreateEmbedding_APIErrorIsWrapped(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client := openai.NewClient(
+		option.WithBaseURL(server.URL),
+		option.WithAPIKey("test-key"),
+		option.WithMaxRetries(0),
+	)
+	tool := &VectorStoreMemoryTool{oaiClient: &client}
+
+	_, err := tool.CreateEmbedding(context.Background(), "hello")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to generate embedding")
+}

--- a/internal/agent/tools/update_scratchpad_test.go
+++ b/internal/agent/tools/update_scratchpad_test.go
@@ -1,0 +1,25 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
+)
+
+// UpdateScratchpadTool's cheapest branch is the invalid-JSON-args guard,
+// which fires before any datastore access, so datastore can stay nil.
+func TestUpdateScratchpadTool_InvalidArgsReturnsErrorResult(t *testing.T) {
+	t.Parallel()
+
+	tool := &ScratchpadTool{logger: zap.NewNop()}
+	chat := &models.Chat{ID: uuid.New(), UserID: uuid.New(), PersonalityID: uuid.New()}
+
+	out, err := tool.UpdateScratchpadTool(context.Background(), chat, []byte(`not json`))
+	require.NoError(t, err)
+	require.Contains(t, out, "invalid arguments")
+	require.Contains(t, out, `"success":false`)
+}

--- a/internal/agent/web_search_tool_calls_claude_coverage_test.go
+++ b/internal/agent/web_search_tool_calls_claude_coverage_test.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/tools"
+)
+
+const claudeWebSearchMessageJSON = `{
+	"type":"message",
+	"role":"assistant",
+	"content":[
+		{"type":"server_tool_use","id":"srv_01","name":"web_search","input":{"query":"weather NYC"},"caller":{"type":"direct"}},
+		{"type":"web_search_tool_result","tool_use_id":"srv_01","content":[{"type":"web_search_result","title":"Weather","url":"https://example.com/w","encrypted_content":"enc","page_age":"1d"}]},
+		{"type":"text","text":"It is sunny.","citations":[{"type":"web_search_result_location","url":"https://example.com/w","title":"Weather","cited_text":"sunny","encrypted_index":"idx"}]}
+	]
+}`
+
+// --- webSearchToolCallsFromClaudeMessages ---
+
+func TestWebSearchToolCallsFromClaudeMessages_NilMessagesAreSkipped(t *testing.T) {
+	t.Parallel()
+	got := webSearchToolCallsFromClaudeMessages(nil, nil)
+	require.Nil(t, got)
+}
+
+func TestWebSearchToolCallsFromClaudeMessages_ExtractsToolCall(t *testing.T) {
+	t.Parallel()
+	var msg anthropic.Message
+	require.NoError(t, json.Unmarshal([]byte(claudeWebSearchMessageJSON), &msg))
+
+	got := webSearchToolCallsFromClaudeMessages(&msg)
+	require.Len(t, got, 1)
+	require.Equal(t, tools.ToolNameWebSearch, got[0].ToolName)
+	require.Equal(t, "weather NYC", got[0].ToolInput)
+	require.Contains(t, got[0].ToolOutput, "https://example.com/w")
+}
+
+func TestWebSearchToolCallsFromClaudeMessages_NoWebSearchBlockReturnsNil(t *testing.T) {
+	t.Parallel()
+	var msg anthropic.Message
+	require.NoError(t, json.Unmarshal([]byte(`{"type":"message","role":"assistant","content":[{"type":"text","text":"hi"}]}`), &msg))
+
+	got := webSearchToolCallsFromClaudeMessages(&msg)
+	require.Nil(t, got)
+}
+
+// --- webSearchToolCallsFromClaudeBetaMessages ---
+
+const claudeBetaWebSearchMessageJSON = `{
+	"type":"message",
+	"role":"assistant",
+	"content":[
+		{"type":"server_tool_use","id":"srv_01","name":"web_search","input":{"query":"weather NYC"},"caller":{"type":"direct"}},
+		{"type":"web_search_tool_result","tool_use_id":"srv_01","content":[{"type":"web_search_result","title":"Weather","url":"https://example.com/w","encrypted_content":"enc","page_age":"1d"}]},
+		{"type":"text","text":"It is sunny.","citations":[{"type":"web_search_result_location","url":"https://example.com/w","title":"Weather","cited_text":"sunny","encrypted_index":"idx"}]}
+	]
+}`
+
+func TestWebSearchToolCallsFromClaudeBetaMessages_NilMessagesAreSkipped(t *testing.T) {
+	t.Parallel()
+	got := webSearchToolCallsFromClaudeBetaMessages(nil, nil)
+	require.Nil(t, got)
+}
+
+func TestWebSearchToolCallsFromClaudeBetaMessages_ExtractsToolCall(t *testing.T) {
+	t.Parallel()
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(claudeBetaWebSearchMessageJSON), &msg))
+
+	got := webSearchToolCallsFromClaudeBetaMessages(&msg)
+	require.Len(t, got, 1)
+	require.Equal(t, tools.ToolNameWebSearch, got[0].ToolName)
+	require.Equal(t, "weather NYC", got[0].ToolInput)
+	require.Contains(t, got[0].ToolOutput, "https://example.com/w")
+	require.Contains(t, got[0].ToolOutput, "Citations:")
+}
+
+func TestWebSearchToolCallsFromClaudeBetaMessages_NoWebSearchBlockReturnsNil(t *testing.T) {
+	t.Parallel()
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(`{"type":"message","role":"assistant","content":[{"type":"text","text":"hi"}]}`), &msg))
+
+	got := webSearchToolCallsFromClaudeBetaMessages(&msg)
+	require.Nil(t, got)
+}
+
+// --- claudeBetaWebSearchQueryForToolUseID ---
+
+func TestClaudeBetaWebSearchQueryForToolUseID_NilMessageReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", claudeBetaWebSearchQueryForToolUseID(nil, "any"))
+}
+
+func TestClaudeBetaWebSearchQueryForToolUseID_MatchesByID(t *testing.T) {
+	t.Parallel()
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(claudeBetaWebSearchMessageJSON), &msg))
+
+	require.Equal(t, "weather NYC", claudeBetaWebSearchQueryForToolUseID(&msg, "srv_01"))
+	require.Equal(t, "", claudeBetaWebSearchQueryForToolUseID(&msg, "other-id"))
+}
+
+// --- formatClaudeBetaWebSearchToolOutput ---
+
+func TestFormatClaudeBetaWebSearchToolOutput_IncludesQueryAndCitations(t *testing.T) {
+	t.Parallel()
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(claudeBetaWebSearchMessageJSON), &msg))
+
+	var ws anthropic.BetaWebSearchToolResultBlock
+	for _, block := range msg.Content {
+		if v, ok := block.AsAny().(anthropic.BetaWebSearchToolResultBlock); ok {
+			ws = v
+			break
+		}
+	}
+	out := formatClaudeBetaWebSearchToolOutput(&msg, ws)
+	require.Contains(t, out, "Queries: weather NYC")
+	require.Contains(t, out, "https://example.com/w")
+	require.Contains(t, out, "Citations:")
+}
+
+// --- formatClaudeBetaWebSearchCitations / collectClaudeBetaWebSearchCitations ---
+
+func TestFormatClaudeBetaWebSearchCitations_NilMessageReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", formatClaudeBetaWebSearchCitations(nil))
+}
+
+func TestFormatClaudeBetaWebSearchCitations_DedupesRepeatedCitations(t *testing.T) {
+	t.Parallel()
+	raw := `{
+		"type":"message",
+		"role":"assistant",
+		"content":[
+			{"type":"text","text":"a","citations":[
+				{"type":"web_search_result_location","url":"https://example.com/w","title":"Weather","cited_text":"sunny","encrypted_index":"idx"},
+				{"type":"web_search_result_location","url":"https://example.com/w","title":"Weather","cited_text":"sunny again","encrypted_index":"idx2"}
+			]}
+		]
+	}`
+	var msg anthropic.BetaMessage
+	require.NoError(t, json.Unmarshal([]byte(raw), &msg))
+
+	got := formatClaudeBetaWebSearchCitations(&msg)
+	require.Equal(t, 1, countOccurrences(got, "https://example.com/w"))
+}
+
+func countOccurrences(haystack, needle string) int {
+	count := 0
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/agent/web_search_tool_calls_openai_coverage_test.go
+++ b/internal/agent/web_search_tool_calls_openai_coverage_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/tools"
+)
+
+// --- webSearchToolCallsFromOpenAIResponses ---
+
+func TestWebSearchToolCallsFromOpenAIResponses_NilResponsesAreSkipped(t *testing.T) {
+	t.Parallel()
+	got := webSearchToolCallsFromOpenAIResponses(nil, nil)
+	require.Nil(t, got)
+}
+
+func TestWebSearchToolCallsFromOpenAIResponses_IncompleteCallIsSkipped(t *testing.T) {
+	t.Parallel()
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{"output":[
+		{"type":"web_search_call","id":"ws_1","status":"in_progress","action":{"type":"search","query":"weather NYC"}}
+	]}`), &resp))
+
+	got := webSearchToolCallsFromOpenAIResponses(&resp)
+	require.Nil(t, got)
+}
+
+func TestWebSearchToolCallsFromOpenAIResponses_CompletedCallExtractsToolCall(t *testing.T) {
+	t.Parallel()
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{"output":[
+		{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"weather NYC"}},
+		{"type":"message","role":"assistant","status":"completed","content":[
+			{"type":"output_text","text":"It is sunny.","annotations":[
+				{"type":"url_citation","url":"https://example.com/a","title":"Example A","start_index":0,"end_index":1}
+			]}
+		]}
+	]}`), &resp))
+
+	got := webSearchToolCallsFromOpenAIResponses(&resp)
+	require.Len(t, got, 1)
+	require.Equal(t, tools.ToolNameWebSearch, got[0].ToolName)
+	require.Equal(t, "weather NYC", got[0].ToolInput)
+	require.Contains(t, got[0].ToolOutput, "Citations:")
+	require.Contains(t, got[0].ToolOutput, "https://example.com/a")
+}
+
+// --- webSearchInputFromCall ---
+
+func TestWebSearchInputFromCall(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "payload queries win",
+			raw:  `{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"search","queries":["a","b"]}}`,
+			want: "a; b",
+		},
+		{
+			name: "payload single query",
+			raw:  `{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"search","query":"solo"}}`,
+			want: "solo",
+		},
+		{
+			name: "no query anywhere returns empty",
+			raw:  `{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"open_page","url":"https://example.com"}}`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var ws responses.ResponseFunctionWebSearch
+			require.NoError(t, ws.UnmarshalJSON([]byte(tc.raw)))
+			require.Equal(t, tc.want, webSearchInputFromCall(ws))
+		})
+	}
+}
+
+// --- extractOpenAIURLCitations ---
+
+func TestExtractOpenAIURLCitations_NilResponseReturnsNil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, extractOpenAIURLCitations(nil))
+}
+
+func TestExtractOpenAIURLCitations_NoMessageOutputReturnsNil(t *testing.T) {
+	t.Parallel()
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{"output":[{"type":"reasoning"}]}`), &resp))
+	require.Nil(t, extractOpenAIURLCitations(&resp))
+}
+
+func TestExtractOpenAIURLCitations_DedupesRepeatedCitations(t *testing.T) {
+	t.Parallel()
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(`{"output":[
+		{"type":"message","role":"assistant","status":"completed","content":[
+			{"type":"output_text","text":"a","annotations":[
+				{"type":"url_citation","url":"https://example.com/a","title":"Example A","start_index":0,"end_index":1},
+				{"type":"url_citation","url":"https://example.com/a","title":"Example A","start_index":2,"end_index":3}
+			]}
+		]}
+	]}`), &resp))
+
+	got := extractOpenAIURLCitations(&resp)
+	require.Len(t, got, 1)
+	require.Equal(t, "https://example.com/a", got[0].URL)
+}


### PR DESCRIPTION
## Summary

Checkpoint 5 of the coverage push, stacked on the datastore tranches
(#15/#16/#18/#19). Covers `internal/agent`, which required an isolated
git worktree (`what-iff-checkpoint5`) to avoid colliding with the
concurrent datastore work.

The handoff doc's original "18/81 uncovered" figure for
`internal/agent/message.go` was the *union* gap across e2e/API flags,
which need Docker and can't be measured on this machine. Measured with
`go-unit` alone, the real local gap was much larger (54/81 for
message.go, plus more across the rest of the package) — this PR closes
that local gap instead.

**Every function in `internal/agent` that was at 0% coverage at the
start of this checkpoint now has at least one covered branch.** Files
brought from zero/low coverage to substantive coverage:
- `message.go` — all 81 functions now non-zero (was 54/81 zero),
  including provider-dispatch paths tested via `httptest` against real
  provider constructors, and the mock-LLM-backend generation path.
- `thread_rehydration.go`, `mcp_tools.go`, `memory.go` — all previously
  zero-coverage functions covered.
- `chatname.go`, `job_phase.go`, `generate_image_tool.go`,
  `agentjob_run.go`, `mood_context.go`,
  `web_search_tool_calls_claude.go`, `web_search_tool_calls_openai.go`,
  `scratchpad.go`, `subagent_tools.go`, `compaction_event_log.go`,
  `memory_merge_infer.go`, `expression_generation.go`,
  `tools/list_kinds.go`, `first_chat_onboarding_prompt.go`,
  `agent_hooks.go`, `recall_distill.go` — zero-coverage functions
  covered.
- `provider/fileattachment.go`, `provider/claude.go`,
  `provider/openai.go`, `provider/gemini.go`,
  `provider/safety_violation.go` — remaining zero-coverage functions
  covered.
- Final 16 stragglers (`agentjob_schedule.go`, `expression_grid_job.go`,
  `generate_personality.go`, `personality_generation_job.go`,
  `personality_media_job_run.go`, `personality_portrait_generation.go`,
  `personality_portrait_job.go`, `message_sync.go`, `rituals.go`,
  `safety_violation.go`, `image_ritual.go`,
  `message_context_builder.go`, `conversation_summary.go`,
  `tools/create_memory.go`, `tools/memory.go`,
  `tools/update_scratchpad.go`) — each covered via its cheapest
  reachable branch (a guard clause, nil-input check, or datastore-error
  path) rather than a full happy path, since the happy paths need a
  full ent begin/exists-check/insert/eager-reload SQL sequence via
  sqlmock, which is fragile to hand-write and was judged not worth
  forcing.

**Test-quality note, not a behavioral bug:** `internal/agent/provider/openai_test.go`'s
pre-existing duplicate-detection tests called a hand-copied
`testProcessResponseOutput` helper instead of the real
`ProcessResponseOutput`/`dedupeParagraphs`, so ~18 passing tests
contributed zero coverage to the code they were meant to protect. New
tests in this PR exercise the real functions directly; the old tests
were left in place since removing them was out of scope here.

No behavioral bugs found in this checkpoint.

`go-unit` (repo-wide): 45.7% -> 51.7%. `internal/agent` package alone:
25.0% -> 47.1%.

## Test plan

- [x] `ENV=test LLM_BACKEND=mock OPENAI_API_KEY=dummy-ci-key go test ./internal/agent/... -race` green (independently re-verified with a cleared test cache)
- [x] `gofmt -l` / `go vet` clean
- [x] `make test-ci` + `make coverage-summary` confirm 51.7%