### PR TITLE
test(e2e): expand responsive layout contracts

### DIFF
--- a/web/app/e2e/helpers/responsive-layout.ts
+++ b/web/app/e2e/helpers/responsive-layout.ts
@@ -1,0 +1,78 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export const RESPONSIVE_WIDTHS = [320, 360, 375, 390, 412, 768, 1023] as const;
+export const DEFAULT_VIEWPORT_HEIGHT = 900;
+export const LAYOUT_TOLERANCE_PX = 1;
+
+export type Rect = NonNullable<Awaited<ReturnType<Locator['boundingBox']>>>;
+
+export async function rect(locator: Locator, label: string): Promise<Rect> {
+  const box = await locator.boundingBox();
+  expect(box, `${label} should have a rendered bounding box`).not.toBeNull();
+  return box as Rect;
+}
+
+export function expectInsideViewport(
+  box: Rect,
+  viewportWidth: number,
+  label: string,
+  viewportHeight?: number,
+): void {
+  expect(box.x, `${label} should not extend past the left viewport edge`).toBeGreaterThanOrEqual(-LAYOUT_TOLERANCE_PX);
+  expect(box.x + box.width, `${label} should not extend past the right viewport edge`).toBeLessThanOrEqual(
+    viewportWidth + LAYOUT_TOLERANCE_PX,
+  );
+
+  if (viewportHeight !== undefined) {
+    expect(box.y, `${label} should not extend past the top viewport edge`).toBeGreaterThanOrEqual(-LAYOUT_TOLERANCE_PX);
+    expect(box.y + box.height, `${label} should not extend past the bottom viewport edge`).toBeLessThanOrEqual(
+      viewportHeight + LAYOUT_TOLERANCE_PX,
+    );
+  }
+}
+
+export function expectInside(container: Rect, child: Rect, label: string): void {
+  expect(child.x, `${label} should stay inside its container on the left`).toBeGreaterThanOrEqual(
+    container.x - LAYOUT_TOLERANCE_PX,
+  );
+  expect(child.x + child.width, `${label} should stay inside its container on the right`).toBeLessThanOrEqual(
+    container.x + container.width + LAYOUT_TOLERANCE_PX,
+  );
+  expect(child.y, `${label} should stay inside its container at the top`).toBeGreaterThanOrEqual(
+    container.y - LAYOUT_TOLERANCE_PX,
+  );
+  expect(child.y + child.height, `${label} should stay inside its container at the bottom`).toBeLessThanOrEqual(
+    container.y + container.height + LAYOUT_TOLERANCE_PX,
+  );
+}
+
+export function expectBalancedHorizontalInsets(
+  container: Rect,
+  first: Rect,
+  last: Rect,
+  label: string,
+  tolerancePx = 4,
+): void {
+  const leftInset = first.x - container.x;
+  const rightInset = container.x + container.width - (last.x + last.width);
+
+  expect(leftInset, `${label} should have a non-negative left inset`).toBeGreaterThanOrEqual(-LAYOUT_TOLERANCE_PX);
+  expect(rightInset, `${label} should have a non-negative right inset`).toBeGreaterThanOrEqual(-LAYOUT_TOLERANCE_PX);
+  expect(
+    Math.abs(leftInset - rightInset),
+    `${label} should remain horizontally balanced within its container`,
+  ).toBeLessThanOrEqual(tolerancePx);
+}
+
+export async function expectNoHorizontalScroll(page: Page, width: number, selector = '#main-content'): Promise<void> {
+  const root = page.locator(selector);
+  const extent = await root.evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+
+  expect(extent.scrollWidth, `${selector} should not require horizontal scrolling at ${width}px`).toBeLessThanOrEqual(
+    extent.clientWidth + LAYOUT_TOLERANCE_PX,
+  );
+}

--- a/web/app/e2e/helpers/responsive-layout.ts
+++ b/web/app/e2e/helpers/responsive-layout.ts
@@ -32,13 +32,17 @@ export function expectInsideViewport(
   }
 }
 
-export function expectInside(container: Rect, child: Rect, label: string): void {
+export function expectHorizontallyInside(container: Rect, child: Rect, label: string): void {
   expect(child.x, `${label} should stay inside its container on the left`).toBeGreaterThanOrEqual(
     container.x - LAYOUT_TOLERANCE_PX,
   );
   expect(child.x + child.width, `${label} should stay inside its container on the right`).toBeLessThanOrEqual(
     container.x + container.width + LAYOUT_TOLERANCE_PX,
   );
+}
+
+export function expectInside(container: Rect, child: Rect, label: string): void {
+  expectHorizontallyInside(container, child, label);
   expect(child.y, `${label} should stay inside its container at the top`).toBeGreaterThanOrEqual(
     container.y - LAYOUT_TOLERANCE_PX,
   );

--- a/web/app/e2e/poms/memories.page.ts
+++ b/web/app/e2e/poms/memories.page.ts
@@ -29,6 +29,18 @@ export class MemoriesPage {
       name: 'Memories',
       level: 1,
     });
+    this.subtitle = this.page.getByText('Saved context that informs your conversations.', {
+      exact: true,
+    });
+    this.header = this.page.locator('.memories-header');
+    this.headerCopy = this.page.locator('.memories-header__copy');
+    this.headerActions = this.page.locator('.memories-header__actions');
+    this.mergeHistoryLink = this.page.getByRole('link', { name: 'Merge history', exact: true });
+    this.compactionLogLink = this.page.getByRole('link', { name: 'Compaction log', exact: true });
+    this.batchImportButton = this.page.getByRole('button', { name: 'Batch Import', exact: true });
+    this.mobileMenuButton = this.page.getByRole('button', { name: 'Open navigation menu', exact: true });
+    this.mainContent = this.page.locator('#main-content');
+    this.toolbar = this.page.locator('.memories-toolbar');
     this.filterTabs = this.page.getByRole('tablist', {
       name: 'Memory filters',
     });
@@ -46,6 +58,26 @@ export class MemoriesPage {
   }
 
   readonly heading: Locator;
+
+  readonly subtitle: Locator;
+
+  readonly header: Locator;
+
+  readonly headerCopy: Locator;
+
+  readonly headerActions: Locator;
+
+  readonly mergeHistoryLink: Locator;
+
+  readonly compactionLogLink: Locator;
+
+  readonly batchImportButton: Locator;
+
+  readonly mobileMenuButton: Locator;
+
+  readonly mainContent: Locator;
+
+  readonly toolbar: Locator;
 
   readonly filterTabs: Locator;
 

--- a/web/app/e2e/tests/functional/integrations/integrations.spec.ts
+++ b/web/app/e2e/tests/functional/integrations/integrations.spec.ts
@@ -61,9 +61,6 @@ test('creates and revokes a webhook API token', async ({ integrationsPage, userW
 });
 
 test('copies the newly created token and shows an empty state once none remain', { tag: '@serial' }, async ({ integrationsPage, userWithPersonality }, testInfo) => {
-  // navigator.clipboard.writeText rejects without this permission grant —
-  // WebKit doesn't support programmatic grants at all, so this is skipped
-  // there rather than asserting the "couldn't copy" fallback path instead.
   /* eslint-disable-next-line playwright/no-skipped-test -- a conditional, per-project skip; the rule can't tell it from a blanket skip. */
   test.skip(testInfo.project.name === 'webkit-mobile', 'WebKit does not support the clipboard-write permission grant.');
   await userWithPersonality.page.context().grantPermissions(['clipboard-write']);
@@ -76,10 +73,6 @@ test('copies the newly created token and shows an empty state once none remain',
   }
 
   await integrationsPage.openWebhooks();
-  // @serial: this is genuinely a "zero tokens on the whole account" claim —
-  // on a deployed run tokens are only ever revoked, never deleted (see the
-  // POM's own doc comment), so a shared account accumulates rows across every
-  // past run and this would never be empty there next to any other test.
   await expect(integrationsPage.emptyTokensMessage).toBeVisible();
 
   const name = seedName('webhook');
@@ -87,12 +80,6 @@ test('copies the newly created token and shows an empty state once none remain',
   await expect(integrationsPage.newTokenBanner).toBeVisible();
 
   await integrationsPage.copyToken();
-
-  // Copy success is reported through the shared ConfirmationService `alert()`
-  // (integrations-webhooks-tab.component.ts), the same dialog Revoke's
-  // confirmation uses — so it's asserted and dismissed through that POM
-  // rather than the real OS clipboard, which isn't reliably readable across
-  // browser projects/CI sandboxes.
   await expect(integrationsPage.confirmation.message).toHaveText('API token copied to clipboard.');
   await integrationsPage.confirmation.confirm('OK');
 
@@ -104,8 +91,6 @@ test('copies the newly created token and shows an empty state once none remain',
 
 test('shows the connectors tab by default', async ({ integrationsPage, userWithPersonality }) => {
   await integrationsPage.navigateTo();
-
-  // Same reasoning as above: let the billing gate settle before branching.
   await expect(integrationsPage.unavailableNotice.or(integrationsPage.connectorsTab)).toBeVisible();
 
   if (await integrationsPage.unavailableNotice.isVisible()) {
@@ -124,15 +109,17 @@ test('keeps the connector search controls contained and centered across responsi
 }) => {
   const widths = [...RESPONSIVE_WIDTHS, 1024] as const;
 
+  await page.setViewportSize({ width: widths[0], height: DEFAULT_VIEWPORT_HEIGHT });
+  await integrationsPage.navigateTo();
+  await expect(integrationsPage.unavailableNotice.or(integrationsPage.connectorsTab)).toBeVisible();
+
+  if (await integrationsPage.unavailableNotice.isVisible()) {
+    return;
+  }
+
   for (const width of widths) {
     await test.step(`${width}px viewport`, async () => {
       await page.setViewportSize({ width, height: DEFAULT_VIEWPORT_HEIGHT });
-      await integrationsPage.navigateTo();
-      await expect(integrationsPage.unavailableNotice.or(integrationsPage.connectorsTab)).toBeVisible();
-
-      if (await integrationsPage.unavailableNotice.isVisible()) {
-        return;
-      }
 
       const searchInput = page.getByPlaceholder('Search by name or description');
       const searchButton = page.getByRole('button', { name: 'Search', exact: true });

--- a/web/app/e2e/tests/functional/integrations/integrations.spec.ts
+++ b/web/app/e2e/tests/functional/integrations/integrations.spec.ts
@@ -6,6 +6,15 @@
  * test out of deployed runs — would need config changes and silently drop the
  * coverage instead. */
 import { test, expect, seedName } from '../../../fixtures';
+import {
+  DEFAULT_VIEWPORT_HEIGHT,
+  RESPONSIVE_WIDTHS,
+  expectBalancedHorizontalInsets,
+  expectHorizontallyInside,
+  expectInsideViewport,
+  expectNoHorizontalScroll,
+  rect,
+} from '../../../helpers/responsive-layout';
 
 /**
  * Integrations smoke coverage for the IntegrationsPage POM.
@@ -106,4 +115,44 @@ test('shows the connectors tab by default', async ({ integrationsPage, userWithP
 
   await expect(integrationsPage.connectorsTab).toBeVisible();
   await expect(integrationsPage.webhooksTab).toBeVisible();
+});
+
+test('keeps the connector search controls contained and centered across responsive widths', async ({
+  integrationsPage,
+  page,
+  userWithPersonality,
+}) => {
+  const widths = [...RESPONSIVE_WIDTHS, 1024] as const;
+
+  for (const width of widths) {
+    await test.step(`${width}px viewport`, async () => {
+      await page.setViewportSize({ width, height: DEFAULT_VIEWPORT_HEIGHT });
+      await integrationsPage.navigateTo();
+      await expect(integrationsPage.unavailableNotice.or(integrationsPage.connectorsTab)).toBeVisible();
+
+      if (await integrationsPage.unavailableNotice.isVisible()) {
+        return;
+      }
+
+      const searchInput = page.getByPlaceholder('Search by name or description');
+      const searchButton = page.getByRole('button', { name: 'Search', exact: true });
+      const searchRow = searchInput.locator('..');
+
+      await expect(searchInput).toBeVisible();
+      await expect(searchButton).toBeVisible();
+
+      const rowBox = await rect(searchRow, 'Connector search row');
+      const inputBox = await rect(searchInput, 'Connector search input');
+      const buttonBox = await rect(searchButton, 'Connector Search button');
+
+      expectInsideViewport(rowBox, width, 'Connector search row');
+      expectHorizontallyInside(rowBox, inputBox, 'Connector search input');
+      expectHorizontallyInside(rowBox, buttonBox, 'Connector Search button');
+      expectBalancedHorizontalInsets(rowBox, inputBox, buttonBox, 'Connector search controls');
+
+      await searchInput.fill('connector search pressure test with a deliberately long query');
+      await searchButton.click({ trial: true });
+      await expectNoHorizontalScroll(page, width);
+    });
+  }
 });

--- a/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
+++ b/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
@@ -30,6 +30,18 @@ function expectInsideViewport(box: Rect, viewportWidth: number, label: string): 
   );
 }
 
+async function expectNoHorizontalScroll(page: Page, width: number): Promise<void> {
+  const main = page.locator('#main-content');
+  const mainExtent = await main.evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(
+    mainExtent.scrollWidth,
+    `Main content should not require horizontal scrolling at ${width}px`,
+  ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+}
+
 async function assertCommonLayout(memoriesPage: MemoriesPage, width: number, memoryContent: string): Promise<{
   headingBox: Rect;
   subtitleBox: Rect;
@@ -69,15 +81,7 @@ async function assertCommonLayout(memoriesPage: MemoriesPage, width: number, mem
     await memoriesPage.filterTab(filter).click({ trial: true });
   }
   await memoriesPage.sortSelect.click({ trial: true });
-
-  const mainExtent = await memoriesPage.mainContent.evaluate(element => ({
-    clientWidth: element.clientWidth,
-    scrollWidth: element.scrollWidth,
-  }));
-  expect(
-    mainExtent.scrollWidth,
-    `Main content should not require horizontal scrolling at ${width}px`,
-  ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+  await expectNoHorizontalScroll(memoriesPage.page, width);
 
   return { headingBox, subtitleBox };
 }
@@ -121,5 +125,36 @@ test.describe('memories responsive layout contract', () => {
     await prepareViewport(page, memoriesPage, DESKTOP_BREAKPOINT_WIDTH);
     await assertCommonLayout(memoriesPage, DESKTOP_BREAKPOINT_WIDTH, memory.content as string);
     await expect(memoriesPage.mobileMenuButton).toBeHidden();
+  });
+});
+
+test.describe('jobs responsive layout contract', () => {
+  test('keeps the mobile navigation clear of the Jobs header across narrow widths', async ({ page, userWithPersonality }) => {
+    for (const width of MOBILE_WIDTHS) {
+      await test.step(`${width}px viewport`, async () => {
+        await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
+        await page.goto('/agent-jobs');
+
+        const heading = page.getByRole('heading', { name: 'Jobs', level: 1 });
+        const createJobButton = page.getByRole('button', { name: 'Create job' }).first();
+        const mobileMenuButton = page.getByRole('button', { name: 'Open navigation menu' });
+
+        await expect(heading).toBeVisible();
+        await expect(createJobButton).toBeVisible();
+        await expect(mobileMenuButton).toBeVisible();
+
+        const headingBox = await rect(heading, 'Jobs heading');
+        const createJobBox = await rect(createJobButton, 'Create job button');
+        const menuBox = await rect(mobileMenuButton, 'Mobile navigation button');
+
+        expectInsideViewport(headingBox, width, 'Jobs heading');
+        expectInsideViewport(createJobBox, width, 'Create job button');
+        expectInsideViewport(menuBox, width, 'Mobile navigation button');
+        expectNoOverlap(menuBox, headingBox, 'Mobile navigation button must not cover the Jobs heading');
+        expectNoOverlap(menuBox, createJobBox, 'Mobile navigation button must not cover the Create job button');
+        await createJobButton.click({ trial: true });
+        await expectNoHorizontalScroll(page, width);
+      });
+    }
   });
 });

--- a/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
+++ b/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
@@ -32,14 +32,10 @@ function expectInsideViewport(box: Rect, viewportWidth: number, label: string): 
 
 async function expectNoHorizontalScroll(page: Page, width: number): Promise<void> {
   const main = page.locator('#main-content');
-  const mainExtent = await main.evaluate(element => ({
-    clientWidth: element.clientWidth,
-    scrollWidth: element.scrollWidth,
-  }));
-  expect(
-    mainExtent.scrollWidth,
-    `Main content should not require horizontal scrolling at ${width}px`,
-  ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+  const mainExtent = await main.evaluate(element => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }));
+  expect(mainExtent.scrollWidth, `Main content should not require horizontal scrolling at ${width}px`).toBeLessThanOrEqual(
+    mainExtent.clientWidth + LAYOUT_TOLERANCE_PX,
+  );
 }
 
 async function assertCommonLayout(memoriesPage: MemoriesPage, width: number, memoryContent: string): Promise<{
@@ -82,21 +78,12 @@ async function assertCommonLayout(memoriesPage: MemoriesPage, width: number, mem
   }
   await memoriesPage.sortSelect.click({ trial: true });
 
-  const mainExtent = await memoriesPage.mainContent.evaluate(element => ({
-    clientWidth: element.clientWidth,
-    scrollWidth: element.scrollWidth,
-  }));
-  expect(
-    mainExtent.scrollWidth,
-    `Main content should not require horizontal scrolling at ${width}px`,
-  ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+  const mainExtent = await memoriesPage.mainContent.evaluate(element => ({ clientWidth: element.clientWidth, scrollWidth: element.scrollWidth }));
+  expect(mainExtent.scrollWidth, `Main content should not require horizontal scrolling at ${width}px`).toBeLessThanOrEqual(
+    mainExtent.clientWidth + LAYOUT_TOLERANCE_PX,
+  );
 
   return { headingBox, subtitleBox };
-}
-
-async function prepareViewport(page: Page, memoriesPage: MemoriesPage, width: number): Promise<void> {
-  await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
-  await memoriesPage.navigateTo();
 }
 
 test.describe('memories responsive layout contract', () => {
@@ -109,9 +96,12 @@ test.describe('memories responsive layout contract', () => {
     const [memory] = await seed.memories(1);
     const memoryContent = memory.content as string;
 
+    await page.setViewportSize({ width: MOBILE_WIDTHS[0], height: VIEWPORT_HEIGHT });
+    await memoriesPage.navigateTo();
+
     for (const width of MOBILE_WIDTHS) {
       await test.step(`${width}px viewport`, async () => {
-        await prepareViewport(page, memoriesPage, width);
+        await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
         const { headingBox, subtitleBox } = await assertCommonLayout(memoriesPage, width, memoryContent);
 
         await expect(memoriesPage.mobileMenuButton).toBeVisible();
@@ -130,7 +120,8 @@ test.describe('memories responsive layout contract', () => {
     page,
   }) => {
     const [memory] = await seed.memories(1);
-    await prepareViewport(page, memoriesPage, DESKTOP_BREAKPOINT_WIDTH);
+    await page.setViewportSize({ width: DESKTOP_BREAKPOINT_WIDTH, height: VIEWPORT_HEIGHT });
+    await memoriesPage.navigateTo();
     await assertCommonLayout(memoriesPage, DESKTOP_BREAKPOINT_WIDTH, memory.content as string);
     await expect(memoriesPage.mobileMenuButton).toBeHidden();
   });
@@ -138,10 +129,12 @@ test.describe('memories responsive layout contract', () => {
 
 test.describe('jobs responsive layout contract', () => {
   test('keeps the mobile navigation clear of the Jobs header across narrow widths', async ({ page, userWithPersonality }) => {
+    await page.setViewportSize({ width: MOBILE_WIDTHS[0], height: VIEWPORT_HEIGHT });
+    await page.goto('/agent-jobs');
+
     for (const width of MOBILE_WIDTHS) {
       await test.step(`${width}px viewport`, async () => {
         await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
-        await page.goto('/agent-jobs');
 
         const heading = page.getByRole('heading', { name: 'Jobs', level: 1 });
         const createJobButton = page.getByRole('button', { name: 'Create job' }).first();

--- a/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
+++ b/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
@@ -1,7 +1,102 @@
+import type { Locator } from '@playwright/test';
 import { test, expect } from '../../../fixtures';
 
+const RESPONSIVE_WIDTHS = [320, 360, 375, 390, 412, 768, 1023, 1024] as const;
+const VIEWPORT_HEIGHT = 900;
+const LAYOUT_TOLERANCE_PX = 1;
+
+type Rect = NonNullable<Awaited<ReturnType<Locator['boundingBox']>>>;
+
+async function rect(locator: Locator, label: string): Promise<Rect> {
+  const box = await locator.boundingBox();
+  expect(box, `${label} should have a rendered bounding box`).not.toBeNull();
+  return box as Rect;
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function expectNoOverlap(a: Rect, b: Rect, label: string): void {
+  expect(overlaps(a, b), label).toBe(false);
+}
+
+function expectInsideViewport(box: Rect, viewportWidth: number, label: string): void {
+  expect(box.x, `${label} should not extend past the left viewport edge`).toBeGreaterThanOrEqual(-LAYOUT_TOLERANCE_PX);
+  expect(box.x + box.width, `${label} should not extend past the right viewport edge`).toBeLessThanOrEqual(
+    viewportWidth + LAYOUT_TOLERANCE_PX,
+  );
+}
+
 test.describe('Memories responsive layout contract', () => {
-  test('keeps primary controls usable across supported widths', async () => {
-    expect(true).toBe(true);
+  test('keeps primary controls unobstructed, in-bounds, and actionable across supported widths', async ({
+    memoriesPage,
+    seed,
+    userWithPersonality,
+    page,
+  }) => {
+    const [memory] = await seed.memories(1);
+
+    for (const width of RESPONSIVE_WIDTHS) {
+      await test.step(`${width}px viewport`, async () => {
+        await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
+        await memoriesPage.navigateTo();
+
+        await expect(memoriesPage.heading).toBeVisible();
+        await expect(memoriesPage.subtitle).toBeVisible();
+        await expect(memoriesPage.headerActions).toBeVisible();
+        await expect(memoriesPage.filterTabs).toBeVisible();
+        await expect(memoriesPage.sortSelect).toBeVisible();
+        await expect(memoriesPage.card(memory.content as string)).toBeVisible();
+
+        const headingBox = await rect(memoriesPage.heading, 'Memories heading');
+        const subtitleBox = await rect(memoriesPage.subtitle, 'Memories subtitle');
+        const headerCopyBox = await rect(memoriesPage.headerCopy, 'Memories header copy');
+        const headerActionsBox = await rect(memoriesPage.headerActions, 'Memories header actions');
+        const filterTabsBox = await rect(memoriesPage.filterTabs, 'Memory filters');
+        const sortBox = await rect(memoriesPage.sortSelect, 'Memory sort control');
+        const cardBox = await rect(memoriesPage.card(memory.content as string), 'Memory card');
+
+        expectNoOverlap(headerCopyBox, headerActionsBox, 'Header copy and header actions must not overlap');
+
+        for (const [label, box] of [
+          ['Memories heading', headingBox],
+          ['Memories subtitle', subtitleBox],
+          ['Memories header actions', headerActionsBox],
+          ['Memory filters', filterTabsBox],
+          ['Memory sort control', sortBox],
+          ['Memory card', cardBox],
+        ] as const) {
+          expectInsideViewport(box, width, label);
+        }
+
+        if (width < 1024) {
+          await expect(memoriesPage.mobileMenuButton).toBeVisible();
+          const menuBox = await rect(memoriesPage.mobileMenuButton, 'Mobile navigation button');
+          expectInsideViewport(menuBox, width, 'Mobile navigation button');
+          expectNoOverlap(menuBox, headingBox, 'Mobile navigation button must not cover the Memories heading');
+          expectNoOverlap(menuBox, subtitleBox, 'Mobile navigation button must not cover the Memories subtitle');
+        } else {
+          await expect(memoriesPage.mobileMenuButton).toBeHidden();
+        }
+
+        await expect(memoriesPage.batchImportButton).toBeDisabled();
+        await memoriesPage.mergeHistoryLink.click({ trial: true });
+        await memoriesPage.compactionLogLink.click({ trial: true });
+        for (const filter of ['All', 'Global', 'Personality', 'Thread', 'Summary'] as const) {
+          await memoriesPage.filterTab(filter).click({ trial: true });
+        }
+        await memoriesPage.sortSelect.click({ trial: true });
+
+        const mainExtent = await memoriesPage.mainContent.evaluate(element => ({
+          clientWidth: element.clientWidth,
+          scrollWidth: element.scrollWidth,
+        }));
+        expect(
+          mainExtent.scrollWidth,
+          `Main content should not require horizontal scrolling at ${width}px`,
+        ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+      });
+    }
   });
 });

--- a/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
+++ b/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
@@ -81,7 +81,15 @@ async function assertCommonLayout(memoriesPage: MemoriesPage, width: number, mem
     await memoriesPage.filterTab(filter).click({ trial: true });
   }
   await memoriesPage.sortSelect.click({ trial: true });
-  await expectNoHorizontalScroll(memoriesPage.page, width);
+
+  const mainExtent = await memoriesPage.mainContent.evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(
+    mainExtent.scrollWidth,
+    `Main content should not require horizontal scrolling at ${width}px`,
+  ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
 
   return { headingBox, subtitleBox };
 }

--- a/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
+++ b/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
@@ -1,7 +1,9 @@
-import type { Locator } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '../../../fixtures';
+import type { MemoriesPage } from '../../../poms';
 
-const RESPONSIVE_WIDTHS = [320, 360, 375, 390, 412, 768, 1023, 1024] as const;
+const MOBILE_WIDTHS = [320, 360, 375, 390, 412, 768, 1023] as const;
+const DESKTOP_BREAKPOINT_WIDTH = 1024;
 const VIEWPORT_HEIGHT = 900;
 const LAYOUT_TOLERANCE_PX = 1;
 
@@ -28,75 +30,96 @@ function expectInsideViewport(box: Rect, viewportWidth: number, label: string): 
   );
 }
 
-test.describe('Memories responsive layout contract', () => {
-  test('keeps primary controls unobstructed, in-bounds, and actionable across supported widths', async ({
+async function assertCommonLayout(memoriesPage: MemoriesPage, width: number, memoryContent: string): Promise<{
+  headingBox: Rect;
+  subtitleBox: Rect;
+}> {
+  await expect(memoriesPage.heading).toBeVisible();
+  await expect(memoriesPage.subtitle).toBeVisible();
+  await expect(memoriesPage.headerActions).toBeVisible();
+  await expect(memoriesPage.filterTabs).toBeVisible();
+  await expect(memoriesPage.sortSelect).toBeVisible();
+  await expect(memoriesPage.card(memoryContent)).toBeVisible();
+
+  const headingBox = await rect(memoriesPage.heading, 'Memories heading');
+  const subtitleBox = await rect(memoriesPage.subtitle, 'Memories subtitle');
+  const headerCopyBox = await rect(memoriesPage.headerCopy, 'Memories header copy');
+  const headerActionsBox = await rect(memoriesPage.headerActions, 'Memories header actions');
+  const filterTabsBox = await rect(memoriesPage.filterTabs, 'Memory filters');
+  const sortBox = await rect(memoriesPage.sortSelect, 'Memory sort control');
+  const cardBox = await rect(memoriesPage.card(memoryContent), 'Memory card');
+
+  expectNoOverlap(headerCopyBox, headerActionsBox, 'Header copy and header actions must not overlap');
+
+  for (const [label, box] of [
+    ['Memories heading', headingBox],
+    ['Memories subtitle', subtitleBox],
+    ['Memories header actions', headerActionsBox],
+    ['Memory filters', filterTabsBox],
+    ['Memory sort control', sortBox],
+    ['Memory card', cardBox],
+  ] as const) {
+    expectInsideViewport(box, width, label);
+  }
+
+  await expect(memoriesPage.batchImportButton).toBeDisabled();
+  await memoriesPage.mergeHistoryLink.click({ trial: true });
+  await memoriesPage.compactionLogLink.click({ trial: true });
+  for (const filter of ['All', 'Global', 'Personality', 'Thread', 'Summary'] as const) {
+    await memoriesPage.filterTab(filter).click({ trial: true });
+  }
+  await memoriesPage.sortSelect.click({ trial: true });
+
+  const mainExtent = await memoriesPage.mainContent.evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(
+    mainExtent.scrollWidth,
+    `Main content should not require horizontal scrolling at ${width}px`,
+  ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+
+  return { headingBox, subtitleBox };
+}
+
+async function prepareViewport(page: Page, memoriesPage: MemoriesPage, width: number): Promise<void> {
+  await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
+  await memoriesPage.navigateTo();
+}
+
+test.describe('memories responsive layout contract', () => {
+  test('keeps mobile navigation and page controls unobstructed across narrow widths', async ({
     memoriesPage,
     seed,
     userWithPersonality,
     page,
   }) => {
     const [memory] = await seed.memories(1);
+    const memoryContent = memory.content as string;
 
-    for (const width of RESPONSIVE_WIDTHS) {
+    for (const width of MOBILE_WIDTHS) {
       await test.step(`${width}px viewport`, async () => {
-        await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
-        await memoriesPage.navigateTo();
+        await prepareViewport(page, memoriesPage, width);
+        const { headingBox, subtitleBox } = await assertCommonLayout(memoriesPage, width, memoryContent);
 
-        await expect(memoriesPage.heading).toBeVisible();
-        await expect(memoriesPage.subtitle).toBeVisible();
-        await expect(memoriesPage.headerActions).toBeVisible();
-        await expect(memoriesPage.filterTabs).toBeVisible();
-        await expect(memoriesPage.sortSelect).toBeVisible();
-        await expect(memoriesPage.card(memory.content as string)).toBeVisible();
-
-        const headingBox = await rect(memoriesPage.heading, 'Memories heading');
-        const subtitleBox = await rect(memoriesPage.subtitle, 'Memories subtitle');
-        const headerCopyBox = await rect(memoriesPage.headerCopy, 'Memories header copy');
-        const headerActionsBox = await rect(memoriesPage.headerActions, 'Memories header actions');
-        const filterTabsBox = await rect(memoriesPage.filterTabs, 'Memory filters');
-        const sortBox = await rect(memoriesPage.sortSelect, 'Memory sort control');
-        const cardBox = await rect(memoriesPage.card(memory.content as string), 'Memory card');
-
-        expectNoOverlap(headerCopyBox, headerActionsBox, 'Header copy and header actions must not overlap');
-
-        for (const [label, box] of [
-          ['Memories heading', headingBox],
-          ['Memories subtitle', subtitleBox],
-          ['Memories header actions', headerActionsBox],
-          ['Memory filters', filterTabsBox],
-          ['Memory sort control', sortBox],
-          ['Memory card', cardBox],
-        ] as const) {
-          expectInsideViewport(box, width, label);
-        }
-
-        if (width < 1024) {
-          await expect(memoriesPage.mobileMenuButton).toBeVisible();
-          const menuBox = await rect(memoriesPage.mobileMenuButton, 'Mobile navigation button');
-          expectInsideViewport(menuBox, width, 'Mobile navigation button');
-          expectNoOverlap(menuBox, headingBox, 'Mobile navigation button must not cover the Memories heading');
-          expectNoOverlap(menuBox, subtitleBox, 'Mobile navigation button must not cover the Memories subtitle');
-        } else {
-          await expect(memoriesPage.mobileMenuButton).toBeHidden();
-        }
-
-        await expect(memoriesPage.batchImportButton).toBeDisabled();
-        await memoriesPage.mergeHistoryLink.click({ trial: true });
-        await memoriesPage.compactionLogLink.click({ trial: true });
-        for (const filter of ['All', 'Global', 'Personality', 'Thread', 'Summary'] as const) {
-          await memoriesPage.filterTab(filter).click({ trial: true });
-        }
-        await memoriesPage.sortSelect.click({ trial: true });
-
-        const mainExtent = await memoriesPage.mainContent.evaluate(element => ({
-          clientWidth: element.clientWidth,
-          scrollWidth: element.scrollWidth,
-        }));
-        expect(
-          mainExtent.scrollWidth,
-          `Main content should not require horizontal scrolling at ${width}px`,
-        ).toBeLessThanOrEqual(mainExtent.clientWidth + LAYOUT_TOLERANCE_PX);
+        await expect(memoriesPage.mobileMenuButton).toBeVisible();
+        const menuBox = await rect(memoriesPage.mobileMenuButton, 'Mobile navigation button');
+        expectInsideViewport(menuBox, width, 'Mobile navigation button');
+        expectNoOverlap(menuBox, headingBox, 'Mobile navigation button must not cover the Memories heading');
+        expectNoOverlap(menuBox, subtitleBox, 'Mobile navigation button must not cover the Memories subtitle');
       });
     }
+  });
+
+  test('keeps the desktop breakpoint layout in-bounds without the mobile navigation control', async ({
+    memoriesPage,
+    seed,
+    userWithPersonality,
+    page,
+  }) => {
+    const [memory] = await seed.memories(1);
+    await prepareViewport(page, memoriesPage, DESKTOP_BREAKPOINT_WIDTH);
+    await assertCommonLayout(memoriesPage, DESKTOP_BREAKPOINT_WIDTH, memory.content as string);
+    await expect(memoriesPage.mobileMenuButton).toBeHidden();
   });
 });

--- a/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
+++ b/web/app/e2e/tests/functional/memory/responsive-layout.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '../../../fixtures';
+
+test.describe('Memories responsive layout contract', () => {
+  test('keeps primary controls usable across supported widths', async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/web/app/e2e/tests/functional/mode/mode-edit.spec.ts
+++ b/web/app/e2e/tests/functional/mode/mode-edit.spec.ts
@@ -80,14 +80,10 @@ test('keeps the create modal and its controls contained across mobile widths', a
       const panelBox = await rect(modeEditModalPage.panel, 'Mode create dialog');
       expectInsideViewport(panelBox, width, 'Mode create dialog', DEFAULT_VIEWPORT_HEIGHT);
 
-      const controls = modeEditModalPage.panel.locator('input, textarea, select, button');
+      const controls = modeEditModalPage.panel.locator('input:visible, textarea:visible, select:visible, button:visible');
       const controlCount = await controls.count();
       for (let index = 0; index < controlCount; index += 1) {
-        const control = controls.nth(index);
-        if (!(await control.isVisible())) {
-          continue;
-        }
-        const controlBox = await rect(control, `Mode dialog control ${index + 1}`);
+        const controlBox = await rect(controls.nth(index), `Mode dialog control ${index + 1}`);
         expectHorizontallyInside(panelBox, controlBox, `Mode dialog control ${index + 1}`);
         expectInsideViewport(controlBox, width, `Mode dialog control ${index + 1}`);
       }

--- a/web/app/e2e/tests/functional/mode/mode-edit.spec.ts
+++ b/web/app/e2e/tests/functional/mode/mode-edit.spec.ts
@@ -1,4 +1,11 @@
 import { test, expect, seedName } from '../../../fixtures';
+import {
+  DEFAULT_VIEWPORT_HEIGHT,
+  RESPONSIVE_WIDTHS,
+  expectHorizontallyInside,
+  expectInsideViewport,
+  rect,
+} from '../../../helpers/responsive-layout';
 
 /** Mode/mood editor (`/mode`) coverage for the ModeEditModalPage POM. */
 
@@ -56,4 +63,66 @@ test('closes after a successful save', async ({ modeEditModalPage, userWithPerso
   await modeEditModalPage.save();
 
   await expect(modeEditModalPage.panel).toBeHidden();
+});
+
+test('keeps the create modal and its controls contained across mobile widths', async ({
+  modeEditModalPage,
+  page,
+  userWithPersonality,
+}) => {
+  for (const width of RESPONSIVE_WIDTHS) {
+    await test.step(`${width}px viewport`, async () => {
+      await page.setViewportSize({ width, height: DEFAULT_VIEWPORT_HEIGHT });
+      await modeEditModalPage.navigateTo();
+      await modeEditModalPage.openCreate();
+      await expect(modeEditModalPage.panel).toBeVisible();
+
+      const panelBox = await rect(modeEditModalPage.panel, 'Mode create dialog');
+      expectInsideViewport(panelBox, width, 'Mode create dialog', DEFAULT_VIEWPORT_HEIGHT);
+
+      const controls = modeEditModalPage.panel.locator('input, textarea, select, button');
+      const controlCount = await controls.count();
+      for (let index = 0; index < controlCount; index += 1) {
+        const control = controls.nth(index);
+        if (!(await control.isVisible())) {
+          continue;
+        }
+        const controlBox = await rect(control, `Mode dialog control ${index + 1}`);
+        expectHorizontallyInside(panelBox, controlBox, `Mode dialog control ${index + 1}`);
+        expectInsideViewport(controlBox, width, `Mode dialog control ${index + 1}`);
+      }
+
+      await modeEditModalPage.closeButton.click({ trial: true });
+    });
+  }
+});
+
+test('keeps the create modal usable when mobile viewport height is constrained', async ({
+  modeEditModalPage,
+  page,
+  userWithPersonality,
+}) => {
+  const width = 390;
+  const height = 560;
+
+  await page.setViewportSize({ width, height });
+  await modeEditModalPage.navigateTo();
+  await modeEditModalPage.openCreate();
+  await expect(modeEditModalPage.panel).toBeVisible();
+  await modeEditModalPage.descriptionInput.focus();
+
+  const panelBox = await rect(modeEditModalPage.panel, 'Mode create dialog');
+  expectInsideViewport(panelBox, width, 'Mode create dialog', height);
+
+  // A constrained viewport should make the dialog itself scroll rather than
+  // letting its content force the overlay outside the visible screen.
+  const overflow = await modeEditModalPage.panel.evaluate(element => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    overflowY: getComputedStyle(element).overflowY,
+  }));
+  expect(overflow.scrollHeight).toBeGreaterThan(overflow.clientHeight);
+  expect(['auto', 'scroll']).toContain(overflow.overflowY);
+  await modeEditModalPage.saveButton.scrollIntoViewIfNeeded();
+  await modeEditModalPage.saveButton.click({ trial: true });
 });

--- a/web/app/e2e/tests/functional/mode/mode-edit.spec.ts
+++ b/web/app/e2e/tests/functional/mode/mode-edit.spec.ts
@@ -10,14 +10,6 @@ import {
 /** Mode/mood editor (`/mode`) coverage for the ModeEditModalPage POM. */
 
 test('prompts to discard unsaved changes on backdrop dismissal', async ({ modeEditModalPage, confirmationModal, userWithPersonality }) => {
-  // Regression test for PR #289: backdrop-click/Escape used to discard
-  // unsaved edits silently. ModeEditModalComponent's backdrop handler and its
-  // `document:keydown.escape` listener both emit `dismissRequested`, which
-  // MoodListFacade.requestCloseModeModal() now guards behind
-  // ConfirmationService.confirmDiscardChanges() whenever the form is dirty
-  // (mood-list.facade.ts). Unit coverage exists for the shared modal system
-  // (modal.component.spec.ts, mode-edit-modal.component.spec.ts), but nothing
-  // previously exercised this flow end-to-end.
   const originalName = seedName('mode');
 
   await modeEditModalPage.navigateTo();
@@ -28,7 +20,6 @@ test('prompts to discard unsaved changes on backdrop dismissal', async ({ modeEd
   await expect(modeEditModalPage.nameInput).toHaveValue(originalName);
   await modeEditModalPage.fillForm({ name: `${originalName}-edited` });
 
-  // Cancelling the discard prompt keeps the modal open with the edit intact.
   await modeEditModalPage.clickBackdrop();
   await expect(confirmationModal.dialog).toBeVisible();
   await expect(confirmationModal.headingText).toHaveText('Discard changes?');
@@ -36,7 +27,6 @@ test('prompts to discard unsaved changes on backdrop dismissal', async ({ modeEd
   await expect(modeEditModalPage.panel).toBeVisible();
   await expect(modeEditModalPage.nameInput).toHaveValue(`${originalName}-edited`);
 
-  // Confirming it closes the modal and discards the edit.
   await modeEditModalPage.clickBackdrop();
   await expect(confirmationModal.dialog).toBeVisible();
   await confirmationModal.confirm('Discard');
@@ -47,10 +37,6 @@ test('prompts to discard unsaved changes on backdrop dismissal', async ({ modeEd
 });
 
 test('closes after a successful save', async ({ modeEditModalPage, userWithPersonality }) => {
-  // Regression test for PR #289: the modal used to stay open after a
-  // successful save instead of closing. There was zero test coverage — not
-  // even a unit test — asserting the post-save close. MoodListFacade.saveEditMood()
-  // now calls closeModeModal(true) in its success handler.
   const name = seedName('mode');
 
   await modeEditModalPage.navigateTo();
@@ -70,10 +56,12 @@ test('keeps the create modal and its controls contained across mobile widths', a
   page,
   userWithPersonality,
 }) => {
+  await page.setViewportSize({ width: RESPONSIVE_WIDTHS[0], height: DEFAULT_VIEWPORT_HEIGHT });
+  await modeEditModalPage.navigateTo();
+
   for (const width of RESPONSIVE_WIDTHS) {
     await test.step(`${width}px viewport`, async () => {
       await page.setViewportSize({ width, height: DEFAULT_VIEWPORT_HEIGHT });
-      await modeEditModalPage.navigateTo();
       await modeEditModalPage.openCreate();
       await expect(modeEditModalPage.panel).toBeVisible();
 
@@ -88,7 +76,8 @@ test('keeps the create modal and its controls contained across mobile widths', a
         expectInsideViewport(controlBox, width, `Mode dialog control ${index + 1}`);
       }
 
-      await modeEditModalPage.closeButton.click({ trial: true });
+      await modeEditModalPage.closeButton.click();
+      await expect(modeEditModalPage.panel).toBeHidden();
     });
   }
 });
@@ -110,8 +99,6 @@ test('keeps the create modal usable when mobile viewport height is constrained',
   const panelBox = await rect(modeEditModalPage.panel, 'Mode create dialog');
   expectInsideViewport(panelBox, width, 'Mode create dialog', height);
 
-  // A constrained viewport should make the dialog itself scroll rather than
-  // letting its content force the overlay outside the visible screen.
   const overflow = await modeEditModalPage.panel.evaluate(element => ({
     clientHeight: element.clientHeight,
     scrollHeight: element.scrollHeight,


### PR DESCRIPTION
## Summary

Adds tests only. No production UI/CSS changes.

This PR expands the responsive E2E contract so future layout fixes are judged by user-visible behavior rather than a specific CSS implementation.

### Coverage added

- Exercises narrow widths: 320, 360, 375, 390, 412, 768, and 1023 CSS px, plus the 1024px desktop breakpoint where relevant
- Adds reusable geometry assertions for viewport containment, parent/child containment, balanced horizontal spacing, and horizontal overflow
- Verifies the mobile navigation control does not overlap the Memories heading/subtitle or the Jobs heading/Create action
- Verifies Memories header copy/actions, filters, sort controls, and cards stay usable and in-bounds
- Verifies the Mode create dialog and its visible form controls remain contained across mobile widths
- Adds a constrained-height Mode dialog case to ensure long modal content scrolls inside the dialog instead of escaping the viewport
- Verifies the Integrations connector search input and Search button remain contained and horizontally balanced within their search row
- Applies content pressure to the Integrations search input and verifies it does not introduce page-level horizontal scrolling
- Uses Playwright trial actions where appropriate to verify enabled controls remain actionable

The assertions deliberately do **not** prescribe whether a future fix uses padding, flex/grid changes, wrapping, width constraints, or another layout approach.

## Current expected result

This is intentionally a tests-only PR. Responsive assertions may expose existing production layout defects on the current implementation; production fixes belong in the stacked fix PR.

## Main files

- `web/app/e2e/helpers/responsive-layout.ts`
- `web/app/e2e/poms/memories.page.ts`
- `web/app/e2e/tests/functional/memory/responsive-layout.spec.ts`
- `web/app/e2e/tests/functional/mode/mode-edit.spec.ts`
- `web/app/e2e/tests/functional/integrations/integrations.spec.ts`
