### PR TITLE
Fix summarizer crash on OpenAI-unsupported images; guard pod against panics

### DIFF
--- a/internal/agent/conversation_summary.go
+++ b/internal/agent/conversation_summary.go
@@ -61,7 +61,10 @@ func buildCheckpointSummaryParams(userID uuid.UUID, existingSummary string, src 
 			OfString: openai.String(updatePrompt),
 		}
 	case src.ModelContext != nil:
-		items := provider.RenderOpenAIInputItems(src.ModelContext)
+		// Strip images OpenAI won't accept (unsupported media types, and file_ids whose
+		// stored filename extension OpenAI rejects case-sensitively, e.g. ".JPG"). Without
+		// this, a single bad image fails the whole checkpoint summary with a 400.
+		items := provider.RenderOpenAIInputItems(provider.SanitizeImagesForOpenAIInput(src.ModelContext))
 		if trimmed := strings.TrimSpace(src.AssistantReply); trimmed != "" {
 			items = append(items, responses.ResponseInputItemParamOfMessage(trimmed, provider.RoleAssistant))
 		}

--- a/internal/agent/conversation_summary_test.go
+++ b/internal/agent/conversation_summary_test.go
@@ -85,6 +85,48 @@ func TestBuildCheckpointSummaryParams_ExplicitMode(t *testing.T) {
 	require.Len(t, items, 4) // history user, current user, assistant reply, update prompt
 }
 
+// TestBuildCheckpointSummaryParams_StripsOpenAIUnsafeImages reproduces the checkpoint
+// summary crash: a Claude-chat turn carried an image whose OpenAI file_id has an uppercase
+// ".JPG" extension (rejected case-sensitively) plus a media type OpenAI does not support,
+// which returned a 400 from the summarizer. The built params must never surface a file_id
+// image or an unsupported media type.
+func TestBuildCheckpointSummaryParams_StripsOpenAIUnsafeImages(t *testing.T) {
+	t.Parallel()
+
+	mc := &provider.ModelContext{}
+	// Supported type carrying both a file_id (the ".JPG" landmine) and raw bytes: kept, but
+	// must render as a data URL, never as the file_id reference.
+	mc.AppendHistoryTurn(provider.RoleUser, "look at this", []provider.UserMessageImage{
+		{FileID: "file-photo-JPG", MediaType: "image/jpeg", RawBytes: []byte{1, 2, 3}},
+	}, false)
+	// Unsupported type from another vendor's turn: must be dropped, its text kept.
+	mc.AppendHistoryTurn(provider.RoleUser, "and this heic", []provider.UserMessageImage{
+		{MediaType: "image/heic", RawBytes: []byte{4, 5}},
+	}, false)
+
+	params, err := buildCheckpointSummaryParams(uuid.New(), "", checkpointSummarySource{ModelContext: mc})
+	require.NoError(t, err)
+
+	sawImage := false
+	for _, item := range params.Input.OfInputItemList {
+		if item.OfMessage == nil {
+			continue
+		}
+		for _, part := range item.OfMessage.Content.OfInputItemContentList {
+			if part.OfInputImage == nil {
+				continue
+			}
+			sawImage = true
+			require.False(t, part.OfInputImage.FileID.Valid(),
+				"summarizer image must not use a file_id (OpenAI validates its stored filename case-sensitively)")
+			require.True(t, part.OfInputImage.ImageURL.Valid(), "kept image should render as a data URL")
+			require.True(t, strings.HasPrefix(part.OfInputImage.ImageURL.Value, "data:image/jpeg;base64,"),
+				"data URL should carry a normalized, supported media type")
+		}
+	}
+	require.True(t, sawImage, "the supported jpeg image should survive sanitization")
+}
+
 func TestBuildCheckpointSummaryParams_RequiresSource(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -503,6 +504,12 @@ func (a *Agent) HandleUserMessage(ctx context.Context, request models.ChatMessag
 	go func() {
 		defer cancel()
 		defer a.unregisterRunningJobCancel(newJob.ID)
+		// An unrecovered panic in any goroutine takes down the whole process (and so the
+		// pod). Recover here so a failure while processing one message fails just that job
+		// instead — e.g. a post-inference checkpoint summary that a provider rejects must
+		// not crash every other in-flight chat. Registered after cancel/unregister so it
+		// runs first (LIFO) and UpdateJobStatus still sees a live runCtx.
+		defer a.recoverAsyncMessageJob(runCtx, userID, newJob.ID, chatMessage.ID)
 		_, err := a.handleUserMessage(runCtx, newJob, chatMessage)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
@@ -526,6 +533,31 @@ func (a *Agent) HandleUserMessage(ctx context.Context, request models.ChatMessag
 		JobID: newJob.ID.String(),
 		Type:  JobTypeChatMessage,
 	}, nil
+}
+
+// recoverAsyncMessageJob is the deferred panic guard for async chat-message processing.
+// A panic in the background goroutine would otherwise crash the whole process (the pod);
+// here it is contained to the single job, which is marked failed and logged with its stack.
+// Failing to record the failed status is itself logged and swallowed — recovery must never
+// re-panic. runCtx must still be live (call before its cancel runs).
+func (a *Agent) recoverAsyncMessageJob(runCtx context.Context, userID, jobID, chatMessageID uuid.UUID) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+	panicMessage := fmt.Sprintf("panic: %v", recovered)
+	if _, failErr := a.ds.UpdateJobStatus(runCtx, userID, jobID, models.JobStatusFailed, panicMessage); failErr != nil {
+		a.logger.Error("failed to mark async agent message job failed after panic",
+			zap.String("job_id", jobID.String()),
+			zap.Error(failErr),
+		)
+	}
+	a.logger.Error("panic recovered in async agent message processing",
+		zap.String("job_id", jobID.String()),
+		zap.String("chat_message_id", chatMessageID.String()),
+		zap.Any("panic", recovered),
+		zap.ByteString("stack_trace", debug.Stack()),
+	)
 }
 
 // RetryUserChatMessage enqueues another chat_message job for an existing user turn.

--- a/internal/agent/message_test.go
+++ b/internal/agent/message_test.go
@@ -9,10 +9,39 @@ import (
 	"github.com/google/uuid"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
 	"go.uber.org/zap"
 )
+
+// TestRecoverAsyncMessageJob_ContainsPanic locks in the pod-crash guard: a panic in the
+// async chat-message goroutine must be contained to its job, not propagated (which would
+// take down the process). It must stay contained even when recording the failed status
+// fails — here the datastore call errors because no expectation is registered.
+func TestRecoverAsyncMessageJob_ContainsPanic(t *testing.T) {
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+	a := newTestAgent(ds)
+
+	require.NotPanics(t, func() {
+		defer a.recoverAsyncMessageJob(context.Background(), uuid.New(), uuid.New(), uuid.New())
+		panic("boom in post-inference checkpoint")
+	})
+}
+
+// TestRecoverAsyncMessageJob_NoPanicIsNoop verifies the guard is inert on the happy path:
+// with no panic in flight it must not touch the datastore (no sqlmock expectations set).
+func TestRecoverAsyncMessageJob_NoPanicIsNoop(t *testing.T) {
+	ds, mock, cleanup := newTestDatastore(t)
+	defer cleanup()
+	a := newTestAgent(ds)
+
+	require.NotPanics(t, func() {
+		defer a.recoverAsyncMessageJob(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	})
+	require.NoError(t, mock.ExpectationsWereMet())
+}
 
 // Test buildAttachmentLabels function
 func TestBuildAttachmentLabels_EmptyAttachments(t *testing.T) {

--- a/internal/agent/provider/fileattachment.go
+++ b/internal/agent/provider/fileattachment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 
@@ -39,7 +40,7 @@ var sandboxLinkRegex = regexp.MustCompile(`\[[^\]]*\]\(sandbox:/mnt/data/[^)]+\)
 var sentenceRegex = regexp.MustCompile(`([.!?]+)\s+`)
 
 func (a *OpenAIProvider) UploadFileAttachment(ctx context.Context, userID uuid.UUID, attrs map[string]string, file io.Reader, fileName string, fileTypeInfo utils.FileTypeInfo) (string, error) {
-	inputFile := openai.File(file, fileName, fileTypeInfo.ContentType)
+	inputFile := openai.File(file, normalizeUploadFileNameExtension(fileName), fileTypeInfo.ContentType)
 
 	storedFile, err := a.oaiClient.Files.New(ctx, openai.FileNewParams{
 		File:    inputFile,
@@ -51,6 +52,22 @@ func (a *OpenAIProvider) UploadFileAttachment(ctx context.Context, userID uuid.U
 	}
 
 	return storedFile.ID, nil
+}
+
+// normalizeUploadFileNameExtension lowercases a filename's extension so files land in the
+// OpenAI Files API with an extension its Responses API accepts. OpenAI validates image
+// extensions case-sensitively (an uploaded "photo.JPG" is later rejected as an unsupported
+// format even though ".jpg" is fine). The base name is left untouched.
+func normalizeUploadFileNameExtension(fileName string) string {
+	ext := path.Ext(fileName)
+	if ext == "" {
+		return fileName
+	}
+	lower := strings.ToLower(ext)
+	if lower == ext {
+		return fileName
+	}
+	return fileName[:len(fileName)-len(ext)] + lower
 }
 
 func (a *OpenAIProvider) DeleteFileAttachment(ctx context.Context, fileID string) error {

--- a/internal/agent/provider/fileattachment_test.go
+++ b/internal/agent/provider/fileattachment_test.go
@@ -360,3 +360,18 @@ This completes the analysis.`
 		assert.Equal(t, expected, result, "Complex markdown with multiple newlines should be fully preserved")
 	})
 }
+
+func TestNormalizeUploadFileNameExtension(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"photo.JPG":       "photo.jpg",
+		"photo.jpg":       "photo.jpg",
+		"doc.PNG":         "doc.png",
+		"archive.tar.GZ":  "archive.tar.gz",
+		"NoExtension":     "NoExtension",
+		"UPPER.name.WEBP": "UPPER.name.webp",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, normalizeUploadFileNameExtension(in), "input %q", in)
+	}
+}

--- a/internal/agent/provider/model_context_openai.go
+++ b/internal/agent/provider/model_context_openai.go
@@ -73,6 +73,82 @@ func appendOpenAIResponseInputImages(parts responses.ResponseInputMessageContent
 	return parts
 }
 
+// openAISupportedImageMediaTypes are the image media types the OpenAI Responses API
+// accepts as input. Other vendors (Anthropic, Gemini) accept a broader set, so an image
+// that arrived on a Claude/Gemini turn can carry a media type OpenAI rejects with a 4xx.
+var openAISupportedImageMediaTypes = map[string]struct{}{
+	"image/jpeg": {},
+	"image/jpg":  {}, // non-standard, but some clients send it
+	"image/png":  {},
+	"image/gif":  {},
+	"image/webp": {},
+}
+
+// openAIAcceptsImage reports whether the OpenAI Responses API will accept this image.
+//
+// Two independent things make OpenAI reject an input image:
+//   - an unsupported media type (e.g. image/heic that rode in on another vendor's turn), and
+//   - a file_id whose *stored* filename extension is not lowercase-supported — OpenAI
+//     validates that case-sensitively, so an uploaded "photo.JPG" is refused even though
+//     JPEG is a supported format.
+//
+// We can inspect the media type here but not the filename behind a file_id, so an image is
+// only accepted when it carries raw bytes to render as a data URL (whose media type we
+// control via normalizeImageMediaType). file_id-only images are treated as unusable for
+// this path; callers that sanitize also clear FileID so survivors render from bytes.
+func openAIAcceptsImage(im UserMessageImage) bool {
+	if len(im.RawBytes) == 0 {
+		return false
+	}
+	mt := strings.ToLower(strings.TrimSpace(im.MediaType))
+	if mt == "" {
+		mt = "image/jpeg" // matches normalizeImageMediaType's default for the data-URL path
+	}
+	_, ok := openAISupportedImageMediaTypes[mt]
+	return ok
+}
+
+// SanitizeImagesForOpenAIInput returns a clone of ctx whose image attachments are safe to
+// send to the OpenAI Responses API. Images OpenAI would reject (see openAIAcceptsImage) are
+// dropped, and FileID is cleared on the survivors so they render as data URLs — sidestepping
+// OpenAI's case-sensitive validation of a file_id's stored filename. A segment left with no
+// images and no text is removed, mirroring StripUserMessageImages, so we never emit an empty
+// turn. Intended for background paths like the checkpoint summarizer, where one bad image
+// must not fail the whole request. Broader upload-time normalization is the longer-term fix.
+func SanitizeImagesForOpenAIInput(ctx *ModelContext) *ModelContext {
+	if ctx == nil {
+		return nil
+	}
+	clone := ctx.Clone()
+	write := 0
+	for read := 0; read < len(clone.Segments); read++ {
+		seg := clone.Segments[read]
+		if len(seg.UserImages) > 0 {
+			kept := seg.UserImages[:0]
+			for _, im := range seg.UserImages {
+				if !openAIAcceptsImage(im) {
+					continue
+				}
+				im.FileID = "" // force the data-URL path; do not trust the stored filename
+				kept = append(kept, im)
+			}
+			if len(kept) == 0 {
+				seg.UserImages = nil
+				// Drop turns that were image-only once their images are gone.
+				if strings.TrimSpace(seg.Content) == "" {
+					continue
+				}
+			} else {
+				seg.UserImages = kept
+			}
+		}
+		clone.Segments[write] = seg
+		write++
+	}
+	clone.Segments = clone.Segments[:write]
+	return clone
+}
+
 func normalizeImageMediaType(mediaType string) string {
 	mt := strings.TrimSpace(mediaType)
 	if mt == "" || !strings.HasPrefix(strings.ToLower(mt), "image/") {

--- a/internal/agent/provider/model_context_openai_test.go
+++ b/internal/agent/provider/model_context_openai_test.go
@@ -191,3 +191,48 @@ func TestBuildOpenAIResponseParams_ModelAndInputItemList(t *testing.T) {
 	require.NotNil(t, p.Input.OfInputItemList)
 	require.GreaterOrEqual(t, len(p.Input.OfInputItemList), 1)
 }
+
+func TestSanitizeImagesForOpenAIInput(t *testing.T) {
+	t.Parallel()
+
+	ctx := &ModelContext{}
+	// Supported type with bytes: kept, but FileID cleared so it renders as a data URL.
+	ctx.AppendUserMessage(RoleUser, "keep me", []UserMessageImage{
+		{FileID: "file-jpg", MediaType: "image/jpeg", RawBytes: []byte{1, 2, 3}},
+	}, false)
+	// Unsupported media type (e.g. from another vendor's turn): dropped, text kept.
+	ctx.AppendUserMessage(RoleUser, "heic here", []UserMessageImage{
+		{MediaType: "image/heic", RawBytes: []byte{4, 5}},
+	}, false)
+	// file_id only, no bytes: cannot verify the stored filename extension, so dropped.
+	ctx.AppendUserMessage(RoleUser, "fileid only", []UserMessageImage{
+		{FileID: "file-JPG", MediaType: "image/jpeg"},
+	}, false)
+	// Image-only turn whose sole image is unsupported: whole segment removed.
+	ctx.AppendUserMessage(RoleUser, "", []UserMessageImage{
+		{MediaType: "image/bmp", RawBytes: []byte{6}},
+	}, false)
+
+	got := SanitizeImagesForOpenAIInput(ctx)
+
+	require.Len(t, got.Segments, 3, "image-only unsupported turn should be dropped")
+
+	require.Len(t, got.Segments[0].UserImages, 1)
+	require.Empty(t, got.Segments[0].UserImages[0].FileID, "FileID must be cleared to force the data-URL path")
+	require.Equal(t, []byte{1, 2, 3}, got.Segments[0].UserImages[0].RawBytes)
+
+	require.Equal(t, "heic here", got.Segments[1].Content)
+	require.Empty(t, got.Segments[1].UserImages)
+
+	require.Equal(t, "fileid only", got.Segments[2].Content)
+	require.Empty(t, got.Segments[2].UserImages)
+
+	// Original context must be untouched (sanitizer works on a clone).
+	require.Equal(t, "file-jpg", ctx.Segments[0].UserImages[0].FileID)
+	require.Len(t, ctx.Segments, 4)
+}
+
+func TestSanitizeImagesForOpenAIInput_NilSafe(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, SanitizeImagesForOpenAIInput(nil))
+}


### PR DESCRIPTION
## Summary

The checkpoint summarizer crashed on images OpenAI won't accept. Some vendors (Anthropic, Gemini) allow image types/filenames OpenAI's Responses API rejects, so when a Claude-model chat reached its checkpoint and rendered those images into the OpenAI summary request, OpenAI returned `400 Bad Request` (`Expected image type ... but got .JPG`) and the whole summary failed. The `.JPG` is OpenAI validating a stored file's **filename extension case-sensitively** on a `file_id` reference — the media type (`image/jpeg`) is valid, the uploaded `.JPG` name is not.

- **Strip OpenAI-unusable images before the summary** (`SanitizeImagesForOpenAIInput`): drop unsupported media types, and render survivors from raw bytes (clearing `FileID`) so we never rely on a stored filename OpenAI might reject. Only affects the Claude checkpoint path; OpenAI chats summarize via `PreviousResponseID` and always carry raw bytes.
- **Normalize uploaded filename extensions to lowercase** so future `file_id` references validate at the source; the strip above is the safety net for files already stored with bad-case names.
- **Recover panics at the async chat-message goroutine root** so a failure fails just that job instead of crashing the process, mirroring the existing `agentjob_run.go` guard.

## Test plan

- [x] `make pre-commit` (fmt, vet, tidy, test, build) — gofmt/vet clean on touched files; `go build ./...` and `go test ./internal/agent/...` pass
- [ ] Frontend lint/test/build (only if `web/` changed) — N/A, backend only
- [x] Manually verified: added regression tests reproduce the exact crash shape (a turn whose image has both a `file_id` and an unsupported sibling) and assert the built summary params surface no `file_id` image and only a normalized data URL; plus sanitizer edge cases, filename normalizer, and the panic guard (contained even when the failed-status DB write errors)

## Checklist

- [x] No credentials, personal exports, generated local state, or production config committed
- [x] Public defaults still work without hosted services (local JWT auth, unlimited usage) — no auth/usage surfaces touched
- [ ] Updated `docs/ARCHITECTURE_SUMMARY.md` / the affected `_PACKAGE_SUMMARY.md` if this touches system boundaries — no boundary changes
- [ ] Regenerated the e2e SDK if `openapi.yaml` changed — N/A
