### PR TITLE
Fix thread manager archive search failures

### DIFF
--- a/internal/datastore/chat.go
+++ b/internal/datastore/chat.go
@@ -580,16 +580,19 @@ func (d *Datastore) ListChats(ctx context.Context, userID uuid.UUID, pageNum, pa
 		queryValue := strings.ToLower(strings.TrimSpace(*filters.Query))
 		if queryValue != "" {
 			likeQuery := "%" + queryValue + "%"
-			// tags are stored as JSON (not a native PG array); use jsonb_array_elements_text.
+			// Tags are stored as JSON (not a native PG array). Legacy rows can contain a
+			// scalar, which jsonb_array_elements_text rejects, so normalize non-arrays to [].
 			// Use sql.P + b.Arg so Postgres gets $n placeholders (ExprP leaves literal "?" in the string).
 			query = query.Where(entchat.Or(
 				entchat.NameContainsFold(queryValue),
 				entchat.CheckpointSummaryContainsFold(queryValue),
 				func(selector *sql.Selector) {
 					selector.Where(sql.P(func(b *sql.Builder) {
-						b.WriteString("EXISTS (SELECT 1 FROM jsonb_array_elements_text(COALESCE(")
+						b.WriteString("EXISTS (SELECT 1 FROM jsonb_array_elements_text(CASE WHEN jsonb_typeof(COALESCE(")
 						b.WriteString(selector.C(entchat.FieldTags))
-						b.WriteString("::jsonb, '[]'::jsonb)) AS _chat_tags(tag_value) WHERE lower(_chat_tags.tag_value) LIKE ")
+						b.WriteString("::jsonb, '[]'::jsonb)) = 'array' THEN COALESCE(")
+						b.WriteString(selector.C(entchat.FieldTags))
+						b.WriteString("::jsonb, '[]'::jsonb) ELSE '[]'::jsonb END) AS _chat_tags(tag_value) WHERE lower(_chat_tags.tag_value) LIKE ")
 						b.Arg(likeQuery)
 						b.WriteString(")")
 					}))
@@ -603,9 +606,11 @@ func (d *Datastore) ListChats(ctx context.Context, userID uuid.UUID, pageNum, pa
 		if exactTag != "" {
 			query = query.Where(func(selector *sql.Selector) {
 				selector.Where(sql.P(func(b *sql.Builder) {
-					b.WriteString("EXISTS (SELECT 1 FROM jsonb_array_elements_text(COALESCE(")
+					b.WriteString("EXISTS (SELECT 1 FROM jsonb_array_elements_text(CASE WHEN jsonb_typeof(COALESCE(")
 					b.WriteString(selector.C(entchat.FieldTags))
-					b.WriteString("::jsonb, '[]'::jsonb)) AS _chat_tags(tag_value) WHERE lower(_chat_tags.tag_value) = ")
+					b.WriteString("::jsonb, '[]'::jsonb)) = 'array' THEN COALESCE(")
+					b.WriteString(selector.C(entchat.FieldTags))
+					b.WriteString("::jsonb, '[]'::jsonb) ELSE '[]'::jsonb END) AS _chat_tags(tag_value) WHERE lower(_chat_tags.tag_value) = ")
 					b.Arg(exactTag)
 					b.WriteString(")")
 				}))

--- a/web/app/e2e/poms/thread-list-panel.page.ts
+++ b/web/app/e2e/poms/thread-list-panel.page.ts
@@ -91,7 +91,19 @@ export class ThreadListPanel {
    * `row(name)`.
    */
   async narrowTo(name: string): Promise<void> {
+    const response = this.page.waitForResponse(
+      candidate => {
+        if (candidate.request().method() !== 'GET') return false;
+        const url = new URL(candidate.url());
+        return url.pathname === '/api/chat' && url.searchParams.get('search') === name;
+      },
+      { timeout: MUTATION_ACK_TIMEOUT },
+    );
     await this.search(name);
+    const completed = await response;
+    if (!completed.ok()) {
+      throw new Error(`Thread search rejected: GET ${new URL(completed.url()).pathname} returned ${completed.status()}`);
+    }
   }
 
   /** Filters the table by personality (the `<select>` in the PERSONALITY header). */

--- a/web/app/src/app/core/services/thread-list.service.spec.ts
+++ b/web/app/src/app/core/services/thread-list.service.spec.ts
@@ -2,7 +2,7 @@ import type { MockedObject } from "vitest";
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { signal } from '@angular/core';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import { ChatService } from './chat.service';
 import { ThreadListService } from './thread-list.service';
@@ -54,6 +54,25 @@ describe('ThreadListService', () => {
         expect(chatService.listAllChats).not.toHaveBeenCalled();
         await new Promise(resolve => setTimeout(resolve, 240));
         expect(chatService.listAllChats).toHaveBeenCalled();
+    });
+
+    it('keeps the newest refresh result when an earlier request resolves last', async () => {
+        const older = new Subject<{ chats: Chat[]; truncated: boolean }>();
+        const newer = new Subject<{ chats: Chat[]; truncated: boolean }>();
+        chatService.listAllChats.mockReturnValueOnce(older).mockReturnValueOnce(newer);
+
+        const olderRefresh = service.refresh();
+        const newerRefresh = service.refresh();
+        newer.next({ chats: [makeChat({ id: 'new', name: 'New result' })], truncated: false });
+        newer.complete();
+        await newerRefresh;
+
+        older.next({ chats: [makeChat({ id: 'old', name: 'Stale result' })], truncated: false });
+        older.complete();
+        await olderRefresh;
+
+        expect(service.filteredThreads().map(thread => thread.id)).toEqual(['new']);
+        expect(service.loading()).toBe(false);
     });
 
     it('optimistically toggles pin and keeps server value', async () => {

--- a/web/app/src/app/core/services/thread-list.service.ts
+++ b/web/app/src/app/core/services/thread-list.service.ts
@@ -51,6 +51,8 @@ export class ThreadListService implements OnDestroy {
   readonly selectedCount = computed(() => this.selectedIds().size);
 
   private queryTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Monotonically increases so a slow prior list request cannot overwrite a newer filter result. */
+  private refreshGeneration = 0;
 
   readonly tags = computed(() => uniqueTags(this.allThreads()));
   readonly personalities = computed<PersonalityOption[]>(() => uniquePersonalityOptions(this.allThreads()));
@@ -159,7 +161,12 @@ export class ThreadListService implements OnDestroy {
     }
   }
 
+  /**
+   * Reloads threads for the current filters. Older in-flight requests are
+   * discarded so slower responses cannot replace newer filter results.
+   */
   async refresh(): Promise<void> {
+    const generation = ++this.refreshGeneration;
     this.clearSelection();
     this.loading.set(true);
     this.error.set(null);
@@ -174,12 +181,14 @@ export class ThreadListService implements OnDestroy {
       const response = await firstValueFrom(
         this.chatService.listAllChats(LIST_PAGE_SIZE, Object.keys(filters).length ? filters : undefined),
       );
+      if (generation !== this.refreshGeneration) return;
       this.allThreads.set(response.chats);
       this.listTruncated.set(response.truncated);
     } catch (error) {
+      if (generation !== this.refreshGeneration) return;
       this.error.set(apiErrorMessage(error, 'Failed to load threads'));
     } finally {
-      this.loading.set(false);
+      if (generation === this.refreshGeneration) this.loading.set(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- ignore stale thread-list refresh responses and wait for filtered-list responses in the E2E POM
- make Postgres tag searches tolerate legacy non-array JSON, avoiding the `/api/chat` 500 that prevented archived threads from appearing
- cover response ordering in `ThreadListService`

## Test plan
- [x] `ENV=test LLM_BACKEND=mock OPENAI_API_KEY=dummy-ci-key go test ./internal/datastore`
- [x] `npm test -- --watch=false --include='src/app/core/services/thread-list.service.spec.ts'`
- [x] `npm run lint:e2e`
- [x] `make ci-local ARGS=\"--only e2e\"`

Made with [Cursor](https://cursor.com)