### PR TITLE
ci: Compact e2e status comments with vs-main baseline and tested SHA

### DIFF
--- a/.github/actions/e2e-status-comment/action.yml
+++ b/.github/actions/e2e-status-comment/action.yml
@@ -1,13 +1,20 @@
 name: 'Post E2E status comment section'
 description: >-
-  Merges one E2E workflow's results into a single sticky PR comment, as a
-  section keyed by a stable id. Each e2e workflow (mock backend, local-LLM
-  backend, ...) calls this once with its own section id so they land as
-  separate parts of one comment instead of one comment per workflow.
+  Merges one E2E workflow's results into a sticky PR comment, as a section
+  keyed by a stable id. Workflows that share a comment-key land as separate
+  sections of one comment; a workflow with its own comment-key (e.g. the
+  opt-in local-LLM run, which triggers on a different cadence) gets its own
+  sticky comment that updates independently.
 inputs:
   pr:
     description: 'Pull request number to comment on'
     required: true
+  comment-key:
+    description: >-
+      Identity of the sticky comment this section belongs to. Sections
+      sharing a key merge into one comment; a distinct key gets its own.
+    required: false
+    default: 'e2e-status-comment'
   section:
     description: "Stable id for this workflow's section, e.g. mock, local-llm"
     required: true
@@ -25,6 +32,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         PR: ${{ inputs.pr }}
+        COMMENT_KEY: ${{ inputs.comment-key }}
         SECTION: ${{ inputs.section }}
         ORDER: ${{ inputs.order }}
         BODY_FILE: ${{ inputs.body-file }}

--- a/.github/actions/e2e-status-comment/merge_comment.py
+++ b/.github/actions/e2e-status-comment/merge_comment.py
@@ -1,31 +1,47 @@
 #!/usr/bin/env python3
-"""Merge one section into the shared E2E status PR comment.
+"""Merge one section into a sticky E2E status PR comment.
 
 Each e2e workflow owns one section, wrapped in its own markers, inside a
-single sticky comment. This script fetches that comment (if any), replaces
-just the caller's section, and posts or patches the result — so a mock-run
-comment and a local-llm-run comment never overwrite each other, even when
-both workflows finish around the same time.
+sticky comment identified by COMMENT_KEY. This script fetches that comment
+(if any), replaces just the caller's section, and posts or patches the
+result — so two workflows sharing a comment never overwrite each other,
+even when both finish around the same time. Workflows with different
+COMMENT_KEYs get entirely separate comments (the opt-in local-LLM run posts
+its own, since it triggers on a different cadence than the mock suite).
+
+Talks to the API with urllib rather than `gh`: this runs inside whatever
+job called the action, and the e2e container image does not ship gh.
 """
 import json
 import os
 import re
-import subprocess
 import sys
+import urllib.request
 
-TOP_MARKER = "<!-- e2e-status-comment -->"
 SECTION_RE = re.compile(
     r"<!-- e2e-status:([\w-]+):(\d+) -->\n(.*?)\n<!-- /e2e-status:\1 -->",
     re.DOTALL,
 )
 
 
-def run(args, **kwargs):
-    result = subprocess.run(args, capture_output=True, text=True, **kwargs)
-    if result.returncode != 0:
-        print(result.stderr, file=sys.stderr)
+def api(method, path, data=None):
+    base = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    req = urllib.request.Request(
+        path if path.startswith("http") else base + path,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "e2e-status-comment",
+        },
+        data=json.dumps(data).encode() if data is not None else None,
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read() or "null")
+    except urllib.error.HTTPError as e:
+        print(f"{method} {path}: HTTP {e.code}: {e.read().decode(errors='replace')}", file=sys.stderr)
         sys.exit(1)
-    return result.stdout
 
 
 def main():
@@ -34,16 +50,17 @@ def main():
     section = os.environ["SECTION"]
     order = os.environ["ORDER"]
     body_file = os.environ["BODY_FILE"]
+    top_marker = f"<!-- {os.environ.get('COMMENT_KEY') or 'e2e-status-comment'} -->"
 
     with open(body_file) as f:
         new_body = f.read().strip("\n")
 
-    # Most recent 30 comments is enough headroom for a sticky comment that
-    # gets updated in place rather than accumulating one per push.
-    comments = json.loads(run(["gh", "api", f"repos/{repo}/issues/{pr}/comments"]))
+    # 100 comments of headroom is plenty for sticky comments that get
+    # updated in place rather than accumulating one per push.
+    comments = api("GET", f"/repos/{repo}/issues/{pr}/comments?per_page=100")
     existing = None
     for c in comments:
-        if c["body"].startswith(TOP_MARKER):
+        if c["body"].startswith(top_marker):
             existing = c
 
     sections = {}
@@ -58,19 +75,13 @@ def main():
         f"<!-- e2e-status:{sid}:{sorder} -->\n{sbody}\n<!-- /e2e-status:{sid} -->"
         for sid, (sorder, sbody) in sorted(sections.items(), key=lambda kv: kv[1][0])
     ]
-    full_body = TOP_MARKER + "\n\n" + "\n\n".join(blocks) + "\n"
-
-    out_path = "/tmp/e2e-status-comment.md"
-    with open(out_path, "w") as f:
-        f.write(full_body)
+    full_body = top_marker + "\n\n" + "\n\n".join(blocks) + "\n"
 
     if existing:
-        run(["gh", "api", "-X", "PATCH", f"repos/{repo}/issues/comments/{existing['id']}",
-             "-F", f"body=@{out_path}"])
+        api("PATCH", f"/repos/{repo}/issues/comments/{existing['id']}", {"body": full_body})
         print(f"updated comment {existing['id']} (section: {section})")
     else:
-        run(["gh", "api", "-X", "POST", f"repos/{repo}/issues/{pr}/comments",
-             "-F", f"body=@{out_path}"])
+        api("POST", f"/repos/{repo}/issues/{pr}/comments", {"body": full_body})
         print(f"posted new comment (section: {section})")
 
 

--- a/.github/workflows/e2e-local-llm.yml
+++ b/.github/workflows/e2e-local-llm.yml
@@ -256,9 +256,9 @@ jobs:
           echo "baseline: $url"
           echo "file=/tmp/baseline/e2e-summary.json" >> "$GITHUB_OUTPUT"
 
-      # This job's section of the shared status comment — see
-      # .github/actions/e2e-status-comment. e2e-mock.yml posts the `mock`
-      # section of the same comment; this is `local-llm`, ordered after it.
+      # This workflow's own sticky status comment — see
+      # .github/actions/e2e-status-comment. Separate from e2e-mock.yml's
+      # comment (distinct comment-key below) because this run is opt-in.
       - name: Build PR comment section
         id: comment
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
@@ -295,6 +295,10 @@ jobs:
         uses: ./.github/actions/e2e-status-comment
         with:
           pr: ${{ github.event.pull_request.number }}
+          # Its own sticky comment, not a section of the mock suite's: this
+          # run is opt-in and label-triggered, so it appears and updates on
+          # its own cadence rather than inside the per-push mock comment.
+          comment-key: e2e-status-local-llm
           section: local-llm
           order: 20
           body-file: /tmp/comment-section.md

--- a/.github/workflows/e2e-local-llm.yml
+++ b/.github/workflows/e2e-local-llm.yml
@@ -29,6 +29,13 @@ on:
       - 'openapi.yaml'
       - 'go.mod'
       - 'go.sum'
+  # Nightly run on main. Not for per-commit coverage — real inference stays
+  # opt-in on PRs — but so a recent main-branch result always exists: the
+  # nightly uploads the `e2e-summary` artifact the PR comment's "vs main"
+  # column compares against. Offset from e2e-mock.yml's 07:00 nightly so the
+  # two full runs don't compete for runners.
+  schedule:
+    - cron: '30 7 * * *'
   workflow_dispatch:
 
 permissions:
@@ -78,7 +85,7 @@ jobs:
     # to a PR that already carries 'run-local-model' does cause an extra run
     # here (as it does for that job too) — accepted as the cost of a simple
     # condition over a more precise but harder-to-read one.
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-local-model')
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-local-model')
     continue-on-error: true
 
     # Job-level permissions replace, not add to, the workflow-level block —
@@ -87,6 +94,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # Needed to download the `e2e-summary` artifact from this workflow's
+      # latest main (nightly) run — the "vs main" baseline in the PR comment.
+      actions: read
 
     # Runs as root, matching e2e-mock.yml's use of the same image family.
     container:
@@ -190,6 +200,7 @@ jobs:
         run: npx playwright test --config e2e/playwright.config.local-llm.ts --project=chromium-desktop --reporter=html,json
 
       - name: Upload report
+        id: report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
@@ -197,6 +208,53 @@ jobs:
           path: web/app/playwright-report
           retention-days: 7
           if-no-files-found: ignore
+
+      # Same summary/baseline mechanism as e2e-mock.yml's merge job, against
+      # this workflow's own runs: the nightly (and manual dispatch) uploads
+      # the summary, a PR run fetches the newest one for the "vs main"
+      # column. `hashFiles` guards the summary steps because a run that died
+      # before Playwright wrote results.json has nothing to summarize.
+      - name: Summarize results
+        if: ${{ !cancelled() && hashFiles('web/app/results.json') != '' }}
+        working-directory: web/app
+        env:
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: node e2e/scripts/report-summary.mjs summary results.json > e2e-summary.json
+
+      - name: Upload main baseline summary
+        if: ${{ !cancelled() && github.event_name != 'pull_request' && hashFiles('web/app/e2e-summary.json') != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-summary-local-llm
+          path: web/app/e2e-summary.json
+          retention-days: 14
+
+      # curl+jq+python3, not `gh` — this is a container job and the CI image
+      # doesn't ship gh (docker/ci/Dockerfile). Fails open: no baseline just
+      # drops the vs-main column, never the job.
+      - name: Fetch main baseline
+        id: baseline
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API: ${{ github.api_url }}/repos/${{ github.repository }}
+          NAME: e2e-summary-local-llm
+        run: |
+          url=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "$API/actions/artifacts?name=$NAME&per_page=50" \
+            | jq -r '[.artifacts[]
+                      | select(.expired == false and .workflow_run.head_branch == "main")
+                     ][0].archive_download_url // empty')
+          if [ -z "$url" ]; then
+            echo "no main baseline found — comment will omit the vs-main column"
+            exit 0
+          fi
+          curl -sfL -H "Authorization: Bearer $GH_TOKEN" "$url" -o /tmp/baseline.zip
+          python3 -c "import zipfile; zipfile.ZipFile('/tmp/baseline.zip').extractall('/tmp/baseline')"
+          echo "baseline: $url"
+          echo "file=/tmp/baseline/e2e-summary.json" >> "$GITHUB_OUTPUT"
 
       # This job's section of the shared status comment — see
       # .github/actions/e2e-status-comment. e2e-mock.yml posts the `mock`
@@ -207,45 +265,26 @@ jobs:
         working-directory: web/app
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: 'E2E · local LLM (opt-in)'
+          SHA: ${{ github.event.pull_request.head.sha }}
+          SHA_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}
+          REPORT_URL: ${{ steps.report.outputs.artifact-url }}
+          BASELINE_FILE: ${{ steps.baseline.outputs.file }}
+          # Single-project workflow: one `chrome` row (chromium-desktop
+          # against the real local model), no mobile/visual rows to render.
+          SUITES: chrome
         run: |
-          {
-            echo '### E2E (local LLM backend, opt-in)'
-            echo
-
-            if [ ! -f results.json ]; then
-              echo '🚨 **No results** — the job failed before Playwright produced a report.'
+          if [ ! -f results.json ]; then
+            {
+              echo '### E2E · local LLM (opt-in) 🚨'
+              echo
+              echo '**No results** — the job failed before Playwright produced a report.'
               echo
               echo "[View run]($RUN_URL)"
-            else
-              EXPECTED=$(jq -r '.stats.expected' results.json)
-              UNEXPECTED=$(jq -r '.stats.unexpected' results.json)
-              FLAKY=$(jq -r '.stats.flaky' results.json)
-              SKIPPED=$(jq -r '.stats.skipped' results.json)
-              DURATION=$(jq -r '(.stats.duration / 1000 | floor)' results.json)
-
-              if [ "$UNEXPECTED" -gt 0 ]; then
-                echo "❌ **$UNEXPECTED failed**, $EXPECTED passed, $FLAKY flaky, $SKIPPED skipped — ${DURATION}s"
-              elif [ "$FLAKY" -gt 0 ]; then
-                echo "⚠️ **$FLAKY flaky**, $EXPECTED passed, $SKIPPED skipped — ${DURATION}s"
-              else
-                echo "✅ **$EXPECTED passed**, $SKIPPED skipped — ${DURATION}s"
-              fi
-              echo
-
-              if [ "$UNEXPECTED" -gt 0 ]; then
-                echo '<details><summary>Failed tests</summary>'
-                echo
-                jq -r '[.. | objects | select(has("ok") and has("title") and has("tests"))
-                        | select(.ok == false) | .title] | .[]' results.json \
-                  | sed 's/^/- /'
-                echo
-                echo '</details>'
-                echo
-              fi
-
-              echo "[Full HTML report]($RUN_URL#artifacts) · [View run]($RUN_URL)"
-            fi
-          } > /tmp/comment-section.md
+            } > /tmp/comment-section.md
+          else
+            node e2e/scripts/report-summary.mjs comment results.json > /tmp/comment-section.md
+          fi
           cat /tmp/comment-section.md
 
       # Skipped for forks — same reasoning as e2e-mock.yml's identically-named

--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -731,6 +731,9 @@ jobs:
       # Needed to post/update the results comment. Scoped to this job so the
       # shard jobs — which run the actual test code — keep a read-only token.
       pull-requests: write
+      # Needed to download the `e2e-summary` artifact from the latest main
+      # run of this workflow — the "vs main" baseline in the PR comment.
+      actions: read
       # OIDC token for the tokenless Codecov upload — see codecov.yml and
       # pr-validation.yml for the same pattern.
       id-token: write
@@ -988,6 +991,73 @@ jobs:
           npx playwright merge-reports --reporter=json ./all-blobs > merged.json
           echo "merged=true" >> "$GITHUB_OUTPUT"
 
+      # Uploaded before the comment is built so the comment can link the
+      # artifact's real download URL (`artifact-url` output) instead of the
+      # run page's #artifacts anchor, which lands on the wrong tab for runs
+      # with many jobs.
+      - name: Upload merged report
+        id: report
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: web/app/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # The per-suite summary the comment renders and the baseline mechanism
+      # ships: chrome / mobile / visual pass counts plus the SHA and run URL,
+      # produced from the same merged.json as the HTML report.
+      - name: Summarize results
+        if: ${{ steps.merge.outputs.merged == 'true' }}
+        working-directory: web/app
+        env:
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: node e2e/scripts/report-summary.mjs summary merged.json > e2e-summary.json
+
+      # Main runs (merge to main, the nightly, manual dispatch) publish their
+      # summary as the baseline PR runs compare against. Retention outlives
+      # the nightly cadence by a wide margin, so a paused schedule doesn't
+      # immediately cost PRs their "vs main" column.
+      - name: Upload main baseline summary
+        if: ${{ github.event_name != 'pull_request' && steps.merge.outputs.merged == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          # Workflow-specific name: the baseline fetch below queries artifacts
+          # repo-wide by name, and e2e-local-llm.yml publishes its own summary
+          # the same way.
+          name: e2e-summary-mock
+          path: web/app/e2e-summary.json
+          retention-days: 14
+
+      # PR runs fetch the newest main-run summary of this same workflow.
+      # Plain curl+jq+python3 rather than `gh` so the identical step works in
+      # e2e-local-llm.yml's container job, where gh is not installed. Fails
+      # open: no baseline just drops the "vs main" column from the comment,
+      # it never fails the job.
+      - name: Fetch main baseline
+        id: baseline
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API: ${{ github.api_url }}/repos/${{ github.repository }}
+          NAME: e2e-summary-mock
+        run: |
+          url=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "$API/actions/artifacts?name=$NAME&per_page=50" \
+            | jq -r '[.artifacts[]
+                      | select(.expired == false and .workflow_run.head_branch == "main")
+                     ][0].archive_download_url // empty')
+          if [ -z "$url" ]; then
+            echo "no main baseline found — comment will omit the vs-main column"
+            exit 0
+          fi
+          curl -sfL -H "Authorization: Bearer $GH_TOKEN" "$url" -o /tmp/baseline.zip
+          python3 -c "import zipfile; zipfile.ZipFile('/tmp/baseline.zip').extractall('/tmp/baseline')"
+          echo "baseline: $url"
+          echo "file=/tmp/baseline/e2e-summary.json" >> "$GITHUB_OUTPUT"
+
       - name: Build PR comment
         id: comment
         if: ${{ github.event_name == 'pull_request' }}
@@ -997,67 +1067,31 @@ jobs:
           FULL_RUN: ${{ env.FULL_RUN }}
           MERGED: ${{ steps.merge.outputs.merged }}
           FRONTEND: ${{ needs.changes.outputs.frontend }}
+          TITLE: 'E2E · mock LLM'
+          SHA: ${{ github.event.pull_request.head.sha }}
+          SHA_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}
+          REPORT_URL: ${{ steps.report.outputs.artifact-url }}
+          BASELINE_FILE: ${{ steps.baseline.outputs.file }}
         run: |
-          {
-            echo '### E2E (mock backend)'
-            echo
-
-            if [ "$MERGED" != "true" ]; then
-              echo '🚨 **No results** — every shard failed before running any test.'
+          if [ "$MERGED" != "true" ]; then
+            {
+              echo '### E2E · mock LLM 🚨'
+              echo
+              echo '**No results** — every shard failed before running any test.'
               echo
               echo "[View run]($RUN_URL)"
-            else
-
-            EXPECTED=$(jq -r '.stats.expected' merged.json)
-            UNEXPECTED=$(jq -r '.stats.unexpected' merged.json)
-            FLAKY=$(jq -r '.stats.flaky' merged.json)
-            SKIPPED=$(jq -r '.stats.skipped' merged.json)
-            DURATION=$(jq -r '(.stats.duration / 1000 | floor)' merged.json)
-
-            if [ "$UNEXPECTED" -gt 0 ]; then
-              echo "❌ **$UNEXPECTED failed**, $EXPECTED passed, $FLAKY flaky, $SKIPPED skipped — ${DURATION}s"
-            elif [ "$FLAKY" -gt 0 ]; then
-              echo "⚠️ **$FLAKY flaky**, $EXPECTED passed, $SKIPPED skipped — ${DURATION}s"
-            else
-              echo "✅ **$EXPECTED passed**, $SKIPPED skipped — ${DURATION}s"
+            } > /tmp/comment-section.md
+          else
+            # Row notes for suites this run legitimately didn't execute; a
+            # skipped visual run that goes unmentioned reads as a passing one.
+            if [ "$FULL_RUN" != "true" ]; then
+              export NOTE_MOBILE='add the `e2e-full` label'
             fi
-            echo
-
-            if [ "$FULL_RUN" = "true" ]; then
-              echo '**Scope:** all projects (desktop + mobile) — `e2e-full`'
-            else
-              echo '**Scope:** `chromium-desktop` only. Add the **`e2e-full`** label for mobile.'
-            fi
-
-            # Say so explicitly. A skipped visual run that goes unmentioned
-            # reads as a passing one.
             if [ "$FRONTEND" != "true" ]; then
-              echo '**Visual:** skipped — no changes under `web/app/` or `openapi.yaml`.'
+              export NOTE_VISUAL='skipped — no changes under `web/app/` or `openapi.yaml`'
             fi
-            echo
-
-            echo '| Project | Passed |'
-            echo '|---|---|'
-            jq -r '[.. | objects | select(has("projectName") and has("results"))
-                    | {p: .projectName, s: (.results[-1].status // "unknown")}]
-                   | group_by(.p)[]
-                   | "| \(.[0].p) | \([.[] | select(.s == "passed")] | length)/\(length) |"' merged.json
-            echo
-
-            if [ "$UNEXPECTED" -gt 0 ]; then
-              echo '<details><summary>Failed tests</summary>'
-              echo
-              jq -r '[.. | objects | select(has("ok") and has("title") and has("tests"))
-                      | select(.ok == false) | .title] | .[]' merged.json \
-                | sed 's/^/- /'
-              echo
-              echo '</details>'
-              echo
-            fi
-
-            echo "[Full HTML report]($RUN_URL#artifacts) · [View run]($RUN_URL)"
-            fi
-          } > /tmp/comment-section.md
+            node e2e/scripts/report-summary.mjs comment merged.json > /tmp/comment-section.md
+          fi
           cat /tmp/comment-section.md
 
       # Sticky: this workflow's section of the shared comment updates in
@@ -1078,11 +1112,3 @@ jobs:
           section: mock
           order: 10
           body-file: /tmp/comment-section.md
-
-      - name: Upload merged report
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-report
-          path: web/app/playwright-report
-          retention-days: 7
-          if-no-files-found: ignore

--- a/.github/workflows/e2e-mock.yml
+++ b/.github/workflows/e2e-mock.yml
@@ -1096,9 +1096,9 @@ jobs:
 
       # Sticky: this workflow's section of the shared comment updates in
       # place rather than adding one per push, so a long-lived PR doesn't
-      # accumulate a wall of near-identical reports. Other e2e workflows
-      # (e.g. e2e-local-llm.yml) post their own section of the same comment —
-      # see .github/actions/e2e-status-comment.
+      # accumulate a wall of near-identical reports. e2e-local-llm.yml posts
+      # a separate sticky comment of its own (distinct comment-key) since it
+      # is opt-in and label-triggered — see .github/actions/e2e-status-comment.
       #
       # Skipped for forks on purpose. This workflow is `pull_request`, so a
       # fork PR gets a read-only token and posting would fail; the fix is NOT

--- a/web/app/e2e/scripts/report-summary.mjs
+++ b/web/app/e2e/scripts/report-summary.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Turns a Playwright JSON report into (a) a machine-readable per-suite
+ * summary and (b) the markdown section of the sticky E2E status comment.
+ *
+ *   node report-summary.mjs summary <report.json>
+ *     Emits JSON: { sha, run_url, event, duration, suites: { chrome: {...} } }.
+ *     Main-branch CI runs upload this as the `e2e-summary` artifact so PR
+ *     runs can show a "vs main" column.
+ *
+ *   node report-summary.mjs comment <report.json>
+ *     Emits markdown for .github/actions/e2e-status-comment. Reads env:
+ *       TITLE          section heading, e.g. "E2E · mock LLM"
+ *       SHA, SHA_URL   commit actually tested (PR head), linked if URL given
+ *       RUN_URL        the Actions run
+ *       REPORT_URL     direct artifact URL of the HTML report (optional)
+ *       BASELINE_FILE  path to a main-run `summary` JSON (optional)
+ *       NOTE_<SUITE>   note shown for a suite with no results, e.g.
+ *                      NOTE_MOBILE="label `e2e-full`" (optional)
+ *       SUITES         comma-separated rows to always render, in order
+ *                      (default "chrome,mobile,visual")
+ *
+ * Suites are buckets, not Playwright projects: the desktop and mobile
+ * projects each run both functional and visual specs, and the comment wants
+ * "visual" as its own row. Classification:
+ *   - project `setup` is auth bootstrap, not a result — dropped
+ *   - specs under tests/visual/ (recorded relative to testDir as visual/...)
+ *     -> visual, whatever project ran them
+ *   - chromium-desktop -> chrome; chromium-mobile / webkit-mobile -> mobile
+ *   - anything else keeps its project name so a new project cannot silently
+ *     vanish from the comment
+ */
+import { readFileSync } from "node:fs";
+
+const MOBILE_PROJECTS = new Set(["chromium-mobile", "webkit-mobile"]);
+const VISUAL_FILE = /(^|[\\/])visual[\\/]/;
+
+function bucketOf(file, projectName) {
+  if (VISUAL_FILE.test(file)) return "visual";
+  if (projectName === "chromium-desktop") return "chrome";
+  if (MOBILE_PROJECTS.has(projectName)) return "mobile";
+  return projectName || "unknown";
+}
+
+function collect(report) {
+  const suites = {};
+  const failures = [];
+  const visit = (suite, file) => {
+    const here = suite.file || file;
+    for (const spec of suite.specs ?? []) {
+      const specFile = spec.file || here || "";
+      for (const test of spec.tests ?? []) {
+        if (test.projectName === "setup") continue;
+        const bucket = bucketOf(specFile, test.projectName);
+        const s = (suites[bucket] ??= { passed: 0, failed: 0, flaky: 0, skipped: 0 });
+        switch (test.status) {
+          case "expected":
+            s.passed++;
+            break;
+          case "unexpected":
+            s.failed++;
+            failures.push(`${spec.title} (${test.projectName})`);
+            break;
+          case "flaky":
+            s.flaky++;
+            break;
+          default:
+            s.skipped++;
+        }
+      }
+    }
+    for (const child of suite.suites ?? []) visit(child, here);
+  };
+  for (const suite of report.suites ?? []) visit(suite, suite.file);
+  return { suites, failures };
+}
+
+// "✅ 96/96" — passed (flaky counts: it did pass) over everything that ran.
+// Skipped tests are excluded from the denominator; they show in the header.
+function cell(s) {
+  if (!s) return null;
+  const ran = s.passed + s.failed + s.flaky;
+  const icon = s.failed ? "❌" : s.flaky ? "⚠️" : "✅";
+  return `${icon} ${s.passed + s.flaky}/${ran}${s.flaky ? ` (${s.flaky} flaky)` : ""}`;
+}
+
+function baselineCell(s) {
+  if (!s) return "–";
+  const ran = s.passed + s.failed + s.flaky;
+  return `${s.passed + s.flaky}/${ran}${s.failed ? " ❌" : ""}`;
+}
+
+function shortSha(sha) {
+  return (sha || "").slice(0, 7);
+}
+
+function renderComment(report, env) {
+  const { suites, failures } = collect(report);
+  const stats = report.stats ?? {};
+  const duration = Math.floor((stats.duration ?? 0) / 1000);
+
+  let baseline = null;
+  if (env.BASELINE_FILE) {
+    try {
+      baseline = JSON.parse(readFileSync(env.BASELINE_FILE, "utf8"));
+    } catch {
+      /* no baseline: column shows – */
+    }
+  }
+
+  const rows = (env.SUITES || "chrome,mobile,visual")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+  // A bucket the run produced but the row list doesn't name still gets a row.
+  for (const name of Object.keys(suites)) if (!rows.includes(name)) rows.push(name);
+
+  const icon = stats.unexpected ? "❌" : stats.flaky ? "⚠️" : "✅";
+  const out = [];
+  out.push(`### ${env.TITLE || "E2E"} ${icon}`);
+  out.push("");
+
+  const headBits = [];
+  if (stats.unexpected) headBits.push(`**${stats.unexpected} failed**, ${stats.expected} passed`);
+  else headBits.push(`**${stats.expected} passed**`);
+  if (stats.flaky) headBits.push(`${stats.flaky} flaky`);
+  if (stats.skipped) headBits.push(`${stats.skipped} skipped`);
+  let head = `${headBits.join(", ")} · ${duration}s`;
+  if (env.SHA) {
+    const sha = shortSha(env.SHA);
+    head += ` · ${env.SHA_URL ? `[\`${sha}\`](${env.SHA_URL})` : `\`${sha}\``}`;
+  }
+  out.push(head);
+  out.push("");
+
+  const hasBaseline = !!baseline?.suites;
+  out.push(hasBaseline ? "| Suite | This PR | `main` |" : "| Suite | This PR |");
+  out.push(hasBaseline ? "|---|---|---|" : "|---|---|");
+  for (const name of rows) {
+    const mine = cell(suites[name]) ?? `– ${env[`NOTE_${name.toUpperCase().replace(/\W/g, "_")}`] || "not run"}`;
+    out.push(hasBaseline ? `| ${name} | ${mine} | ${baselineCell(baseline.suites[name])} |` : `| ${name} | ${mine} |`);
+  }
+  out.push("");
+
+  if (failures.length) {
+    out.push("<details><summary>Failed tests</summary>");
+    out.push("");
+    for (const f of failures) out.push(`- ${f}`);
+    out.push("");
+    out.push("</details>");
+    out.push("");
+  }
+
+  const links = [];
+  links.push(`[HTML report](${env.REPORT_URL || `${env.RUN_URL}#artifacts`})`);
+  if (env.RUN_URL) links.push(`[run](${env.RUN_URL})`);
+  if (hasBaseline && baseline.sha) {
+    const ref = baseline.run_url ? `[\`${shortSha(baseline.sha)}\`](${baseline.run_url})` : `\`${shortSha(baseline.sha)}\``;
+    links.push(`main baseline: ${ref}${baseline.event === "schedule" ? " (nightly)" : ""}`);
+  } else {
+    links.push("main baseline: none yet");
+  }
+  out.push(links.join(" · "));
+  return out.join("\n") + "\n";
+}
+
+const [mode, reportPath] = process.argv.slice(2);
+if (!mode || !reportPath) {
+  console.error("usage: report-summary.mjs summary|comment <report.json>");
+  process.exit(2);
+}
+const report = JSON.parse(readFileSync(reportPath, "utf8"));
+
+if (mode === "summary") {
+  const { suites } = collect(report);
+  process.stdout.write(
+    JSON.stringify(
+      {
+        sha: process.env.SHA || null,
+        run_url: process.env.RUN_URL || null,
+        event: process.env.EVENT || null,
+        duration: Math.floor((report.stats?.duration ?? 0) / 1000),
+        suites,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+} else if (mode === "comment") {
+  process.stdout.write(renderComment(report, process.env));
+} else {
+  console.error(`unknown mode: ${mode}`);
+  process.exit(2);
+}


### PR DESCRIPTION
Reworks the sticky E2E PR comments into a tighter, more informative view.

## What changed

**One compact table per suite group**, rendered by a new shared script (`web/app/e2e/scripts/report-summary.mjs`) instead of inline jq. Rows are meaningful suites, not raw Playwright project names:

- **chrome** — `chromium-desktop` functional specs
- **mobile** — `chromium-mobile` + `webkit-mobile`
- **visual** — `tests/visual/` specs across projects

The auth `setup` project is excluded from counts, and a suite that didn't run says why inline (`add the e2e-full label`, `skipped — no changes under web/app/`) instead of separate Scope/Visual paragraphs.

**vs-main baseline column.** Main-branch runs (merge to main, the nightly, manual dispatch) upload a small `e2e-summary-{mock,local-llm}` artifact; PR runs fetch the newest one via the artifacts API and render a `main` column plus a link to the baseline run. The fetch fails open — no baseline just drops the column. `e2e-local-llm.yml` had no main-branch trigger at all, so it gains a nightly (07:30, offset from the mock nightly) to produce that baseline; real inference stays opt-in on PRs.

**Tested SHA.** Each comment names the linked PR head commit it actually tested — some of these runs are label-triggered rather than per-push, so the comment can lag the branch.

**Working report links.** `Full HTML report` now uses upload-artifact's `artifact-url` output (the report upload moved ahead of the comment build), a direct link to the artifact instead of the `#artifacts` anchor.

**Separate comments for mock vs local LLM.** They trigger differently (per-push vs `run-local-model` label), so the local-LLM run now maintains its own sticky comment via a new `comment-key` input on the `e2e-status-comment` action, instead of a section of the mock comment.

**Bug fix in passing:** `merge_comment.py` shelled out to `gh`, which the e2e container image doesn't ship — posting from `e2e-local-llm.yml`'s container job would fail, hidden behind that job's `continue-on-error`. It now uses stdlib urllib. The baseline fetch uses curl+jq+python3 for the same reason.

## Example rendering

> ### E2E · mock LLM ✅
> **100 passed**, 7 skipped · 443s · [`abc1234`](https://example.invalid)
>
> | Suite | This PR | `main` |
> |---|---|---|
> | chrome | ✅ 96/96 | 96/96 |
> | mobile | – add the `e2e-full` label | 190/192 ❌ |
> | visual | ✅ 12/12 | 12/12 |
>
> [HTML report](https://example.invalid) · [run](https://example.invalid) · main baseline: [`def5678`](https://example.invalid) (nightly)

## Notes

- The vs-main column won't appear on PRs until the first main run after merge uploads a baseline artifact.
- Script verified against synthetic reports covering pass/fail/flaky/skipped, baseline/no-baseline, and desktop-only runs.