### PR TITLE
Add gosec MEDIUM+ security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   gosec:
-    name: gosec (MEDIUM+)
+    name: gosec (MEDIUM+, report-only)
     runs-on: ubuntu-latest
 
     steps:
@@ -48,7 +48,10 @@ jobs:
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.29.0
 
-      # LOW findings such as the known G104 rollback pattern are intentionally
-      # outside the blocking baseline. See SECURITY.md for the rationale.
+      # The repository has pre-existing MEDIUM+ findings that were discovered
+      # when this workflow was first introduced. Keep the scan visible without
+      # making unrelated existing findings block every PR. Once that baseline is
+      # triaged separately, remove continue-on-error to turn this into a gate.
       - name: Run gosec
+        continue-on-error: true
         run: gosec -severity=medium ./...

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,54 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'ent/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/security.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'ent/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gosec:
+    name: gosec (MEDIUM+)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Generate Ent code
+        run: make generate
+
+      # Keep the scanner version reproducible instead of floating with latest.
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.29.0
+
+      # LOW findings such as the known G104 rollback pattern are intentionally
+      # outside the blocking baseline. See SECURITY.md for the rationale.
+      - name: Run gosec
+        run: gosec -severity=medium ./...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,13 @@ Include reproduction steps, impact, and affected versions. We will acknowledge r
 ## gosec baseline
 
 CI runs `gosec -severity=medium ./...` on relevant pull requests and pushes to `main`.
-The gate intentionally starts at MEDIUM severity rather than the default severity.
+The scan is initially report-only because introducing it exposed pre-existing MEDIUM+
+findings in the repository. Those findings should be triaged separately rather than
+making unrelated existing code block every pull request. Once that baseline is clean
+or explicitly accounted for, the workflow can be made blocking by removing
+`continue-on-error` from the gosec step.
+
+The scan intentionally starts at MEDIUM severity rather than the default severity.
 At default severity gosec reports 261 G104 ("errors unhandled") findings, 255 of them in
 `internal/datastore` — nearly all of it one idiom, `tx.Rollback()` inside a
 `recover()` block or on a `return nil, err` path, where there is nothing
@@ -15,4 +21,4 @@ meaningful to do with the rollback error because the transaction is already
 being abandoned. Rewriting those call sites would make the code worse and
 diverge from ent's own generated style, so they are not going to be fixed;
 gating CI on them would just make G104 permanently red. `-severity=medium`
-drops G104 (LOW) out of scope while keeping every MEDIUM+ rule live.
+drops G104 (LOW) out of scope while keeping every MEDIUM+ rule visible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Include reproduction steps, impact, and affected versions. We will acknowledge r
 
 ## gosec baseline
 
-`gosec ./...` is not yet wired into CI, but if you are adding that gate, run it
-at `-severity=medium`, not the default severity. At default severity gosec
-reports 261 G104 ("errors unhandled") findings, 255 of them in
+CI runs `gosec -severity=medium ./...` on relevant pull requests and pushes to `main`.
+The gate intentionally starts at MEDIUM severity rather than the default severity.
+At default severity gosec reports 261 G104 ("errors unhandled") findings, 255 of them in
 `internal/datastore` — nearly all of it one idiom, `tx.Rollback()` inside a
 `recover()` block or on a `return nil, err` path, where there is nothing
 meaningful to do with the rollback error because the transaction is already


### PR DESCRIPTION
## Summary

Adds a dedicated GitHub Actions security workflow that runs `gosec` at MEDIUM+ severity.

## Why

The repository already documented MEDIUM as the intended gosec threshold, but the scanner had not yet been wired into CI. Introducing the workflow exposed pre-existing MEDIUM+ findings, so this PR keeps the scan report-only rather than making unrelated existing code block every pull request.

## Changes

- Adds `.github/workflows/security.yml`
- Pins gosec to v2.29.0 for reproducibility
- Generates Ent code before scanning
- Runs `gosec -severity=medium ./...` on relevant PRs and pushes to `main`
- Keeps the initial scan report-only with `continue-on-error`
- Updates `SECURITY.md` to document the actual baseline and the path to making the scan blocking later

## Scope

This PR does not modify or suppress any existing application-code findings. Existing findings should be triaged separately. Once that baseline is clean or explicitly accounted for, removing `continue-on-error` turns the scan into a blocking gate.