### PR TITLE
Fix mobile New chat sidebar dismissal

### DIFF
--- a/web/app/src/app/layout/app-layout.component.spec.ts
+++ b/web/app/src/app/layout/app-layout.component.spec.ts
@@ -7,6 +7,7 @@ import { Router, provideRouter } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { AuthService } from '../core/services/auth.service';
+import { ChatService } from '../core/services/chat.service';
 import { CommandPaletteService } from '../core/services/command-palette.service';
 import { KeyboardShortcutService } from '../core/services/keyboard-shortcut.service';
 import { NavService } from '../core/services/nav.service';
@@ -164,6 +165,44 @@ describe('AppLayoutComponent', () => {
         newChatCommand?.run();
 
         expect(fixture.componentInstance.personaPickerOpen()).toBe(true);
+    });
+
+    it('collapses the mobile sidebar after a successful New chat creation', async () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => fakeMediaQueryList(query, false));
+        const fixture = TestBed.createComponent(AppLayoutComponent);
+        const router = TestBed.inject(Router);
+        const nav = TestBed.inject(NavService) as MockedObject<NavService>;
+        const chatService = TestBed.inject(ChatService);
+        fixture.detectChanges();
+        vi.mocked(nav.setCollapsed).mockClear();
+        vi.spyOn(chatService, 'createChat').mockReturnValue(of({
+            id: 'ba83002b-fa33-4bff-a13a-6399376fc798',
+            name: 'New Chat',
+            personality_id: 'personality-1',
+        } as any));
+
+        await fixture.componentInstance.onPersonaPicked({ id: 'personality-1' } as any);
+
+        expect(router.url).toBe('/chat/ba83002b-fa33-4bff-a13a-6399376fc798');
+        expect(nav.setCollapsed).toHaveBeenCalledWith(true);
+    });
+
+    it('does not collapse the desktop sidebar after a successful New chat creation', async () => {
+        vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => fakeMediaQueryList(query, true));
+        const fixture = TestBed.createComponent(AppLayoutComponent);
+        const nav = TestBed.inject(NavService) as MockedObject<NavService>;
+        const chatService = TestBed.inject(ChatService);
+        fixture.detectChanges();
+        vi.mocked(nav.setCollapsed).mockClear();
+        vi.spyOn(chatService, 'createChat').mockReturnValue(of({
+            id: 'ba83002b-fa33-4bff-a13a-6399376fc798',
+            name: 'New Chat',
+            personality_id: 'personality-1',
+        } as any));
+
+        await fixture.componentInstance.onPersonaPicked({ id: 'personality-1' } as any);
+
+        expect(nav.setCollapsed).not.toHaveBeenCalled();
     });
 
     it('disposes shortcut + handler + commands on destroy', () => {

--- a/web/app/src/app/layout/app-layout.component.ts
+++ b/web/app/src/app/layout/app-layout.component.ts
@@ -225,6 +225,9 @@ export class AppLayoutComponent implements OnInit, OnDestroy {
       );
       this.chatService.setLastChatId(chat.id);
       await this.router.navigate(['/chat', chat.id]);
+      if (this.isMobileNav()) {
+        this.closeMobileSidebar();
+      }
     } catch (error) {
       console.error('Failed to start chat with personality', error);
     }


### PR DESCRIPTION
## Summary

Fixes #36.

The mobile left navigation owns its open/closed state through `NavService.collapsed`. Starting a new thread from the sidebar opens the personality picker, creates the thread, and navigates successfully, but the successful creation path did not collapse the mobile navigation. The new chat therefore appeared behind the still-open sidebar.

## Validation

- Added mobile regression coverage proving successful New chat navigation collapses the sidebar.
- Added desktop coverage proving desktop sidebar behavior remains unchanged.
- The implementation only collapses after successful creation/navigation on mobile.

A passing regression test guards the encoded path; it is not treated as proof that every possible mobile-navigation failure is impossible.

## BSD rerun — coding profile / current engine

Reran the mobile New-chat dismissal slice under the packaged `coding` engineering profile (`evidence_floor=0.40`, `ppi_base_sensitivity=4.0`) using the canonical implementation-correctness output space. The bounded mechanistic chain is `CERTIFIED_WITH_LIMITS` at structural reliability `0.833333`; evidence mass is `1.0`. The canonical mapping is configured and comparable, but PPI is `UNAVAILABLE` specifically because `INSUFFICIENT_SUPPORTED_STRUCTURES`: the competing/falsification frame did not independently earn positive support. Response policy is `DIRECT` with `MISSING_INFORMATION`, `PPI_UNAVAILABLE`, and `SCOPE_LIMITED` disclosures.

The repository source registry remains `CALLER_SUPPLIED_UNVERIFIED` / `UNVERIFIED_REGISTRY`. A direct BSD `code.github` verification attempt returned `RETRIEVAL_FAILED` because the execution environment could not resolve external DNS, so this rerun does not claim adapter-verified GitHub provenance. Code and tests remain one dependent evidence group; `1.0` is coverage, not truth probability. The result supports only the encoded mobile/desktop navigation path; repository CI/runtime verification remains the acceptance gate.