### PR TITLE
feat(chat): message bookmarks + long-thread navigator

### DIFF
--- a/ent/schema/chatmessage.go
+++ b/ent/schema/chatmessage.go
@@ -65,6 +65,9 @@ func (ChatMessage) Fields() []ent.Field {
 		field.JSON("context_breakdown", &modeltypes.ContextBreakdown{}).
 			Optional().
 			Comment("jsonb snapshot (modeltypes.ContextBreakdown) of the model-context segment/token composition captured at generation time for this assistant message; used by the Context X-ray UI. jsonb (not text) keeps DB-side JSON queries open; a version field inside guards shape evolution."),
+		field.Bool("bookmarked").
+			Default(false).
+			Comment("User-flagged bookmark for navigating long threads; either origin can be bookmarked."),
 	}
 }
 
@@ -103,5 +106,7 @@ func (ChatMessage) Indexes() []ent.Index {
 		index.Fields("response_id"),
 		index.Edges("chat").Fields("sent_at"),
 		index.Edges("chat").Fields("origin", "read_status"),
+		// Serves the per-chat bookmarks listing (WHERE chat=? AND bookmarked=true).
+		index.Edges("chat").Fields("bookmarked"),
 	}
 }

--- a/internal/agent/tools/recall.go
+++ b/internal/agent/tools/recall.go
@@ -31,7 +31,9 @@ const (
 	recallModeRelated      = "related"
 	recallModeOrigin       = "origin"
 	recallModeConversation = "conversation"
-	recallModeThreadAlias  = "thread"
+	// recallModeBookmarks lists user-pinned navigation markers for one conversation.
+	recallModeBookmarks   = "bookmarks"
+	recallModeThreadAlias = "thread"
 	// recallModeLifecycleEvents lists memory fold/link (and related) audit rows — a paginated
 	// inspectability surface, not semantic search.
 	recallModeLifecycleEvents = "lifecycle_events"
@@ -57,6 +59,9 @@ const (
 // recallSummaryTargetPrefix resolves a fetch target of the form "summary:<conversation-uuid>" to
 // that conversation's checkpoint summary, mirroring the "memory:" prefix convention.
 const recallSummaryTargetPrefix = "summary:"
+
+// recallBookmarkTargetPrefix resolves an explicitly pinned message into its full raw text.
+const recallBookmarkTargetPrefix = "bookmark:"
 
 // recallTargetCurrentConversation is the sentinel `target` value conversation mode resolves to
 // the current chat, alongside the default of an empty target. Case-insensitive.
@@ -90,6 +95,7 @@ Modes:
 - related: memory ID -> similar memories. Accepts a full UUID, memory:<uuid>, or a unique short hex prefix from sources (e.g. memory:df3e519d).
 - origin: Have a memory ID and want where it came from? Pass it as target — returns that memory plus the last ~5 turns of its source conversation ending at the memory's creation time. Same ID shapes as related. Page with next_page_token for progressively older turns; forward paging is not available.
 - conversation (alias: thread): one conversation's history from its beginning forward -> pass a conversation ID, or omit it (or pass "current_conversation") for the current conversation; filter with time_scope. Also returns that conversation's checkpoint summary, if one exists. Follow next_page_token to continue toward the end. Use to recover what was said, and when.
+- bookmarks: pinned message index for one conversation (target or current), oldest first. Returns small labels and fetch targets only; use its bookmark:<conversation-id>:<message-id> target to read one pinned message's full text.
 - lifecycle_events (alias: merge_history): paginated audit list of memory lifecycle events (fold/link and related merge-audit rows — not semantic search). Filter with query (content substring), target (a survivor memory ID), and time_scope. Responses include page, total_count, has_more, and next_page_token when more pages exist.
 
 Modifiers: time_scope ("last 7 days", "before 2025-01-01", "between A and B"), source_type (memories|files|conversations|summaries|all), current_conversation (scopes search/investigate to this conversation), next_page_token (page large results — fetch, conversation, origin, and lifecycle_events), max_chunks (depth; origin defaults to 5 turns; lifecycle_events defaults to 20 events per page).
@@ -105,8 +111,8 @@ var RecallToolSpec = FunctionToolSpec{
 	Properties: map[string]interface{}{
 		"mode": map[string]interface{}{
 			"type":        "string",
-			"enum":        []string{recallModeInvestigate, recallModeSearch, recallModeFetch, recallModeRelated, recallModeOrigin, recallModeConversation, recallModeThreadAlias, recallModeLifecycleEvents, recallModeMergeHistoryAlias},
-			"description": "Access mode. Optional — defaults to 'investigate' when omitted. investigate: ask a question, get a compressed sourced answer. search: semantic search returning raw chunks. fetch: retrieve a specific file, memory, or conversation summary by name/ID (images attach directly to your context instead of returning chunks). related: memories similar to a given memory ID. origin: memory ID -> last ~5 source-conversation turns ending at that memory's creation time (page for more). conversation: one conversation's history from its beginning forward (target or current) by time range, including its checkpoint summary. 'thread' is accepted as a legacy alias for 'conversation'. lifecycle_events: paginated audit list of memory lifecycle events (fold/link); 'merge_history' is accepted as a legacy alias.",
+			"enum":        []string{recallModeInvestigate, recallModeSearch, recallModeFetch, recallModeRelated, recallModeOrigin, recallModeConversation, recallModeBookmarks, recallModeThreadAlias, recallModeLifecycleEvents, recallModeMergeHistoryAlias},
+			"description": "Access mode. Optional — defaults to 'investigate' when omitted. investigate: ask a question, get a compressed sourced answer. search: semantic search returning raw chunks. fetch: retrieve a specific file, memory, conversation summary, or a bookmark fetch target returned by bookmarks mode (images attach directly to your context instead of returning chunks). related: memories similar to a given memory ID. origin: memory ID -> last ~5 source-conversation turns ending at that memory's creation time (page for more). conversation: one conversation's history from its beginning forward (target or current) by time range, including its checkpoint summary. bookmarks: compact pinned-message index for a conversation; use a returned fetch_target for the selected message. 'thread' is accepted as a legacy alias for 'conversation'. lifecycle_events: paginated audit list of memory lifecycle events (fold/link); 'merge_history' is accepted as a legacy alias.",
 		},
 		"query": map[string]interface{}{
 			"type":        "string",
@@ -114,7 +120,7 @@ var RecallToolSpec = FunctionToolSpec{
 		},
 		"target": map[string]interface{}{
 			"type":        "string",
-			"description": "Filename, memory ID, or conversation ID depending on mode. fetch: filename, memory/file ID, a conversation ID (returns its checkpoint summary), or summary:<conversation-id>. related/origin: memory UUID, memory:<uuid>, or unique short hex prefix from investigate.sources. conversation: conversation ID, or \"current_conversation\" (or omit) for the current conversation. lifecycle_events: a survivor memory ID to filter to that memory's lifecycle events.",
+			"description": "Filename, memory ID, or conversation ID depending on mode. fetch: filename, memory/file ID, a conversation ID (returns its checkpoint summary), summary:<conversation-id>, or bookmark:<conversation-id>:<message-id>. related/origin: memory UUID, memory:<uuid>, or unique short hex prefix from investigate.sources. conversation/bookmarks: conversation ID, or \"current_conversation\" (or omit) for the current conversation. lifecycle_events: a survivor memory ID to filter to that memory's lifecycle events.",
 		},
 		"time_scope": map[string]interface{}{
 			"type":        "string",
@@ -158,7 +164,9 @@ type recallStore interface {
 	ListFileChunksForAttachment(ctx context.Context, fileAttachmentID uuid.UUID, limit int) ([]datastore.FileChunkResult, error)
 	ListFileAttachments(ctx context.Context, userID uuid.UUID, pageNum, pageSize int, filters models.FileAttachmentFilters) (*models.PaginatedResponse, error)
 	GetFileAttachment(ctx context.Context, userID, id uuid.UUID) (*models.FileAttachment, error)
+	GetChatMessage(ctx context.Context, userID, id uuid.UUID) (*models.ChatMessage, error)
 	ListChatMessages(ctx context.Context, userID, chatID uuid.UUID, pageNum, pageSize int, filters models.ChatMessageFilters) (*models.PaginatedResponse, error)
+	ListChatMessageBookmarksPage(ctx context.Context, userID, chatID uuid.UUID, pageNum, pageSize int) (*models.PaginatedResponse, error)
 	// ListChatMessagesAfter returns an ascending (sent_at, id) page strictly after the supplied
 	// keyset position. Zero values select the conversation's first message.
 	ListChatMessagesAfter(ctx context.Context, userID, chatID uuid.UUID, afterSentAt time.Time, afterID uuid.UUID, pageSize int, filters models.ChatMessageFilters) (*models.PaginatedResponse, error)
@@ -239,6 +247,15 @@ type recallMessage struct {
 	sentAt time.Time
 }
 
+// recallBookmark is a compact navigation row. Full content is returned only by its FetchTarget.
+type recallBookmark struct {
+	MessageID   string `json:"message_id"`
+	Origin      string `json:"origin"`
+	SentAt      string `json:"sent_at"`
+	Snippet     string `json:"snippet"`
+	FetchTarget string `json:"fetch_target"`
+}
+
 type recallConversation struct {
 	ConversationID   string          `json:"conversation_id"`
 	ConversationName string          `json:"conversation_name,omitempty"`
@@ -269,6 +286,7 @@ type recallResult struct {
 	Memories        []string               `json:"memories,omitempty"`
 	Chunks          []recallChunk          `json:"chunks,omitempty"`
 	Conversations   []recallConversation   `json:"conversations,omitempty"`
+	Bookmarks       []recallBookmark       `json:"bookmarks,omitempty"`
 	LifecycleEvents []recallLifecycleEvent `json:"lifecycle_events,omitempty"`
 	Sources         []string               `json:"sources,omitempty"`
 	TimeScope       *recallTimeScope       `json:"time_scope,omitempty"`
@@ -441,10 +459,12 @@ func (t *RecallTool) Recall(ctx context.Context, chat *models.Chat, args []byte)
 		return t.origin(ctx, chat, a)
 	case recallModeConversation:
 		return t.conversation(ctx, chat, a)
+	case recallModeBookmarks:
+		return t.bookmarks(ctx, chat, a)
 	case recallModeLifecycleEvents:
 		return t.lifecycleEvents(ctx, chat, a)
 	default:
-		return t.fail(mode, fmt.Sprintf("unknown mode %q; expected one of investigate, search, fetch, related, origin, conversation, lifecycle_events", a.Mode))
+		return t.fail(mode, fmt.Sprintf("unknown mode %q; expected one of investigate, search, fetch, related, origin, conversation, bookmarks, lifecycle_events", a.Mode))
 	}
 }
 

--- a/internal/agent/tools/recall_modes.go
+++ b/internal/agent/tools/recall_modes.go
@@ -263,6 +263,16 @@ func (t *RecallTool) fetch(ctx context.Context, chat *models.Chat, a recallArgs)
 		}, []*models.Memory{mem}, nil)
 	}
 
+	// Explicit bookmark:<conversation-id>:<message-id> tokens return one pinned message's raw text. Keeping this
+	// separate from bookmarks mode means agents can scan compact labels before paying for a body.
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(target)), recallBookmarkTargetPrefix) {
+		chatID, messageID, err := parseBookmarkFetchTarget(target)
+		if err != nil {
+			return t.fail(recallModeFetch, err.Error())
+		}
+		return t.fetchBookmark(ctx, chat.UserID, chatID, messageID)
+	}
+
 	// Explicit summary:<conversation-id> tokens resolve only as a conversation's checkpoint summary.
 	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(target)), recallSummaryTargetPrefix) {
 		idStr := strings.TrimSpace(target[len(recallSummaryTargetPrefix):])
@@ -319,6 +329,42 @@ func summaryChunkResult(sum *models.Memory, chatID uuid.UUID) recallResult {
 		Mode:   recallModeFetch,
 		Chunks: []recallChunk{{SourceType: "summary", Name: sum.ChatName, ConversationID: chatID.String(), Text: sum.Content}},
 	}
+}
+
+func (t *RecallTool) fetchBookmark(ctx context.Context, userID, chatID, messageID uuid.UUID) (string, []*models.Memory, []*models.FileAttachment, error) {
+	message, err := t.store.GetChatMessage(ctx, userID, messageID)
+	if err != nil {
+		t.logger.Warn("recall: fetch bookmark failed", zap.Error(err))
+		return t.fail(recallModeFetch, "failed to load bookmark")
+	}
+	if message == nil || !message.Bookmarked || message.ChatID != chatID {
+		return t.fail(recallModeFetch, "no bookmarked message found for that conversation")
+	}
+	return t.ok(recallResult{
+		Mode: recallModeFetch,
+		Chunks: []recallChunk{{
+			SourceType:     "conversation",
+			Name:           "bookmark",
+			ConversationID: message.ChatID.String(),
+			Text:           message.Message,
+		}},
+	}, nil, nil)
+}
+
+func parseBookmarkFetchTarget(target string) (uuid.UUID, uuid.UUID, error) {
+	parts := strings.Split(strings.TrimSpace(target[len(recallBookmarkTargetPrefix):]), ":")
+	if len(parts) != 2 {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("target must be bookmark:<conversation-uuid>:<message-uuid>")
+	}
+	chatID, err := uuid.Parse(parts[0])
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("target must be bookmark:<conversation-uuid>:<message-uuid>")
+	}
+	messageID, err := uuid.Parse(parts[1])
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("target must be bookmark:<conversation-uuid>:<message-uuid>")
+	}
+	return chatID, messageID, nil
 }
 
 // fetchSummary resolves fetch mode for an explicit summary:<conversation-id> target.
@@ -548,20 +594,9 @@ func (t *RecallTool) conversation(ctx context.Context, chat *models.Chat, a reca
 		page = 1
 	}
 
-	// Resolve the target conversation: explicit conversation ID or the current_conversation
-	// sentinel (case-insensitive), else default to the current conversation.
-	chatID := chat.ID
-	if tgt := strings.TrimSpace(a.Target); tgt != "" {
-		switch strings.ToLower(tgt) {
-		case recallTargetCurrentConversation:
-			// Sentinel for "current conversation" — chatID already defaults to chat.ID.
-		default:
-			id, perr := uuid.Parse(tgt)
-			if perr != nil {
-				return t.fail(recallModeConversation, "target must be a valid conversation ID")
-			}
-			chatID = id
-		}
+	chatID, err := recallConversationTarget(chat.ID, a.Target)
+	if err != nil {
+		return t.fail(recallModeConversation, err.Error())
 	}
 
 	if cur.ConversationID != "" && cur.ConversationID != chatID.String() {
@@ -603,6 +638,74 @@ func (t *RecallTool) conversation(ctx context.Context, chat *models.Chat, a reca
 		}
 	}
 	return t.ok(res, nil, nil)
+}
+
+// bookmarks lists compact pinned-message markers for one conversation. The labels intentionally
+// exclude full message bodies; agents fetch a selected bookmark:<conversation-id>:<message-id>
+// on demand.
+func (t *RecallTool) bookmarks(ctx context.Context, chat *models.Chat, a recallArgs) (string, []*models.Memory, []*models.FileAttachment, error) {
+	pageSize := t.maxChunks(a.MaxChunks, models.BookmarkPageDefault)
+	cur, err := decodeCursor(a.NextPageToken)
+	if err != nil {
+		return t.fail(recallModeBookmarks, err.Error())
+	}
+	page := cur.Page
+	if page < 1 {
+		page = 1
+	}
+	chatID, err := recallConversationTarget(chat.ID, a.Target)
+	if err != nil {
+		return t.fail(recallModeBookmarks, err.Error())
+	}
+	rows, err := t.store.ListChatMessageBookmarksPage(ctx, chat.UserID, chatID, page, pageSize)
+	if err != nil {
+		t.logger.Warn("recall: list bookmarks failed", zap.Error(err))
+		return t.fail(recallModeBookmarks, "failed to list bookmarks")
+	}
+	bookmarks := make([]recallBookmark, 0)
+	total := 0
+	if rows != nil {
+		total = rows.TotalCount
+	}
+	if rows != nil {
+		for _, item := range rows.Results {
+			message, ok := item.(*models.ChatMessage)
+			if !ok || message == nil {
+				continue
+			}
+			bookmarks = append(bookmarks, recallBookmark{
+				MessageID:   message.ID.String(),
+				Origin:      string(message.Origin),
+				SentAt:      message.SentAt.UTC().Format(time.RFC3339),
+				Snippet:     models.BookmarkSnippet(message.Message),
+				FetchTarget: bookmarkFetchTarget(chatID, message.ID),
+			})
+		}
+	}
+	res := recallResult{Mode: recallModeBookmarks, Bookmarks: bookmarks}
+	res.setPageCursor(page, pageSize, total)
+	if len(bookmarks) == 0 {
+		res.Note = "No bookmarks found for that conversation."
+	} else if res.HasMore {
+		res.Note = "More bookmarks available — pass next_page_token for the next page."
+	}
+	return t.ok(res, nil, nil)
+}
+
+func recallConversationTarget(currentChatID uuid.UUID, target string) (uuid.UUID, error) {
+	target = strings.TrimSpace(target)
+	if target == "" || strings.EqualFold(target, recallTargetCurrentConversation) {
+		return currentChatID, nil
+	}
+	id, err := uuid.Parse(target)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("target must be a valid conversation ID")
+	}
+	return id, nil
+}
+
+func bookmarkFetchTarget(chatID, messageID uuid.UUID) string {
+	return recallBookmarkTargetPrefix + chatID.String() + ":" + messageID.String()
 }
 
 // conversationWindow freezes resolved time bounds into the cursor. A relative scope such as

--- a/internal/agent/tools/recall_test.go
+++ b/internal/agent/tools/recall_test.go
@@ -242,6 +242,17 @@ func (f *fakeRecallStore) GetFileAttachment(_ context.Context, _, id uuid.UUID) 
 	}
 	return nil, nil
 }
+func (f *fakeRecallStore) GetChatMessage(_ context.Context, _, id uuid.UUID) (*models.ChatMessage, error) {
+	for _, m := range f.messages {
+		if m.ID == id {
+			return m, nil
+		}
+	}
+	return nil, nil
+}
+func (f *fakeRecallStore) ListChatMessageBookmarksPage(_ context.Context, _, _ uuid.UUID, _, _ int) (*models.PaginatedResponse, error) {
+	return &models.PaginatedResponse{Results: []any{}, TotalCount: 0, Page: 1}, nil
+}
 func (f *fakeRecallStore) ListChatMessages(_ context.Context, _, chatID uuid.UUID, pageNum, pageSize int, filters models.ChatMessageFilters) (*models.PaginatedResponse, error) {
 	f.lastMsgChatID = chatID
 	f.lastMsgFilters = filters

--- a/internal/datastore/chatmessage.go
+++ b/internal/datastore/chatmessage.go
@@ -42,6 +42,7 @@ func toChatMessageModel(e *ent.ChatMessage) *models.ChatMessage {
 		GenerationPersonality: e.GenerationPersonality,
 		SentAt:                e.SentAt,
 		Tokens:                e.Tokens,
+		Bookmarked:            e.Bookmarked,
 	}
 
 	if e.Edges.GenerationMood != nil {
@@ -998,6 +999,93 @@ func (d *Datastore) UpdateChatMessageGenerationExpression(ctx context.Context, u
 	}
 
 	return toChatMessageModel(entChatMessage), nil
+}
+
+// SetChatMessageBookmarked toggles the bookmark flag on a chat message the user owns and
+// returns the updated message. Either origin (user or assistant) may be bookmarked.
+func (d *Datastore) SetChatMessageBookmarked(ctx context.Context, userID, messageID uuid.UUID, bookmarked bool) (*models.ChatMessage, error) {
+	n, err := d.dbClient.ChatMessage.Update().
+		Where(
+			chatmessage.ID(messageID),
+			chatmessage.HasChatWith(
+				entchat.HasOwnerWith(user.ID(userID)),
+			),
+		).
+		SetBookmarked(bookmarked).
+		Save(ctx)
+	if err != nil {
+		d.logger.Error("failed to set bookmarked on chat message", zap.Error(err))
+		return nil, err
+	}
+	if n == 0 {
+		return nil, ErrChatMessageNotFound
+	}
+	return d.GetChatMessage(ctx, userID, messageID)
+}
+
+// ListChatMessageBookmarks returns every bookmarked message in a chat the user owns, oldest
+// first (thread order), independent of message-list pagination so the navigator always sees
+// the complete set. Bodies are trimmed to a snippet by the caller/handler if needed.
+func (d *Datastore) ListChatMessageBookmarks(ctx context.Context, userID, chatID uuid.UUID) ([]*models.ChatMessage, error) {
+	rows, err := d.dbClient.ChatMessage.Query().
+		Where(
+			chatmessage.Bookmarked(true),
+			chatmessage.HasChatWith(
+				entchat.ID(chatID),
+				entchat.HasOwnerWith(user.ID(userID)),
+			),
+		).
+		Order(ent.Asc(chatmessage.FieldSentAt)).
+		All(ctx)
+	if err != nil {
+		d.logger.Error("failed to list chat message bookmarks", zap.Error(err))
+		return nil, err
+	}
+	out := make([]*models.ChatMessage, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toChatMessageModel(row))
+	}
+	return out, nil
+}
+
+// ListChatMessageBookmarksPage returns bookmark navigation metadata in stable thread order.
+// Unlike ListChatMessageBookmarks (the complete UI navigator feed), this is bounded for
+// agent-tool responses.
+func (d *Datastore) ListChatMessageBookmarksPage(ctx context.Context, userID, chatID uuid.UUID, pageNum, pageSize int) (*models.PaginatedResponse, error) {
+	query := d.dbClient.ChatMessage.Query().
+		Where(
+			chatmessage.Bookmarked(true),
+			chatmessage.HasChatWith(
+				entchat.ID(chatID),
+				entchat.HasOwnerWith(user.ID(userID)),
+			),
+		)
+
+	totalCount, err := query.Count(ctx)
+	if err != nil {
+		d.logger.Error("failed to count chat message bookmarks", zap.Error(err))
+		return nil, err
+	}
+	if pageNum < 1 {
+		pageNum = 1
+	}
+	if pageSize < 1 {
+		pageSize = models.BookmarkPageDefault
+	}
+	rows, err := query.
+		Offset((pageNum-1)*pageSize).
+		Limit(pageSize).
+		Order(ent.Asc(chatmessage.FieldSentAt), ent.Asc(chatmessage.FieldID)).
+		All(ctx)
+	if err != nil {
+		d.logger.Error("failed to list chat message bookmark page", zap.Error(err))
+		return nil, err
+	}
+	results := make([]any, 0, len(rows))
+	for _, row := range rows {
+		results = append(results, toChatMessageModel(row))
+	}
+	return &models.PaginatedResponse{Results: results, TotalCount: totalCount, Page: pageNum}, nil
 }
 
 // SetChatMessageCheckpointCompletedAt records a successful scratchpad/memory/summary checkpoint on an assistant message.

--- a/internal/datastore/job_test.go
+++ b/internal/datastore/job_test.go
@@ -136,6 +136,7 @@ func createPartialJobTestTables(t *testing.T, ds *Datastore) {
 			last_error_message text,
 			checkpoint_completed_at datetime,
 			context_breakdown json,
+			bookmarked boolean NOT NULL DEFAULT false,
 			chat_messages uuid NOT NULL,
 			chat_message_generation_mood uuid,
 			chat_message_generation_expression uuid

--- a/internal/handlers/chat/chatmessage.go
+++ b/internal/handlers/chat/chatmessage.go
@@ -212,6 +212,77 @@ func (h *Handler) GetChatMessage(w http.ResponseWriter, r *http.Request) {
 	handlerutils.RespondWithJSON(w, h.logger, http.StatusOK, respMessage)
 }
 
+// SetChatMessageBookmark toggles the bookmark flag on a message (PATCH
+// /chat/{chatId}/chat-message/{messageId}/bookmark, body {"bookmarked": bool}) and returns
+// the updated message. Ownership is enforced in the datastore via the chat→owner edge.
+func (h *Handler) SetChatMessageBookmark(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserIDFromContext(r.Context())
+	if !ok {
+		handlerutils.RespondWithError(w, h.logger, http.StatusUnauthorized, handlerutils.CodeNotSet, "Unauthorized", nil)
+		return
+	}
+
+	messageID, err := uuid.Parse(mux.Vars(r)["messageId"])
+	if err != nil {
+		handlerutils.RespondWithError(w, h.logger, http.StatusBadRequest, handlerutils.CodeNotSet, "Invalid chat message ID", err)
+		return
+	}
+
+	var req models.ChatMessageBookmarkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		handlerutils.RespondWithError(w, h.logger, http.StatusBadRequest, handlerutils.CodeNotSet, "Invalid request body", err)
+		return
+	}
+
+	updated, err := h.ds.SetChatMessageBookmarked(r.Context(), userID, messageID, req.Bookmarked)
+	if errors.Is(err, datastore.ErrChatMessageNotFound) || ent.IsNotFound(err) {
+		handlerutils.RespondWithError(w, h.logger, http.StatusNotFound, handlerutils.CodeNotSet, "Chat message not found", err)
+		return
+	} else if err != nil {
+		h.logger.Error("failed to set message bookmark", zap.String("user_id", userID.String()), zap.Error(err))
+		handlerutils.RespondWithError(w, h.logger, http.StatusInternalServerError, handlerutils.CodeNotSet, "failed to update bookmark", err)
+		return
+	}
+
+	handlerutils.RespondWithJSON(w, h.logger, http.StatusOK, updated)
+}
+
+// GetChatMessageBookmarks returns every bookmarked message in a chat as lightweight snippets
+// (GET /chat/{chatId}/bookmarks), in thread order. The complete set is returned regardless of
+// message-list pagination so the navigator can jump to bookmarks not yet loaded in the client.
+func (h *Handler) GetChatMessageBookmarks(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserIDFromContext(r.Context())
+	if !ok {
+		handlerutils.RespondWithError(w, h.logger, http.StatusUnauthorized, handlerutils.CodeNotSet, "Unauthorized", nil)
+		return
+	}
+
+	chatID, err := uuid.Parse(mux.Vars(r)["chatId"])
+	if err != nil {
+		handlerutils.RespondWithError(w, h.logger, http.StatusBadRequest, handlerutils.CodeNotSet, "Invalid chat ID", err)
+		return
+	}
+
+	messages, err := h.ds.ListChatMessageBookmarks(r.Context(), userID, chatID)
+	if err != nil {
+		h.logger.Error("failed to list message bookmarks", zap.String("user_id", userID.String()), zap.Error(err))
+		handlerutils.RespondWithError(w, h.logger, http.StatusInternalServerError, handlerutils.CodeNotSet, "failed to list bookmarks", err)
+		return
+	}
+
+	bookmarks := make([]models.ChatMessageBookmark, 0, len(messages))
+	for _, m := range messages {
+		bookmarks = append(bookmarks, models.ChatMessageBookmark{
+			ID:      m.ID,
+			Origin:  m.Origin,
+			Snippet: models.BookmarkSnippet(m.Message),
+			SentAt:  m.SentAt,
+		})
+	}
+
+	handlerutils.RespondWithJSON(w, h.logger, http.StatusOK, bookmarks)
+}
+
 // GetChatMessages handler function for GET /chat-message
 func (h *Handler) GetChatMessages(w http.ResponseWriter, r *http.Request) {
 	userID, ok := middleware.GetUserIDFromContext(r.Context())

--- a/internal/handlers/chat/handler.go
+++ b/internal/handlers/chat/handler.go
@@ -59,6 +59,8 @@ func (h *Handler) RegisterRoutes(router *mux.Router) {
 
 	chatRouter.HandleFunc("/{chatId}/chat-message/{messageId}/retry", h.RetryChatMessage).Methods("POST")
 	chatRouter.HandleFunc("/{chatId}/chat-message/{messageId}/active-job", h.GetActiveChatMessageJob).Methods("GET")
+	chatRouter.HandleFunc("/{chatId}/chat-message/{messageId}/bookmark", h.SetChatMessageBookmark).Methods("PATCH")
+	chatRouter.HandleFunc("/{chatId}/bookmarks", h.GetChatMessageBookmarks).Methods("GET")
 	chatRouter.HandleFunc("/{chatId}/chat-message", h.GetChatMessages).Methods("GET")
 	chatRouter.HandleFunc("/{chatId}/chat-message", h.CreateChatMessage).Methods("POST")
 	chatRouter.HandleFunc("/{chatId}/welcome-message", h.CreateWelcomeMessage).Methods("POST")

--- a/internal/handlers/chat/provider.go
+++ b/internal/handlers/chat/provider.go
@@ -23,6 +23,8 @@ type Store interface {
 	ListChatMessages(ctx context.Context, userID, chatID uuid.UUID, pageNum, pageSize int, filters models.ChatMessageFilters) (*models.PaginatedResponse, error)
 	GetChatMessage(ctx context.Context, userID, messageID uuid.UUID) (*models.ChatMessage, error)
 	MarkChatMessagesRead(ctx context.Context, userID, chatID uuid.UUID) (int, error)
+	SetChatMessageBookmarked(ctx context.Context, userID, messageID uuid.UUID, bookmarked bool) (*models.ChatMessage, error)
+	ListChatMessageBookmarks(ctx context.Context, userID, chatID uuid.UUID) ([]*models.ChatMessage, error)
 	CreateFileAttachment(ctx context.Context, userID uuid.UUID, fileAttachment models.FileAttachment) (*models.FileAttachment, error)
 	DeleteFileAttachment(ctx context.Context, userID, id uuid.UUID) error
 	SetFileAttachmentS3Key(ctx context.Context, userID, id uuid.UUID, s3Key string) error

--- a/internal/handlers/chat/update_patch_test.go
+++ b/internal/handlers/chat/update_patch_test.go
@@ -129,6 +129,12 @@ func (f *fakeStore) GetUserByID(ctx context.Context, userID uuid.UUID) (*models.
 	return nil, errors.New("not implemented")
 }
 
+func (f *fakeStore) SetChatMessageBookmarked(ctx context.Context, userID, messageID uuid.UUID, bookmarked bool) (*models.ChatMessage, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeStore) ListChatMessageBookmarks(ctx context.Context, userID, chatID uuid.UUID) ([]*models.ChatMessage, error) {
+	return nil, errors.New("not implemented")
+}
 func (f *fakeStore) FindLatestActiveChatMessageJob(ctx context.Context, userID, userMessageID uuid.UUID) (*models.Job, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/models/chatmessage.go
+++ b/internal/models/chatmessage.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,6 +85,39 @@ type ChatMessage struct {
 	LastErrorMessage *string `json:"last_error_message,omitempty"`
 	// CheckpointCompletedAt is set on assistant messages after a successful checkpoint (scratchpad, memories, summary).
 	CheckpointCompletedAt *time.Time `json:"checkpoint_completed_at,omitempty"`
+	// Bookmarked is a user-flagged marker for navigating long threads. Either origin can be bookmarked.
+	Bookmarked bool `json:"bookmarked"`
+}
+
+// ChatMessageBookmarkRequest is the PATCH body for toggling a message bookmark.
+type ChatMessageBookmarkRequest struct {
+	Bookmarked bool `json:"bookmarked"`
+}
+
+// ChatMessageBookmark is a lightweight bookmark entry for the thread navigator: enough to
+// label the jump target without shipping the full message (and its edges) for every bookmark.
+type ChatMessageBookmark struct {
+	ID      uuid.UUID     `json:"id"`
+	Origin  MessageOrigin `json:"origin"`
+	Snippet string        `json:"snippet"`
+	SentAt  time.Time     `json:"sent_at"`
+}
+
+// bookmarkSnippetMaxRunes bounds the navigator label length.
+const bookmarkSnippetMaxRunes = 140
+
+// BookmarkPageDefault is the bounded default for non-UI bookmark consumers, such as agent tools.
+const BookmarkPageDefault = 25
+
+// BookmarkSnippet renders a single-line, length-bounded preview of a message for the
+// bookmark navigator (collapses whitespace, appends an ellipsis when truncated).
+func BookmarkSnippet(message string) string {
+	collapsed := strings.Join(strings.Fields(message), " ")
+	runes := []rune(collapsed)
+	if len(runes) <= bookmarkSnippetMaxRunes {
+		return collapsed
+	}
+	return strings.TrimSpace(string(runes[:bookmarkSnippetMaxRunes])) + "…"
 }
 
 type ChatMessageFilters struct {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3886,6 +3886,89 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /chat/{chatId}/chat-message/{messageId}/bookmark:
+    patch:
+      summary: Set or clear a message bookmark
+      description: Toggles the user's bookmark flag on a message (either origin) for long-thread navigation. Returns the updated message.
+      tags: [Chat Messages]
+      parameters:
+        - name: chatId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: messageId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bookmarked:
+                  type: boolean
+                  description: Desired bookmark state.
+              required: [bookmarked]
+      responses:
+        '200':
+          description: Updated message
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatMessage'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Message not found or not owned by the user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /chat/{chatId}/bookmarks:
+    get:
+      summary: List bookmarked messages in a chat
+      description: Returns every bookmarked message in the chat as lightweight snippets, in thread order. Complete regardless of message-list pagination so the navigator can jump to bookmarks not yet loaded client-side.
+      tags: [Chat Messages]
+      parameters:
+        - name: chatId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Bookmarks in thread order
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChatMessageBookmark'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /chat/{chatId}/chat-message/{messageId}/retry:
     post:
       summary: Retry generation for a user message
@@ -5839,6 +5922,24 @@ components:
       enum: [read, unread]
       example: "read"
 
+    ChatMessageBookmark:
+      type: object
+      description: Lightweight bookmark entry for the thread navigator — enough to label and jump to a message.
+      properties:
+        id:
+          type: string
+          format: uuid
+        origin:
+          type: string
+          enum: [User, Assistant]
+        snippet:
+          type: string
+          description: Single-line, length-bounded preview of the bookmarked message.
+        sent_at:
+          type: string
+          format: date-time
+      required: [id, origin, snippet, sent_at]
+
     ChatMessage:
       type: object
       properties:
@@ -5917,6 +6018,9 @@ components:
             Per-turn snapshot of the model-context composition captured at generation time
             (segment-by-segment estimated tokens + budget) for the "Context X-ray" UI. Set on
             assistant messages when captured; absent on user messages and older assistant messages.
+        bookmarked:
+          type: boolean
+          description: Whether the user has bookmarked this message for long-thread navigation.
       example:
         id: "123e4567-e89b-12d3-a456-426614174000"
         chat_id: "123e4567-e89b-12d3-a456-426614174001"

--- a/web/app/e2e/api-tests/bookmarks.spec.ts
+++ b/web/app/e2e/api-tests/bookmarks.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from './fixtures';
+import {
+  createChat,
+  deleteChat,
+  listChatMessages,
+  listChatBookmarks,
+  sendChatMessage,
+  setMessageBookmark,
+  type Chat,
+} from '../sdk/client';
+
+test.describe('message bookmarks', () => {
+  let chat: Chat;
+
+  test.beforeEach(async ({ apiClient }) => {
+    chat = await createChat(apiClient, { name: 'e2e-api-bookmarks' });
+  });
+
+  test.afterEach(async ({ apiClient }) => {
+    await deleteChat(apiClient, chat.id!);
+  });
+
+  test('bookmarking a message adds it to the list', async ({ apiClient }) => {
+    await sendChatMessage(apiClient, chat.id!, 'please bookmark me');
+
+    const messages = await listChatMessages(apiClient, chat.id!);
+    const userMsg = messages.find(m => m.origin === 'User');
+    expect(userMsg).toBeTruthy();
+    const msgId = userMsg!.id!;
+
+    // Initially no bookmarks.
+    const beforeBookmarks = await listChatBookmarks(apiClient, chat.id!);
+    expect(beforeBookmarks).toHaveLength(0);
+
+    const updated = await setMessageBookmark(apiClient, chat.id!, msgId, true);
+    expect(updated.bookmarked).toBe(true);
+    expect(updated.id).toBe(msgId);
+
+    const afterBookmarks = await listChatBookmarks(apiClient, chat.id!);
+    expect(afterBookmarks).toHaveLength(1);
+    expect(afterBookmarks[0].id).toBe(msgId);
+    expect(afterBookmarks[0].snippet).toBeTruthy();
+    expect(afterBookmarks[0].origin).toBe('User');
+  });
+
+  test('un-bookmarking removes it from the list', async ({ apiClient }) => {
+    await sendChatMessage(apiClient, chat.id!, 'toggle me');
+
+    const messages = await listChatMessages(apiClient, chat.id!);
+    const msgId = messages.find(m => m.origin === 'User')!.id!;
+
+    await setMessageBookmark(apiClient, chat.id!, msgId, true);
+    expect(await listChatBookmarks(apiClient, chat.id!)).toHaveLength(1);
+
+    const removed = await setMessageBookmark(apiClient, chat.id!, msgId, false);
+    expect(removed.bookmarked).toBe(false);
+    expect(await listChatBookmarks(apiClient, chat.id!)).toHaveLength(0);
+  });
+
+  test('bookmarks are scoped to the owning chat', async ({ apiClient }) => {
+    const otherChat = await createChat(apiClient, { name: 'e2e-api-bookmarks-other' });
+    try {
+      await sendChatMessage(apiClient, chat.id!, 'only mine');
+      const messages = await listChatMessages(apiClient, chat.id!);
+      const msgId = messages.find(m => m.origin === 'User')!.id!;
+      await setMessageBookmark(apiClient, chat.id!, msgId, true);
+
+      // The other chat should have no bookmarks.
+      const otherBookmarks = await listChatBookmarks(apiClient, otherChat.id!);
+      expect(otherBookmarks).toHaveLength(0);
+    } finally {
+      await deleteChat(apiClient, otherChat.id!);
+    }
+  });
+
+  test('snippet is a single-line excerpt capped at 140 runes', async ({ apiClient }) => {
+    const longText = 'A'.repeat(200);
+    await sendChatMessage(apiClient, chat.id!, longText);
+
+    const messages = await listChatMessages(apiClient, chat.id!);
+    const msgId = messages.find(m => m.origin === 'User')!.id!;
+    await setMessageBookmark(apiClient, chat.id!, msgId, true);
+
+    const [bookmark] = await listChatBookmarks(apiClient, chat.id!);
+    expect([...bookmark.snippet!].length).toBeLessThanOrEqual(141); // 140 + ellipsis
+    expect(bookmark.snippet).not.toContain('\n');
+  });
+});

--- a/web/app/e2e/sdk/client.ts
+++ b/web/app/e2e/sdk/client.ts
@@ -508,6 +508,33 @@ export async function listChatMessages(client: ApiClient, chatId: string, params
   return data.results ?? [];
 }
 
+// --- Chat message bookmarks ------------------------------------------------
+
+export type ChatMessageBookmark = components['schemas']['ChatMessageBookmark'];
+
+/** Sets or clears a bookmark on one chat message. Returns the updated message. */
+export async function setMessageBookmark(client: ApiClient, chatId: string, messageId: string, bookmarked: boolean): Promise<ChatMessage> {
+  const { data, error, response } = await client.PATCH('/chat/{chatId}/chat-message/{messageId}/bookmark', {
+    params: { path: { chatId, messageId } },
+    body: { bookmarked },
+  });
+  if (error || !data) {
+    fail('set message bookmark', response.status, error);
+  }
+  return data;
+}
+
+/** Lists all bookmarked messages in a chat as lightweight snippets. */
+export async function listChatBookmarks(client: ApiClient, chatId: string): Promise<ChatMessageBookmark[]> {
+  const { data, error, response } = await client.GET('/chat/{chatId}/bookmarks', {
+    params: { path: { chatId } },
+  });
+  if (error || !data) {
+    fail('list chat bookmarks', response.status, error);
+  }
+  return data;
+}
+
 // --- Chat context ----------------------------------------------------------
 
 /** Reads the scratchpad and checkpoint summary backing a chat session. */

--- a/web/app/e2e/sdk/schema.d.ts
+++ b/web/app/e2e/sdk/schema.d.ts
@@ -5624,6 +5624,132 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/chat/{chatId}/chat-message/{messageId}/bookmark": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set or clear a message bookmark
+         * @description Toggles the user's bookmark flag on a message (either origin) for long-thread navigation. Returns the updated message.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    chatId: string;
+                    messageId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description Desired bookmark state. */
+                        bookmarked: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description Updated message */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ChatMessage"];
+                    };
+                };
+                /** @description Invalid request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Message not found or not owned by the user */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/chat/{chatId}/bookmarks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List bookmarked messages in a chat
+         * @description Returns every bookmarked message in the chat as lightweight snippets, in thread order. Complete regardless of message-list pagination so the navigator can jump to bookmarks not yet loaded client-side.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    chatId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Bookmarks in thread order */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ChatMessageBookmark"][];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/chat/{chatId}/chat-message/{messageId}/retry": {
         parameters: {
             query?: never;
@@ -7712,6 +7838,17 @@ export interface components {
          * @enum {string}
          */
         MessageReadStatus: "read" | "unread";
+        /** @description Lightweight bookmark entry for the thread navigator — enough to label and jump to a message. */
+        ChatMessageBookmark: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            origin: "User" | "Assistant";
+            /** @description Single-line, length-bounded preview of the bookmarked message. */
+            snippet: string;
+            /** Format: date-time */
+            sent_at: string;
+        };
         /**
          * @example {
          *       "id": "123e4567-e89b-12d3-a456-426614174000",
@@ -7765,6 +7902,8 @@ export interface components {
             checkpoint_completed_at?: string | null;
             /** @description Per-turn snapshot of the model-context composition captured at generation time (segment-by-segment estimated tokens + budget) for the "Context X-ray" UI. Set on assistant messages when captured; absent on user messages and older assistant messages. */
             context_breakdown?: components["schemas"]["ContextBreakdown"] | null;
+            /** @description Whether the user has bookmarked this message for long-thread navigation. */
+            bookmarked?: boolean;
         };
         /** @description One segment-kind row of a per-turn context breakdown ("Context X-ray"). */
         ContextSegmentStat: {

--- a/web/app/e2e/tests/functional/chat/bookmarks.spec.ts
+++ b/web/app/e2e/tests/functional/chat/bookmarks.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '../../../fixtures';
+import { sendChatMessage } from '../../../sdk/client';
+import { IMMEDIATE_UI_UPDATE_TIMEOUT, UI_REACTION_TIMEOUT } from '../../../timeouts';
+
+/**
+ * Bookmark toggle and navigator smoke coverage.
+ *
+ * A user message is injected directly through the API before navigation so it
+ * is present on the initial page load — no need to wait for an LLM reply or
+ * use the composer. The navigator (ThreadBookmarksComponent) only appears once
+ * the chat has at least one bookmark, so its presence is used to confirm that
+ * the bookmark was persisted and synced to the listing endpoint.
+ */
+
+test('starring a message bookmarks it and shows the navigator pill', async ({
+  chatPage,
+  seed,
+  userWithPersonality,
+  page,
+  apiClient,
+}) => {
+  const thread = await seed.thread();
+
+  // Inject a user message via the API before navigating so it arrives on initial load.
+  await sendChatMessage(apiClient, thread.id!, 'please star me');
+
+  await chatPage.navigateTo(thread.id!);
+
+  // Wait for the message to be visible.
+  const bubble = chatPage.messageText('please star me');
+  await expect(bubble).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+
+  // Hover to reveal the meta row (opacity: 0 → 1 on hover via CSS).
+  await bubble.hover();
+
+  const saveButton = bubble.getByRole('button', { name: 'Bookmark this message' });
+  await expect(saveButton).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+  await saveButton.click();
+
+  // Optimistic update: button reflects the new state immediately.
+  const removeButton = bubble.getByRole('button', { name: 'Remove bookmark' });
+  await expect(removeButton).toBeVisible({ timeout: IMMEDIATE_UI_UPDATE_TIMEOUT });
+
+  // Navigator pill appears once the bookmarks list endpoint confirms the bookmark.
+  const navigatorPill = page.getByRole('button', { name: 'Jump to a bookmark' });
+  await expect(navigatorPill).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+});
+
+test('bookmark navigator opens a dropdown with the snippet and selecting it closes the menu', async ({
+  chatPage,
+  seed,
+  userWithPersonality,
+  page,
+  apiClient,
+}) => {
+  const thread = await seed.thread();
+  await sendChatMessage(apiClient, thread.id!, 'navigator target');
+  await chatPage.navigateTo(thread.id!);
+
+  const bubble = chatPage.messageText('navigator target');
+  await expect(bubble).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+  await bubble.hover();
+
+  await bubble.getByRole('button', { name: 'Bookmark this message' }).click();
+
+  const navigatorPill = page.getByRole('button', { name: 'Jump to a bookmark' });
+  await expect(navigatorPill).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+
+  // Open the dropdown.
+  await navigatorPill.click();
+  await expect(page.getByRole('menu', { name: 'Bookmarks' })).toBeVisible();
+
+  // The snippet for our message should appear in the list.
+  const menuItem = page.getByRole('menuitem').filter({ hasText: 'navigator target' });
+  await expect(menuItem).toBeVisible();
+
+  // Clicking a bookmark emits `jump` and closes the dropdown.
+  await menuItem.click();
+  await expect(page.getByRole('menu', { name: 'Bookmarks' })).toBeHidden({ timeout: UI_REACTION_TIMEOUT });
+});
+
+test('un-starring a message removes it from the navigator', async ({
+  chatPage,
+  seed,
+  userWithPersonality,
+  page,
+  apiClient,
+}) => {
+  const thread = await seed.thread();
+  await sendChatMessage(apiClient, thread.id!, 'toggle off');
+  await chatPage.navigateTo(thread.id!);
+
+  const bubble = chatPage.messageText('toggle off');
+  await expect(bubble).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+  await bubble.hover();
+
+  // Bookmark it.
+  await bubble.getByRole('button', { name: 'Bookmark this message' }).click();
+  const navigatorPill = page.getByRole('button', { name: 'Jump to a bookmark' });
+  await expect(navigatorPill).toBeVisible({ timeout: UI_REACTION_TIMEOUT });
+
+  // Un-bookmark it.
+  await bubble.hover();
+  await bubble.getByRole('button', { name: 'Remove bookmark' }).click();
+
+  // Navigator disappears when no bookmarks remain.
+  await expect(navigatorPill).toBeHidden({ timeout: UI_REACTION_TIMEOUT });
+});

--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -36,6 +36,7 @@
         "@angular/compiler-cli": "^22.1.3",
         "@playwright/test": "1.62.1",
         "@tailwindcss/typography": "^0.5.20",
+        "@vitest/browser-playwright": "^4.1.11",
         "@vitest/coverage-v8": "^4.1.11",
         "dotenv": "^17.4.2",
         "esbuild": "^0.28.1",
@@ -2033,6 +2034,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -4820,6 +4828,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -5963,6 +5978,53 @@
       },
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.11.tgz",
+      "integrity": "sha512-bwMovvAeuTFOK5kIFevw4VEf+1gVEICv4SYK4k3knJOxl6b1zEWud8mYKD73e1B0odAn174h1MofURy2TPWf3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.11"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.11.tgz",
+      "integrity": "sha512-riLBxPqwnJ0lWs2DN2WeUfYeKLoAjbP2Xx8cLQdSddzMi20sksIa6K2mPz79DyMZKKVKH2ksOC2yJvtNcZg8cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -10050,6 +10112,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -10630,6 +10702,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
@@ -10910,6 +10997,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -12023,6 +12120,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -78,6 +78,7 @@
     "@angular/compiler-cli": "^22.1.3",
     "@playwright/test": "1.62.1",
     "@tailwindcss/typography": "^0.5.20",
+    "@vitest/browser-playwright": "^4.1.11",
     "@vitest/coverage-v8": "^4.1.11",
     "dotenv": "^17.4.2",
     "esbuild": "^0.28.1",

--- a/web/app/src/app/core/models/message.model.ts
+++ b/web/app/src/app/core/models/message.model.ts
@@ -63,6 +63,16 @@ export interface ChatMessage {
   checkpoint_completed_at?: string | null;
   /** Per-turn model-context composition captured at generation time (assistant messages). */
   context_breakdown?: ContextBreakdown | null;
+  /** Whether the user has bookmarked this message for long-thread navigation. */
+  bookmarked?: boolean;
+}
+
+/** Lightweight bookmark entry for the thread navigator (from GET /chat/{id}/bookmarks). */
+export interface MessageBookmark {
+  id: string;
+  origin: MessageOrigin;
+  snippet: string;
+  sent_at: string;
 }
 
 export interface ChatMessageFilters {

--- a/web/app/src/app/core/services/message.service.ts
+++ b/web/app/src/app/core/services/message.service.ts
@@ -1,13 +1,14 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, BehaviorSubject, throwError } from 'rxjs';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError, map, tap } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import {
   ChatMessage,
   ChatMessageFilters,
   CreateChatMessageRequest,
   ChatMessageResponse,
+  MessageBookmark,
   MessageReadStatus
 } from '../models/message.model';
 import { PaginatedResponse } from '../models/common.model';
@@ -29,6 +30,10 @@ export class MessageService {
 
   // Current active chat ID for message filtering
   private currentChatId: string | null = null;
+
+  // The active optimistic bookmark request for each loaded message. A newer request or
+  // reconciliation supersedes its token so an older response cannot overwrite newer state.
+  private bookmarkOperations = new Map<string, symbol>();
 
   setCurrentChatId(chatId: string | null): void {
     this.currentChatId = chatId;
@@ -55,12 +60,57 @@ export class MessageService {
             // Replace message list on first page
             this.messagesSubject.next(response.results.reverse()); // Reverse to show newest at bottom
           } else {
-            // Prepend older messages for infinite scroll up
+            // Prepend older messages for infinite scroll up. Dedup by id: offset-based pages
+            // can overlap what we already have once newer messages arrive, and duplicate ids
+            // would break `track message.id` rendering.
             const currentMessages = this.messagesSubject.getValue();
-            this.messagesSubject.next([...response.results.reverse(), ...currentMessages]);
+            const known = new Set(currentMessages.map(m => m.id));
+            const older = response.results.reverse().filter(m => !known.has(m.id));
+            if (older.length > 0) {
+              this.messagesSubject.next([...older, ...currentMessages]);
+            }
           }
         }),
         catchError(this.handleError)
+      );
+  }
+
+  /**
+   * Non-destructively reconcile the newest page into the loaded list: update messages already
+   * present (streaming→final, read status, bookmarks, context breakdown) and append any that
+   * arrived while away — without dropping older loaded pages or moving scroll. Returns how many
+   * new messages were appended, the server total, and whether a gap was detected (more than a
+   * page arrived while away, so the loaded tail no longer overlaps the newest page — the caller
+   * decides whether a full reload is worthwhile).
+   */
+  reconcileLatestPage(chatId: string, limit: number = 50): Observable<{ appended: number; total: number; gap: boolean }> {
+    const params = { page: '1', limit: limit.toString() };
+    return this.http
+      .get<PaginatedResponse<ChatMessage>>(`${this.apiUrl}/${chatId}/chat-message`, { params })
+      .pipe(
+        map(response => {
+          const fresh = [...response.results].reverse(); // oldest-first
+          const total = response.total_count ?? fresh.length;
+          const current = this.messagesSubject.getValue();
+          if (current.length === 0) {
+            this.messagesSubject.next(fresh);
+            return { appended: fresh.length, total, gap: false };
+          }
+          const known = new Set(current.map(m => m.id));
+          const hasOverlap = fresh.some(m => known.has(m.id));
+          if (!hasOverlap) {
+            // The loaded tail is older than the entire newest page — merging would leave a hole.
+            return { appended: 0, total, gap: true };
+          }
+          const freshById = new Map(fresh.map(m => [m.id, m]));
+          // A server reconciliation is newer than a pending optimistic bookmark update.
+          fresh.forEach(message => this.bookmarkOperations.delete(message.id));
+          const merged = current.map(m => freshById.get(m.id) ?? m);
+          const appended = fresh.filter(m => !known.has(m.id));
+          this.messagesSubject.next(appended.length > 0 ? [...merged, ...appended] : merged);
+          return { appended: appended.length, total, gap: false };
+        }),
+        catchError(this.handleError),
       );
   }
 
@@ -122,6 +172,54 @@ export class MessageService {
   getMessage(messageId: string): Observable<ChatMessage> {
     return this.http.get<ChatMessage>(`${this.apiUrl}/chat-message/${messageId}`)
       .pipe(catchError(this.handleError));
+  }
+
+  /** List all bookmarked messages for a chat (complete, regardless of pagination). */
+  listBookmarks(chatId: string): Observable<MessageBookmark[]> {
+    return this.http.get<MessageBookmark[]>(`${this.apiUrl}/${chatId}/bookmarks`)
+      .pipe(catchError(this.handleError));
+  }
+
+  /**
+   * Toggle a message bookmark. Updates the in-memory list optimistically and reconciles with
+   * the server response (reverting on error).
+   */
+  setBookmark(chatId: string, messageId: string, bookmarked: boolean): Observable<ChatMessage> {
+    const previousMessage = this.messagesSubject.getValue().find(message => message.id === messageId);
+    const previousBookmarked = previousMessage?.bookmarked;
+    const operation = Symbol(messageId);
+    this.bookmarkOperations.set(messageId, operation);
+    this.patchMessageInList(messageId, { bookmarked });
+    return this.http
+      .patch<ChatMessage>(`${this.apiUrl}/${chatId}/chat-message/${messageId}/bookmark`, { bookmarked })
+      .pipe(
+        tap(updated => {
+          if (this.bookmarkOperations.get(messageId) === operation) {
+            this.bookmarkOperations.delete(messageId);
+            this.patchMessageInList(messageId, { bookmarked: updated.bookmarked });
+          }
+        }),
+        catchError(error => {
+          if (this.bookmarkOperations.get(messageId) === operation) {
+            this.bookmarkOperations.delete(messageId);
+            const currentMessage = this.messagesSubject.getValue().find(message => message.id === messageId);
+            if (previousMessage && currentMessage) {
+              this.patchMessageInList(messageId, { bookmarked: previousBookmarked });
+            }
+          }
+          return this.handleError(error);
+        }),
+      );
+  }
+
+  /** Shallow-merge a patch onto a message already in the list (no-op if absent). */
+  private patchMessageInList(messageId: string, patch: Partial<ChatMessage>): void {
+    const current = this.messagesSubject.getValue();
+    const idx = current.findIndex(m => m.id === messageId);
+    if (idx < 0) return;
+    const next = [...current];
+    next[idx] = { ...next[idx], ...patch };
+    this.messagesSubject.next(next);
   }
 
   /** Re-run async generation for an existing user message (same turn). */

--- a/web/app/src/app/features/chat/chat-page.component.html
+++ b/web/app/src/app/features/chat/chat-page.component.html
@@ -86,6 +86,7 @@
           </div>
         </div>
         <div class="chat-page__title-actions">
+          <app-thread-bookmarks [bookmarks]="bookmarks()" (jump)="jumpToBookmark($event)" />
           <button type="button" class="chat-page__export" (click)="exportActiveChat()" aria-label="Export thread">
             <ui-file-icon [size]="12" />
             <span>Export</span>
@@ -174,6 +175,7 @@
             [displayRevision]="session.getDisplayRevision()"
             (copy)="copyMessage($event)"
             (showContext)="openContextForMessage($event)"
+            (toggleBookmark)="toggleBookmarkFromList($event)"
             (openToolCallDetail)="openToolCall($event)"
             (retryUserMessage)="retryUserMessageFromList($event)"
             (loadOlder)="session.loadOlderMessages()"

--- a/web/app/src/app/features/chat/chat-page.component.spec.ts
+++ b/web/app/src/app/features/chat/chat-page.component.spec.ts
@@ -30,7 +30,7 @@ describe('ChatPageComponent', () => {
     type ChatServiceMock = Pick<MockedObject<ChatService>, 'createChat' | 'createWelcomeMessage' | 'getChat' | 'getChatContext' | 'getLastChatId' | 'listChats' | 'patchChat' | 'setLastChatId' | 'clearLastChatId' | 'exportChat' | 'markChatRead' | 'listAllChats'>;
     type ImageGalleryServiceMock = Pick<MockedObject<ImageGalleryService>, 'referenceImage' | 'getImageUrl'>;
     type FileAttachmentServiceMock = Pick<MockedObject<FileAttachmentService>, 'uploadChatFileAttachment'>;
-    type MessageServiceMock = Pick<MockedObject<MessageService>, 'clearMessages' | 'listMessages' | 'sendMessage' | 'setCurrentChatId' | 'markAssistantMessagesRead' | 'messages$'>;
+    type MessageServiceMock = Pick<MockedObject<MessageService>, 'clearMessages' | 'listMessages' | 'listBookmarks' | 'sendMessage' | 'setCurrentChatId' | 'markAssistantMessagesRead' | 'messages$'>;
     type RouterMock = Pick<MockedObject<Router>, 'navigate' | 'events'>;
 
     let chatService: ChatServiceMock;
@@ -67,6 +67,7 @@ describe('ChatPageComponent', () => {
         messageService = {
             clearMessages: vi.fn().mockName("MessageService.clearMessages"),
             listMessages: vi.fn().mockName("MessageService.listMessages"),
+            listBookmarks: vi.fn().mockName("MessageService.listBookmarks"),
             sendMessage: vi.fn().mockName("MessageService.sendMessage"),
             setCurrentChatId: vi.fn().mockName("MessageService.setCurrentChatId"),
             markAssistantMessagesRead: vi.fn().mockName("MessageService.markAssistantMessagesRead"),
@@ -134,6 +135,7 @@ describe('ChatPageComponent', () => {
         messageService.markAssistantMessagesRead.mockImplementation(() => {
         });
         messageService.listMessages.mockReturnValue(of({ results: [], page: 1, total_count: 0 }));
+        messageService.listBookmarks.mockReturnValue(of([]));
         messageService.sendMessage.mockReturnValue(of({ id: 'msg-1', job_id: '', type: 'message' }));
         draftService.getDraft.mockReturnValue(null);
         fileAttachmentService.uploadChatFileAttachment.mockReturnValue(of(fileAttachment()));

--- a/web/app/src/app/features/chat/chat-page.component.ts
+++ b/web/app/src/app/features/chat/chat-page.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, DOCUMENT } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, computed, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, computed, effect, inject, signal, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
@@ -12,7 +12,7 @@ import { ImageGalleryService } from '../../core/services/image-gallery.service';
 import { ModelService } from '../../core/services/model.service';
 import { PersonalityService } from '../../core/services/personality.service';
 import { RitualService } from '../../core/services/ritual.service';
-import { ChatMessage } from '../../core/models/message.model';
+import { ChatMessage, MessageBookmark } from '../../core/models/message.model';
 import {
   createPendingFileAttachment,
   FileAttachment,
@@ -23,6 +23,8 @@ import { Personality, PersonalityExpression } from '../../core/models/personalit
 import { ToolCall } from '../../core/models/toolcall.model';
 import { ChatComposerComponent } from './components/chat-composer/chat-composer.component';
 import { MessageListComponent } from './components/message-list/message-list.component';
+import { ThreadBookmarksComponent } from './components/thread-bookmarks/thread-bookmarks.component';
+import { MessageService } from '../../core/services/message.service';
 import { PersonaPickerDialogComponent } from '../personality/picker/persona-picker-dialog.component';
 import { personalityCoverUrl } from '../personality/helpers/cover-image.helpers';
 import { AuthImagePipe } from '../../core/pipes/auth-image.pipe';
@@ -64,6 +66,7 @@ const DEFAULT_ASSISTANT_ACCENT = 'hsl(220 70% 50%)';
     ChatSendOutletComponent,
     ChatComposerComponent,
     MessageListComponent,
+    ThreadBookmarksComponent,
     PersonaPickerDialogComponent,
     ToolCallDetailModalComponent,
     AuthImagePipe,
@@ -92,6 +95,7 @@ export class ChatPageComponent implements OnInit, OnDestroy {
   private readonly modelService = inject(ModelService);
   private readonly personalityService = inject(PersonalityService);
   private readonly ritualService = inject(RitualService);
+  private readonly messageService = inject(MessageService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly document = inject(DOCUMENT);
@@ -129,6 +133,9 @@ export class ChatPageComponent implements OnInit, OnDestroy {
   readonly loadedToolCalls = computed(() =>
     this.session.messages().flatMap(message => message.tool_calls ?? []),
   );
+  /** Complete bookmark list for the active thread (for the navigator), loaded from the API. */
+  readonly bookmarks = signal<MessageBookmark[]>([]);
+  private readonly messageList = viewChild(MessageListComponent);
   /** Most recent assistant message that captured a Context X-ray, or null. */
   readonly latestContextMessage = computed(() => {
     const messages = this.session.messages();
@@ -242,7 +249,10 @@ export class ChatPageComponent implements OnInit, OnDestroy {
     const now = Date.now();
     if (now - this.lastThreadRefreshAt < ChatPageComponent.THREAD_REFRESH_THROTTLE_MS) return;
     this.lastThreadRefreshAt = now;
-    this.session.reloadActiveThread();
+    // Only follow the conversation to the present when the user is already at the bottom; if
+    // they've scrolled up to read history, the sync preserves their position and loaded pages.
+    const nearBottom = this.messageList()?.isNearBottom() ?? true;
+    this.session.syncActiveThread(nearBottom);
   };
   private readonly activeHotkeyListeners = new Map<string, (event: KeyboardEvent) => void>();
   private readonly hotkeySequenceState = new Map<string, { keys: string[]; currentIndex: number; timeout?: ReturnType<typeof setTimeout> }>();
@@ -268,6 +278,15 @@ export class ChatPageComponent implements OnInit, OnDestroy {
   private readonly syncContextPanelBreakdown = effect(() => {
     const message = this.latestContextMessage();
     this.contextPanel.setLatestBreakdown(message?.context_breakdown ?? null, message?.id ?? null);
+  });
+  // Load the complete bookmark list whenever the active thread changes.
+  private lastBookmarksThreadId: string | null = null;
+  private readonly loadBookmarksOnThread = effect(() => {
+    const threadId = this.session.thread()?.id ?? null;
+    if (threadId === this.lastBookmarksThreadId) return;
+    this.lastBookmarksThreadId = threadId;
+    this.bookmarks.set([]);
+    if (threadId) this.refreshBookmarks(threadId);
   });
   private readonly syncActiveModel = effect(() => {
     const modelId = this.session.model()?.id ?? this.session.thread()?.model_id ?? null;
@@ -670,6 +689,39 @@ export class ChatPageComponent implements OnInit, OnDestroy {
     if (this.isMobileViewport()) {
       this.contextPanel.openMobile();
     }
+  }
+
+  private refreshBookmarks(chatId: string): void {
+    this.subscriptions.add(
+      this.messageService.listBookmarks(chatId).subscribe({
+        next: bookmarks => {
+          if (this.session.thread()?.id === chatId) this.bookmarks.set(bookmarks);
+        },
+        error: () => {
+          /* best-effort: navigator just stays empty */
+        },
+      }),
+    );
+  }
+
+  // Toggle a message's bookmark (star button in its hover row). The message list updates
+  // optimistically in MessageService; we refresh the navigator list on success.
+  toggleBookmarkFromList(message: ChatMessage): void {
+    const chatId = this.session.thread()?.id;
+    if (!chatId) return;
+    const next = !message.bookmarked;
+    this.subscriptions.add(
+      this.messageService.setBookmark(chatId, message.id, next).subscribe({
+        next: () => this.refreshBookmarks(chatId),
+        error: () => this.refreshBookmarks(chatId),
+      }),
+    );
+  }
+
+  // Jump to a bookmark from the navigator: load older pages until it's present, then scroll.
+  async jumpToBookmark(bookmark: MessageBookmark): Promise<void> {
+    await this.session.loadOlderMessagesUntil(bookmark.id);
+    this.messageList()?.scrollToMessage(bookmark.id);
   }
 
   exportActiveChat(): void {

--- a/web/app/src/app/features/chat/chat-session.service.spec.ts
+++ b/web/app/src/app/features/chat/chat-session.service.spec.ts
@@ -19,7 +19,7 @@ import { CHAT_PENDING_ASSISTANT_MESSAGE_ID } from './chat.constants';
 describe('ChatSessionService', () => {
     type ChatServiceMock = Pick<MockedObject<ChatService>, 'createChat' | 'getChat' | 'patchChat' | 'setLastChatId' | 'markChatRead'>;
     type ThreadListServiceMock = Pick<MockedObject<ThreadListService>, 'clearUnreadForThread'>;
-    type MessageServiceMock = Pick<MockedObject<MessageService>, 'clearMessages' | 'listMessages' | 'sendMessage' | 'retryUserMessage' | 'setCurrentChatId' | 'markAssistantMessagesRead' | 'messages$'>;
+    type MessageServiceMock = Pick<MockedObject<MessageService>, 'clearMessages' | 'listMessages' | 'reconcileLatestPage' | 'sendMessage' | 'retryUserMessage' | 'setCurrentChatId' | 'markAssistantMessagesRead' | 'messages$'>;
     type ChatStreamingServiceMock = Pick<MockedObject<ChatStreamingService>, 'appendServerChunks' | 'clearMessageState' | 'completeStreaming' | 'configure' | 'destroy' | 'getDisplayMessage' | 'getDisplayRevision' | 'setCompletionCallback' | 'startStreaming' | 'stopStreaming'>;
     type DraftMessageServiceMock = Pick<MockedObject<DraftMessageService>, 'clearDraft' | 'getDraft' | 'saveDraft'>;
     type JobServiceMock = Pick<MockedObject<JobService>, 'pollJob' | 'getActiveChatMessageJob' | 'isJobBeingPolled' | 'cancelJob'>;
@@ -65,6 +65,7 @@ describe('ChatSessionService', () => {
         messageService = {
             clearMessages: vi.fn().mockName("MessageService.clearMessages"),
             listMessages: vi.fn().mockName("MessageService.listMessages"),
+            reconcileLatestPage: vi.fn().mockName("MessageService.reconcileLatestPage"),
             sendMessage: vi.fn().mockName("MessageService.sendMessage"),
             retryUserMessage: vi.fn().mockName("MessageService.retryUserMessage"),
             setCurrentChatId: vi.fn().mockName("MessageService.setCurrentChatId"),
@@ -114,6 +115,7 @@ describe('ChatSessionService', () => {
         chatService.createChat.mockReturnValue(of(chat));
         chatService.markChatRead.mockReturnValue(of({ updated_count: 0 }));
         messageService.listMessages.mockReturnValue(of({ results: [], page: 1, total_count: 0 }));
+        messageService.reconcileLatestPage.mockReturnValue(of({ appended: 0, total: 0, gap: false }));
         messageService.sendMessage.mockReturnValue(of({ id: 'user-msg', job_id: 'job-1', type: 'chat_message' }));
         messageService.retryUserMessage.mockReturnValue(of({ id: 'user-msg', job_id: 'job-2', type: 'chat_message' }));
         draftService.getDraft.mockReturnValue({ chatId: 'chat-1', message: 'saved draft', timestamp: Date.now() });
@@ -414,26 +416,25 @@ describe('ChatSessionService', () => {
         expect(service.contextCheckpointToken()).toBe(1);
     });
 
-    it('reloads the active thread messages on return to the app', () => {
+    it('reconciles the active thread messages on return to the app', () => {
         service.setActive('chat-1');
-        messageService.listMessages.mockClear();
-        messageService.listMessages.mockReturnValue(of({ results: [], page: 1, total_count: 3 }));
+        messageService.reconcileLatestPage.mockClear();
 
-        service.reloadActiveThread();
+        service.syncActiveThread(true);
 
-        expect(messageService.listMessages).toHaveBeenCalledWith('chat-1', 1, expect.any(Number));
+        expect(messageService.reconcileLatestPage).toHaveBeenCalledWith('chat-1', expect.any(Number));
     });
 
-    it('does not reload the active thread while a job is in flight', () => {
+    it('does not reconcile the active thread while a job is in flight', () => {
         const activeJob$ = new Subject<any>();
         jobService.pollJob.mockReturnValue(activeJob$ as any);
         service.setActive('chat-1');
         service.startAssistantJobPolling('job-1', 'chat-1');
-        messageService.listMessages.mockClear();
+        messageService.reconcileLatestPage.mockClear();
 
-        service.reloadActiveThread();
+        service.syncActiveThread(true);
 
-        expect(messageService.listMessages).not.toHaveBeenCalled();
+        expect(messageService.reconcileLatestPage).not.toHaveBeenCalled();
         activeJob$.complete();
     });
 

--- a/web/app/src/app/features/chat/chat-session.service.ts
+++ b/web/app/src/app/features/chat/chat-session.service.ts
@@ -244,7 +244,15 @@ export class ChatSessionService implements OnDestroy {
    * No-op while this tab has its own in-flight job or streaming: the job poller
    * already keeps it current, and we must not disturb that state.
    */
-  reloadActiveThread(): void {
+  /**
+   * Refresh the active thread after a tab-return/focus without destroying the user's scrollback.
+   * Thread metadata (name/summary) always refreshes. Messages are reconciled non-destructively:
+   * messages already loaded are updated in place and anything new is appended — older loaded
+   * pages and the scroll position are preserved. A full reload only happens when more than a
+   * page arrived while away (a gap) AND the user is following at the bottom; a user reading
+   * history is never yanked back to the present.
+   */
+  syncActiveThread(nearBottom: boolean): void {
     const threadId = this.activeThreadId;
     if (!threadId || this.assistantJobPending() || this.isStreaming()) {
       return;
@@ -263,6 +271,30 @@ export class ChatSessionService implements OnDestroy {
     );
 
     this.subscriptions.add(
+      this.messageService.reconcileLatestPage(threadId, MESSAGE_LIST_PAGE_SIZE).subscribe({
+        next: result => {
+          if (!this.isActiveThread(threadId)) return;
+          if (result.gap) {
+            // More than a page arrived while away. Rebuild only if the user is following the
+            // conversation; if they're reading history, leave their view exactly as it is.
+            if (nearBottom) this.reloadFromLatest(threadId);
+            return;
+          }
+          this.messagesTotalCount = result.total;
+          this.hasMoreOlderMessages.set(this.messages().length < this.messagesTotalCount);
+          this.resumePendingJobIfNeeded(threadId);
+          this.markActiveThreadRead(threadId);
+        },
+        error: () => {
+          // Best-effort refresh: leave the current list intact on failure.
+        },
+      }),
+    );
+  }
+
+  /** Destructive reload to the newest page (used only when a gap makes a merge unsafe). */
+  private reloadFromLatest(threadId: string): void {
+    this.subscriptions.add(
       this.messageService.listMessages(threadId, 1, MESSAGE_LIST_PAGE_SIZE).subscribe({
         next: response => {
           if (!this.isActiveThread(threadId)) return;
@@ -270,21 +302,25 @@ export class ChatSessionService implements OnDestroy {
           this.messagesTotalCount = response.total_count ?? response.results.length;
           this.hasMoreOlderMessages.set(this.messages().length < this.messagesTotalCount);
           this.resumePendingJobIfNeeded(threadId);
-          this.subscriptions.add(
-            this.chatService.markChatRead(threadId).subscribe({
-              next: () => {
-                if (!this.isActiveThread(threadId)) return;
-                this.messageService.markAssistantMessagesRead(threadId);
-                this.threadList.clearUnreadForThread(threadId);
-              },
-              error: () => {
-                // Best-effort: thread still works if mark-read fails.
-              },
-            }),
-          );
+          this.markActiveThreadRead(threadId);
         },
         error: () => {
-          // Best-effort refresh: leave the current list intact on failure.
+          // Best-effort: leave the current list intact on failure.
+        },
+      }),
+    );
+  }
+
+  private markActiveThreadRead(threadId: string): void {
+    this.subscriptions.add(
+      this.chatService.markChatRead(threadId).subscribe({
+        next: () => {
+          if (!this.isActiveThread(threadId)) return;
+          this.messageService.markAssistantMessagesRead(threadId);
+          this.threadList.clearUnreadForThread(threadId);
+        },
+        error: () => {
+          // Best-effort: thread still works if mark-read fails.
         },
       }),
     );
@@ -315,6 +351,51 @@ export class ChatSessionService implements OnDestroy {
           }
         },
       });
+  }
+
+  /**
+   * Load successive older pages until `messageId` is present in the list, or there are no more
+   * pages / a page cap is hit. Resolves to whether the message is now loaded. Powers jumping to
+   * a bookmark that lives on an older, not-yet-loaded page.
+   */
+  loadOlderMessagesUntil(messageId: string, maxPages = 60): Promise<boolean> {
+    const threadId = this.activeThreadId;
+    const isLoaded = () => this.messages().some(m => m.id === messageId);
+    if (!threadId || isLoaded()) {
+      return Promise.resolve(isLoaded());
+    }
+    return new Promise<boolean>(resolve => {
+      let remaining = maxPages;
+      const step = (): void => {
+        if (isLoaded()) {
+          resolve(true);
+          return;
+        }
+        if (!this.hasMoreOlderMessages() || remaining-- <= 0) {
+          resolve(isLoaded());
+          return;
+        }
+        const nextPage = this.messagesPage + 1;
+        this.loadingOlderMessages.set(true);
+        this.messageService
+          .listMessages(threadId, nextPage, MESSAGE_LIST_PAGE_SIZE)
+          .pipe(finalize(() => this.loadingOlderMessages.set(false)))
+          .subscribe({
+            next: response => {
+              if (!this.isActiveThread(threadId)) {
+                resolve(false);
+                return;
+              }
+              this.messagesPage = nextPage;
+              this.messagesTotalCount = response.total_count ?? this.messagesTotalCount;
+              this.hasMoreOlderMessages.set(this.messages().length < this.messagesTotalCount);
+              step();
+            },
+            error: () => resolve(isLoaded()),
+          });
+      };
+      step();
+    });
   }
 
   clearActive(): void {

--- a/web/app/src/app/features/chat/components/message-bubble/message-bubble.component.ts
+++ b/web/app/src/app/features/chat/components/message-bubble/message-bubble.component.ts
@@ -4,17 +4,19 @@ import { ChangeDetectionStrategy, Component, computed, input, output } from '@an
 import { ChatMessage } from '../../../../core/models/message.model';
 import { CHAT_PENDING_ASSISTANT_MESSAGE_ID } from '../../chat.constants';
 import { TooltipDirective } from '../../../../shared/ui/tooltip/tooltip.directive';
+import { StarIconComponent } from '../../../../shared/ui/icons/icons';
 import { MessageContentComponent } from '../message-content/message-content.component';
 
 @Component({
   selector: 'app-message-bubble',
   standalone: true,
-  imports: [MessageContentComponent, TooltipDirective],
+  imports: [MessageContentComponent, TooltipDirective, StarIconComponent],
   template: `
     <article
       class="bubble"
       [class.bubble--user]="message().origin === 'User'"
       [class.bubble--pending]="showPendingDots()"
+      [class.bubble--bookmarked]="message().bookmarked && !isPendingPlaceholder()"
       [attr.aria-label]="ariaLabel()"
     >
       <div class="bubble__body">
@@ -45,6 +47,17 @@ import { MessageContentComponent } from '../message-content/message-content.comp
               <span>{{ shortTime(message().sent_at) }}</span>
             </time>
             <button type="button" class="bubble__copy" (click)="copy.emit(message())">Copy</button>
+            <button
+              type="button"
+              class="bubble__bookmark"
+              [class.bubble__bookmark--active]="message().bookmarked"
+              [attr.aria-pressed]="!!message().bookmarked"
+              (click)="toggleBookmark.emit(message())"
+              [title]="message().bookmarked ? 'Remove bookmark' : 'Bookmark this message'"
+            >
+              <ui-star-icon [size]="12" [filled]="!!message().bookmarked" />
+              <span>{{ message().bookmarked ? 'Saved' : 'Save' }}</span>
+            </button>
           </div>
           <div class="bubble__meta-end">
             @if (hasContextBreakdown()) {
@@ -68,6 +81,8 @@ import { MessageContentComponent } from '../message-content/message-content.comp
       display: block;
       max-width: 100%;
       min-width: 0;
+      /* Bookmark accent; a warm gold that reads on both light and dark surfaces. */
+      --bookmark-gold: #e0a53a;
     }
 
     .bubble {
@@ -217,6 +232,36 @@ import { MessageContentComponent } from '../message-content/message-content.comp
       opacity: 1;
     }
 
+    .bubble__bookmark {
+      align-items: center;
+      border: 1px solid var(--color-border-base);
+      border-radius: 999px;
+      color: var(--color-text-muted);
+      display: inline-flex;
+      flex-shrink: 0;
+      gap: 0.2rem;
+      opacity: 0.8;
+      padding: 0.125rem 0.375rem;
+      transition: background 150ms ease, color 150ms ease, opacity 150ms ease;
+    }
+
+    .bubble__bookmark:hover,
+    .bubble__bookmark:focus-visible { opacity: 1; }
+
+    .bubble__bookmark--active {
+      border-color: color-mix(in srgb, var(--bookmark-gold) 50%, var(--color-border-base));
+      color: var(--bookmark-gold);
+      opacity: 1;
+    }
+
+    /* Always-visible gold bar so bookmarks are spottable while scrolling (layout-safe inset). */
+    .bubble--bookmarked .bubble__body {
+      box-shadow: inset 3px 0 0 0 var(--bookmark-gold);
+    }
+    .bubble--bookmarked.bubble--user .bubble__body {
+      box-shadow: inset -3px 0 0 0 var(--bookmark-gold);
+    }
+
     .bubble--user .bubble__meta {
       justify-content: flex-end;
     }
@@ -259,6 +304,20 @@ import { MessageContentComponent } from '../message-content/message-content.comp
       0%, 60%, 100% { opacity: 0.35; transform: translateY(0); }
       30% { opacity: 1; transform: translateY(-0.125rem); }
     }
+
+    /* Applied by message-list.scrollToMessage when jumping to a message (e.g. a bookmark). */
+    :host(.message-flash) .bubble__body {
+      animation: bubble-flash 1.8s ease;
+    }
+
+    @keyframes bubble-flash {
+      0%, 100% { box-shadow: 0 0 0 0 transparent; }
+      15% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--bookmark-gold) 60%, transparent); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host(.message-flash) .bubble__body { animation: none; }
+    }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -266,6 +325,7 @@ export class MessageBubbleComponent {
   readonly message = input.required<ChatMessage>();
   readonly displayContent = input('');
   readonly copy = output<ChatMessage>();
+  readonly toggleBookmark = output<ChatMessage>();
   readonly showContext = output<ChatMessage>();
 
   /** True for assistant replies that captured a Context X-ray snapshot. */

--- a/web/app/src/app/features/chat/components/message-bubble/message-bubble.component.ts
+++ b/web/app/src/app/features/chat/components/message-bubble/message-bubble.component.ts
@@ -52,6 +52,7 @@ import { MessageContentComponent } from '../message-content/message-content.comp
               class="bubble__bookmark"
               [class.bubble__bookmark--active]="message().bookmarked"
               [attr.aria-pressed]="!!message().bookmarked"
+              [attr.aria-label]="message().bookmarked ? 'Remove bookmark' : 'Bookmark this message'"
               (click)="toggleBookmark.emit(message())"
               [title]="message().bookmarked ? 'Remove bookmark' : 'Bookmark this message'"
             >

--- a/web/app/src/app/features/chat/components/message-group/message-group.component.ts
+++ b/web/app/src/app/features/chat/components/message-group/message-group.component.ts
@@ -93,6 +93,7 @@ interface AssistantVisual {
             [displayContent]="displayMessage(message)"
             (copy)="copy.emit($event)"
             (showContext)="showContext.emit($event)"
+            (toggleBookmark)="toggleBookmark.emit($event)"
           />
         }
         @if (userGenerationError(); as errInfo) {
@@ -418,6 +419,7 @@ export class MessageGroupComponent {
   readonly displayResolver = input<(message: ChatMessage) => string>((message) => message.message);
   readonly copy = output<ChatMessage>();
   readonly showContext = output<ChatMessage>();
+  readonly toggleBookmark = output<ChatMessage>();
   readonly retryUserMessage = output<ChatMessage>();
 
   /** When false, hide the entire assistant image column (expression, portrait, thinking). */

--- a/web/app/src/app/features/chat/components/message-list/message-list.component.ts
+++ b/web/app/src/app/features/chat/components/message-list/message-list.component.ts
@@ -9,6 +9,8 @@ import { ToolCallGroupComponent } from '../tool-call-group/tool-call-group.compo
 
 const AUTO_SCROLL_BOTTOM_EPSILON_PX = 8;
 const STREAM_FOLLOW_SCROLL_MIN_INTERVAL_MS = 220;
+// Start loading the next older page this far from the top so it lands before the user hits it.
+const OLDER_LOAD_THRESHOLD_PX = 600;
 
 interface AssistantVisual {
   avatarUrl: string | null;
@@ -51,6 +53,7 @@ interface AssistantVisual {
                 [displayResolver]="displayResolver()"
                 (copy)="copy.emit($event)"
                 (showContext)="showContext.emit($event)"
+                (toggleBookmark)="toggleBookmark.emit($event)"
                 (retryUserMessage)="retryUserMessage.emit($event)"
               />
             }
@@ -200,6 +203,7 @@ export class MessageListComponent {
   readonly loadOlder = output<void>();
   readonly copy = output<ChatMessage>();
   readonly showContext = output<ChatMessage>();
+  readonly toggleBookmark = output<ChatMessage>();
   readonly openToolCallDetail = output<ToolCall>();
   readonly retryUserMessage = output<ChatMessage>();
   readonly scrollToBottomRequested = output<void>();
@@ -217,7 +221,12 @@ export class MessageListComponent {
   private lastAppliedScrollDigest = '';
   private lastAutoScrollTailId: string | null = null;
   private lastAutoScrollAtMs = 0;
-  private scrollHeightBeforePrepend: number | null = null;
+  // Anchor for restoring scroll after an older page prepends (element id + its viewport top).
+  private pendingPrependAnchor: { id: string; top: number } | null = null;
+  // Guards against firing multiple older-page loads for one scroll gesture.
+  private prependInFlight = false;
+  // Last observed scrollTop, to detect scroll direction (only auto-load older when going up).
+  private lastScrollTop = 0;
   private lastCheckpointMessageId: string | null = null;
   private readonly groupsLengthForScrollRestore = computed(() => this.groups().length);
 
@@ -250,22 +259,23 @@ export class MessageListComponent {
       this.scheduleScrollToBottom();
     });
 
+    // Preserve the reading position when older messages prepend. Anchoring to a specific
+    // element (not a raw scrollHeight delta) survives asynchronously-sized content above the
+    // fold (avatars, expression portraits) that would otherwise shove the view as it loads.
     effect(() => {
       const length = this.groupsLengthForScrollRestore();
-      const prevHeight = this.scrollHeightBeforePrepend;
-      if (prevHeight === null) {
-        return;
-      }
       void length;
-      queueMicrotask(() => {
-        const container = this.scrollContainer()?.nativeElement;
-        if (!container) {
-          this.scrollHeightBeforePrepend = null;
-          return;
-        }
-        container.scrollTop += container.scrollHeight - prevHeight;
-        this.scrollHeightBeforePrepend = null;
-      });
+      const anchor = this.pendingPrependAnchor;
+      if (!anchor) return;
+      this.pendingPrependAnchor = null;
+      this.restoreToAnchor(anchor);
+    });
+
+    // Release the in-flight guard once the parent finishes loading an older page.
+    effect(() => {
+      if (!this.loadingOlder()) {
+        this.prependInFlight = false;
+      }
     });
 
     effect(() => {
@@ -295,19 +305,112 @@ export class MessageListComponent {
     });
   }
 
+  /**
+   * Scroll a message into view and briefly flash it. Retries across a few animation frames so
+   * it works whether the target is already rendered or was just loaded (e.g. jumping to a
+   * bookmark on an older page). No-op if the message never renders within the window.
+   */
+  scrollToMessage(messageId: string): void {
+    let attempts = 0;
+    const tryScroll = (): void => {
+      const container = this.scrollContainer()?.nativeElement;
+      const target = container?.querySelector<HTMLElement>(`[data-message-id="${messageId}"]`);
+      if (container && target) {
+        this.stickyToBottom.set(false);
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        target.classList.add('message-flash');
+        setTimeout(() => target.classList.remove('message-flash'), 1800);
+        return;
+      }
+      if (attempts++ < 30) {
+        requestAnimationFrame(tryScroll);
+      }
+    };
+    requestAnimationFrame(tryScroll);
+  }
+
   requestLoadOlder(): void {
-    const container = this.scrollContainer()?.nativeElement;
-    if (container) {
-      this.scrollHeightBeforePrepend = container.scrollHeight;
+    if (!this.hasMoreOlder() || this.loadingOlder() || this.prependInFlight) {
+      return;
     }
+    this.prependInFlight = true;
+    this.captureAnchor();
     this.loadOlder.emit();
   }
 
   onScroll(event: Event): void {
     const target = event.target as HTMLElement;
-    const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
+    const scrollTop = target.scrollTop;
+    const distanceFromBottom = target.scrollHeight - scrollTop - target.clientHeight;
     this.isNearBottom.set(distanceFromBottom < 96);
     this.stickyToBottom.set(distanceFromBottom <= AUTO_SCROLL_BOTTOM_EPSILON_PX);
+    // Infinite scroll-up: pull older history as the user nears the top so scrolling back
+    // through a long thread is continuous instead of a button-click-per-page grind. Only when
+    // actively scrolling *up* — otherwise the initial auto-scroll-to-bottom (and the anchor
+    // re-pin after a prepend), which both increase scrollTop through the top region, would
+    // trigger spurious loads.
+    const scrollingUp = scrollTop < this.lastScrollTop;
+    this.lastScrollTop = scrollTop;
+    if (scrollingUp && scrollTop <= OLDER_LOAD_THRESHOLD_PX) {
+      this.requestLoadOlder();
+    }
+  }
+
+  /** Record the first message currently in view and its viewport position, to re-pin after prepend. */
+  private captureAnchor(): void {
+    const container = this.scrollContainer()?.nativeElement;
+    if (!container) return;
+    const containerTop = container.getBoundingClientRect().top;
+    const elements = container.querySelectorAll<HTMLElement>('[data-message-id]');
+    for (const el of Array.from(elements)) {
+      const top = el.getBoundingClientRect().top;
+      if (top - containerTop >= 0) {
+        this.pendingPrependAnchor = { id: el.getAttribute('data-message-id') ?? '', top };
+        return;
+      }
+    }
+    const first = elements[0];
+    if (first) {
+      this.pendingPrependAnchor = { id: first.getAttribute('data-message-id') ?? '', top: first.getBoundingClientRect().top };
+    }
+  }
+
+  /**
+   * Keep the anchored message pinned to its previous viewport position after a prepend. The first
+   * correction must happen in this render turn: delaying it until requestAnimationFrame lets the
+   * reader see the newly-prepended page shove their viewport. Follow-up frames only absorb
+   * late-sizing content (avatars and portraits) above the anchor.
+   */
+  private restoreToAnchor(anchor: { id: string; top: number }): void {
+    const container = this.scrollContainer()?.nativeElement;
+    if (!container || !anchor.id) return;
+    // Effects observing groups() run after Angular has rendered the updated list, so pin now
+    // before the browser can paint the prepended page at the wrong visual position.
+    this.pinToAnchor(container, anchor);
+
+    let frames = 0;
+    const settleLateLayout = (): void => {
+      this.pinToAnchor(container, anchor);
+      if (frames++ < 6) {
+        requestAnimationFrame(settleLateLayout);
+      }
+    };
+    requestAnimationFrame(settleLateLayout);
+  }
+
+  /** Apply one instant anchor correction; scheduling late layout passes stays in restoreToAnchor. */
+  private pinToAnchor(container: HTMLElement, anchor: { id: string; top: number }): void {
+    const el = container.querySelector<HTMLElement>(`[data-message-id="${anchor.id}"]`);
+    if (!el) return;
+    const delta = el.getBoundingClientRect().top - anchor.top;
+    if (Math.abs(delta) <= 0.5) return;
+
+    // The list defaults to smooth scrolling for explicit navigation. An anchor correction is
+    // layout preservation, not navigation — smooth behavior here creates a visible wobble.
+    const priorBehavior = container.style.scrollBehavior;
+    container.style.scrollBehavior = 'auto';
+    container.scrollTop += delta;
+    container.style.scrollBehavior = priorBehavior;
   }
 
   scrollToBottom(behavior: ScrollBehavior = 'smooth', emit = true): void {

--- a/web/app/src/app/features/chat/components/thread-bookmarks/thread-bookmarks.component.ts
+++ b/web/app/src/app/features/chat/components/thread-bookmarks/thread-bookmarks.component.ts
@@ -1,0 +1,217 @@
+import { DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, ElementRef, input, output, signal, viewChild, viewChildren } from '@angular/core';
+
+import { MessageBookmark } from '../../../../core/models/message.model';
+import { StarIconComponent } from '../../../../shared/ui/icons/icons';
+
+/**
+ * Thread bookmark navigator: a small toolbar button (shown only when the thread has bookmarks)
+ * that opens a dropdown list of every bookmark. Selecting one emits `jump` so the page can
+ * load the owning page if needed and scroll to it. Purely presentational otherwise.
+ */
+@Component({
+  selector: 'app-thread-bookmarks',
+  standalone: true,
+  imports: [DatePipe, StarIconComponent],
+  template: `
+    @if (bookmarks().length) {
+      <div class="tb">
+        <button
+          type="button"
+          class="tb__btn"
+          [class.tb__btn--open]="open()"
+          [attr.aria-expanded]="open()"
+          aria-haspopup="menu"
+          aria-controls="thread-bookmarks-menu"
+          (click)="toggle()"
+          title="Jump to a bookmark"
+          #trigger
+        >
+          <ui-star-icon [size]="12" [filled]="true" />
+          <span>{{ bookmarks().length }}</span>
+        </button>
+
+        @if (open()) {
+          <div class="tb__backdrop" (click)="close(true)"></div>
+          <div id="thread-bookmarks-menu" class="tb__panel" role="menu" aria-label="Bookmarks">
+            <div class="tb__head">Bookmarks · {{ bookmarks().length }}</div>
+            <ul class="tb__list">
+              @for (b of bookmarks(); track b.id; let index = $index) {
+                <li>
+                  <button
+                    type="button"
+                    class="tb__item"
+                    role="menuitem"
+                    [attr.tabindex]="activeIndex() === index ? 0 : -1"
+                    (click)="select(b)"
+                    (keydown)="onMenuKeydown($event, index)"
+                    #menuItem
+                  >
+                    <span class="tb__badge" [class.tb__badge--assistant]="b.origin === 'Assistant'">
+                      {{ b.origin === 'User' ? 'You' : 'AI' }}
+                    </span>
+                    <span class="tb__snippet">{{ b.snippet || '(no text)' }}</span>
+                    <time class="tb__time" [attr.datetime]="b.sent_at">{{ b.sent_at | date: 'MMM d' }}</time>
+                  </button>
+                </li>
+              }
+            </ul>
+          </div>
+        }
+      </div>
+    }
+  `,
+  styles: [`
+    :host { --bookmark-gold: #e0a53a; }
+    .tb { position: relative; display: inline-flex; }
+
+    .tb__btn {
+      align-items: center;
+      background: transparent;
+      border: 1px solid color-mix(in srgb, var(--bookmark-gold) 45%, var(--color-border-base));
+      border-radius: 0.5rem;
+      color: var(--bookmark-gold);
+      cursor: pointer;
+      display: inline-flex;
+      font-size: 0.7rem;
+      font-weight: 700;
+      gap: 0.25rem;
+      padding: 0.25rem 0.45rem;
+    }
+    .tb__btn--open,
+    .tb__btn:hover { background: color-mix(in srgb, var(--bookmark-gold) 14%, transparent); }
+
+    .tb__backdrop { inset: 0; position: fixed; z-index: 40; }
+
+    .tb__panel {
+      background: var(--color-surface-raised, var(--color-surface-base));
+      border: 1px solid var(--color-border-base);
+      border-radius: 0.6rem;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+      max-height: min(60vh, 24rem);
+      overflow-y: auto;
+      position: absolute;
+      right: 0;
+      top: calc(100% + 0.35rem);
+      width: min(20rem, 80vw);
+      z-index: 41;
+    }
+
+    .tb__head {
+      color: var(--color-text-muted);
+      font-size: 0.625rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      padding: 0.55rem 0.75rem 0.35rem;
+      text-transform: uppercase;
+    }
+
+    .tb__list { display: grid; list-style: none; margin: 0; padding: 0 0.35rem 0.35rem; }
+
+    .tb__item {
+      align-items: center;
+      background: transparent;
+      border: 0;
+      border-radius: 0.45rem;
+      cursor: pointer;
+      display: grid;
+      gap: 0.5rem;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      padding: 0.4rem 0.4rem;
+      text-align: left;
+      width: 100%;
+    }
+    .tb__item:hover { background: color-mix(in srgb, var(--color-accent) 12%, transparent); }
+
+    .tb__badge {
+      background: color-mix(in srgb, var(--color-accent) 55%, var(--color-surface-base));
+      border-radius: 999px;
+      color: #fff;
+      font-size: 0.55rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      padding: 0.05rem 0.35rem;
+      text-transform: uppercase;
+    }
+    .tb__badge--assistant { background: color-mix(in srgb, var(--bookmark-gold) 78%, var(--color-surface-base)); }
+
+    .tb__snippet {
+      color: var(--color-text-primary);
+      font-size: 0.78rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .tb__time { color: var(--color-text-muted); font-size: 0.65rem; white-space: nowrap; }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ThreadBookmarksComponent {
+  readonly bookmarks = input<MessageBookmark[]>([]);
+  readonly jump = output<MessageBookmark>();
+
+  readonly open = signal(false);
+  readonly activeIndex = signal(0);
+
+  private readonly trigger = viewChild<ElementRef<HTMLButtonElement>>('trigger');
+  private readonly menuItems = viewChildren<ElementRef<HTMLButtonElement>>('menuItem');
+
+  toggle(): void {
+    if (this.open()) {
+      this.close(true);
+    } else {
+      this.openMenu(0);
+    }
+  }
+
+  close(returnFocus = false): void {
+    this.open.set(false);
+    if (returnFocus) {
+      queueMicrotask(() => this.trigger()?.nativeElement.focus());
+    }
+  }
+
+  select(bookmark: MessageBookmark): void {
+    this.jump.emit(bookmark);
+    this.close(true);
+  }
+
+  onMenuKeydown(event: KeyboardEvent, currentIndex: number): void {
+    let nextIndex: number | undefined;
+    switch (event.key) {
+      case 'ArrowDown':
+        nextIndex = currentIndex + 1;
+        break;
+      case 'ArrowUp':
+        nextIndex = currentIndex - 1;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = this.bookmarks().length - 1;
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.close(true);
+        return;
+      default:
+        return;
+    }
+    event.preventDefault();
+    this.focusItem(nextIndex);
+  }
+
+  private openMenu(index: number): void {
+    this.open.set(true);
+    queueMicrotask(() => this.focusItem(index));
+  }
+
+  private focusItem(index: number): void {
+    const items = this.menuItems();
+    if (!items.length) return;
+    const normalizedIndex = (index + items.length) % items.length;
+    this.activeIndex.set(normalizedIndex);
+    items[normalizedIndex].nativeElement.focus();
+  }
+}

--- a/web/app/src/app/features/chat/components/thread-bookmarks/thread-bookmarks.component.ts
+++ b/web/app/src/app/features/chat/components/thread-bookmarks/thread-bookmarks.component.ts
@@ -21,6 +21,7 @@ import { StarIconComponent } from '../../../../shared/ui/icons/icons';
           class="tb__btn"
           [class.tb__btn--open]="open()"
           [attr.aria-expanded]="open()"
+          aria-label="Jump to a bookmark"
           aria-haspopup="menu"
           aria-controls="thread-bookmarks-menu"
           (click)="toggle()"


### PR DESCRIPTION
Port of chat-app PR  to what-iff.

Adding "bookmarks": Bookmarks allow users to 'tag' specific messages in a conversation and then use the new, top menu to auto-scroll back to that point in the conversation. Allowing users to find things in long conversations where scrolling or search are not practical.

Also done in this PR: updated our logic around chat rendering to prevent the chat window from resetting to bottom when user leaves + returns and limit the 'jarring' shifts when loading additional pages of history.

- New `bookmarked` bool on ChatMessage (ent schema + auto-migrate index)
- PATCH /chat/{chatId}/chat-message/{messageId}/bookmark and GET /chat/{chatId}/bookmarks
- BookmarkSnippet / BookmarkPageDefault helpers in models
- ListChatMessageBookmarks (complete, for UI navigator) + ListChatMessageBookmarksPage (bounded, for agent tools)
- find_context `bookmarks` mode + bookmark:<chat>:<msg> fetch-target prefix so agents can scan compact labels before fetching a body
- refactored `recallConversationTarget` helper shared by conversation and bookmarks modes
- Frontend: star toggle on every message bubble (optimistic, reverts on error)
- ThreadBookmarksComponent: gold pill button in thread header showing count, dropdown navigator
- Jump logic: loadOlderMessagesUntil pages back until the target is loaded, scrollToMessage retries across rAF frames and flashes the bubble
- reconcileLatestPage for non-destructive tab-return sync (no scroll position loss); syncActiveThread replaces reloadActiveThread
- Anchor-based scroll restoration after older-page prepend (replaces rawscrollHeight delta); infinite auto-load as user scrolls toward top
- openapi.yaml updated with both endpoints and ChatMessageBookmark schema

