### PR TITLE
fix(nav): close mobile nav drawer after navigation

### DIFF
--- a/web/app/src/app/layout/app-layout.component.spec.ts
+++ b/web/app/src/app/layout/app-layout.component.spec.ts
@@ -7,12 +7,15 @@ import { Router, provideRouter } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { AuthService } from '../core/services/auth.service';
+import { ChatService } from '../core/services/chat.service';
 import { CommandPaletteService } from '../core/services/command-palette.service';
 import { KeyboardShortcutService } from '../core/services/keyboard-shortcut.service';
 import { NavService } from '../core/services/nav.service';
 import { ThemeService } from '../core/services/theme.service';
 import { AppLayoutComponent } from './app-layout.component';
 import { RightPanelService } from '../core/services/right-panel.service';
+import type { Chat } from '../core/models/chat.model';
+import type { Personality } from '../core/models/personality.model';
 
 @Component({ selector: 'noop', standalone: true, changeDetection: ChangeDetectionStrategy.Eager,
     template: '' })
@@ -164,6 +167,43 @@ describe('AppLayoutComponent', () => {
         newChatCommand?.run();
 
         expect(fixture.componentInstance.personaPickerOpen()).toBe(true);
+    });
+
+    it('collapses the mobile sidebar drawer when a new thread is created', async () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => fakeMediaQueryList(query, false));
+        const fixture = TestBed.createComponent(AppLayoutComponent);
+        const chatService = TestBed.inject(ChatService);
+        vi.spyOn(chatService, 'createChat').mockReturnValue(
+            of({ id: 'ba83002b-fa33-4bff-a13a-6399376fc798', name: 'New Chat' } as Chat),
+        );
+        vi.spyOn(chatService, 'setLastChatId').mockImplementation(() => undefined);
+        fixture.detectChanges();
+
+        const nav = TestBed.inject(NavService) as MockedObject<NavService>;
+        // Clear the initial mobile-load collapse so we only assert on the new-thread flow.
+        nav.setCollapsed.mockClear();
+
+        await fixture.componentInstance.onPersonaPicked({ id: 'p1', name: 'Persona' } as Personality);
+
+        expect(nav.setCollapsed).toHaveBeenCalledWith(true);
+    });
+
+    it('does not collapse the sidebar on desktop when a new thread is created', async () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => fakeMediaQueryList(query, true));
+        const fixture = TestBed.createComponent(AppLayoutComponent);
+        const chatService = TestBed.inject(ChatService);
+        vi.spyOn(chatService, 'createChat').mockReturnValue(
+            of({ id: 'ba83002b-fa33-4bff-a13a-6399376fc798', name: 'New Chat' } as Chat),
+        );
+        vi.spyOn(chatService, 'setLastChatId').mockImplementation(() => undefined);
+        fixture.detectChanges();
+
+        const nav = TestBed.inject(NavService) as MockedObject<NavService>;
+        nav.setCollapsed.mockClear();
+
+        await fixture.componentInstance.onPersonaPicked({ id: 'p1', name: 'Persona' } as Personality);
+
+        expect(nav.setCollapsed).not.toHaveBeenCalled();
     });
 
     it('disposes shortcut + handler + commands on destroy', () => {

--- a/web/app/src/app/layout/app-layout.component.spec.ts
+++ b/web/app/src/app/layout/app-layout.component.spec.ts
@@ -206,6 +206,37 @@ describe('AppLayoutComponent', () => {
         expect(nav.setCollapsed).not.toHaveBeenCalled();
     });
 
+    it('collapses the mobile drawer when navigating to an existing thread', async () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => fakeMediaQueryList(query, false));
+        const fixture = TestBed.createComponent(AppLayoutComponent);
+        const router = TestBed.inject(Router);
+        fixture.detectChanges();
+
+        const nav = TestBed.inject(NavService) as MockedObject<NavService>;
+        // Clear the initial mobile-load collapse so we only assert on the navigation.
+        nav.setCollapsed.mockClear();
+
+        await router.navigateByUrl('/chat/ba83002b-fa33-4bff-a13a-6399376fc798');
+        fixture.detectChanges();
+
+        expect(nav.setCollapsed).toHaveBeenCalledWith(true);
+    });
+
+    it('does not collapse the sidebar on navigation on desktop', async () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => fakeMediaQueryList(query, true));
+        const fixture = TestBed.createComponent(AppLayoutComponent);
+        const router = TestBed.inject(Router);
+        fixture.detectChanges();
+
+        const nav = TestBed.inject(NavService) as MockedObject<NavService>;
+        nav.setCollapsed.mockClear();
+
+        await router.navigateByUrl('/chat/ba83002b-fa33-4bff-a13a-6399376fc798');
+        fixture.detectChanges();
+
+        expect(nav.setCollapsed).not.toHaveBeenCalled();
+    });
+
     it('disposes shortcut + handler + commands on destroy', () => {
         const fixture = TestBed.createComponent(AppLayoutComponent);
         fixture.detectChanges();

--- a/web/app/src/app/layout/app-layout.component.ts
+++ b/web/app/src/app/layout/app-layout.component.ts
@@ -216,6 +216,11 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
 
   async onPersonaPicked(personality: Personality): Promise<void> {
     this.personaPickerOpen.set(false);
+    // On mobile the sidebar is an overlay drawer. Collapse it so the freshly
+    // created thread isn't left hidden behind an open drawer (issue #36).
+    if (this.isMobileNav()) {
+      this.nav.setCollapsed(true);
+    }
     try {
       const chat = await firstValueFrom(
         this.chatService.createChat({

--- a/web/app/src/app/layout/app-layout.component.ts
+++ b/web/app/src/app/layout/app-layout.component.ts
@@ -123,6 +123,13 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
       this.router.events.subscribe(event => {
         if (event instanceof NavigationEnd) {
           this.setRightPanelVisibility(event.urlAfterRedirects);
+          // On mobile the sidebar is an overlay drawer. Collapse it after any
+          // navigation so the destination — a newly created thread, a thread
+          // picked from the drawer, or another section — isn't left hidden
+          // behind an open drawer (issue #36).
+          if (this.isMobileNav()) {
+            this.nav.setCollapsed(true);
+          }
         }
       }),
     );
@@ -216,11 +223,6 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
 
   async onPersonaPicked(personality: Personality): Promise<void> {
     this.personaPickerOpen.set(false);
-    // On mobile the sidebar is an overlay drawer. Collapse it so the freshly
-    // created thread isn't left hidden behind an open drawer (issue #36).
-    if (this.isMobileNav()) {
-      this.nav.setCollapsed(true);
-    }
     try {
       const chat = await firstValueFrom(
         this.chatService.createChat({


### PR DESCRIPTION
## Summary

Fixes #36, and the same-class bug where selecting an **existing** thread from the mobile drawer also left it hidden behind the still-open drawer.

## Root cause

On mobile the sidebar renders as an overlay drawer, shown while `isMobileNav() && !nav.collapsed()`. Several actions navigate to a new view without ever collapsing the drawer:
- **New thread**: `sidebar → newThread → openPersonaPicker → onPersonaPicked` creates the chat and navigates to it.
- **Existing thread**: `AppSidebarComponent.openThread` navigates to `/chat/:id`.

In both cases the destination opens *behind* the open drawer.

## Fix

Collapse the mobile drawer centrally on every `NavigationEnd` while `isMobileNav()` is true, rather than special-casing each navigation site. This is the idiomatic mobile-drawer pattern and covers new-thread, existing-thread selection, nav-item taps, and mode switches with one mechanism. Desktop is untouched (the collapse is guarded by `isMobileNav()`, so the desktop sidebar collapse *preference* is preserved).

Change is in [`app-layout.component.ts`](web/app/src/app/layout/app-layout.component.ts).

## Tests

Unit tests in `app-layout.component.spec.ts` cover both flows on mobile and desktop:
- mobile: starting a new thread collapses the drawer
- mobile: navigating to an existing thread collapses the drawer
- desktop: navigation does **not** touch the collapse state (both new-thread and generic navigation)

## Update: merged `main`

`main` had independently picked up a narrower fix for the new-thread case only (`fix: close mobile sidebar after creating chat`, with its own tests), while this branch already had the broader `NavigationEnd`-based fix covering both new-thread and existing-thread navigation. Merged `origin/main` into this branch (regular merge, history preserved — no rebase) and resolved the conflict by:
- Keeping the single `NavigationEnd`-based mechanism (superset behavior: covers existing-thread selection too, which the narrower `main` fix did not).
- Removing the now-redundant `onPersonaPicked`-specific `closeMobileSidebar()` call that came in from `main`, since the generic mechanism already handles that case.
- Keeping this branch's four tests (mobile/desktop × new-thread/existing-thread), which are a superset of the two duplicate tests `main` added for the new-thread case only.

## Validation

- `npx ng test --watch=false --include='**/app-layout.component.spec.ts'` — 10/10 passed.
- `npx ng test --watch=false --include='**/layout/**/*.spec.ts'` — 90/90 passed (all specs under `web/app/src/app/layout/`).
- `npx tsc -p tsconfig.app.json --noEmit` — no errors.
- App source has no ESLint config yet (`eslint.config.mjs` is intentionally scoped to `e2e/` only), so lint was not applicable to the changed files.

## Limitations

No e2e coverage added for this specific interaction; validated via unit tests only. Manual/browser verification of the drawer behavior was not performed in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)