### PR TITLE
Fix datastore SQLite test schema drift

### DIFF
--- a/internal/datastore/testharness_test.go
+++ b/internal/datastore/testharness_test.go
@@ -14,6 +14,36 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+func ensureChatMessageBookmarkedTestColumn(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	var tableName string
+	err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'chat_messages'`).Scan(&tableName)
+	if err == sql.ErrNoRows {
+		return
+	}
+	require.NoError(t, err)
+
+	rows, err := db.Query(`PRAGMA table_info(chat_messages)`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, pk int
+		var defaultValue any
+		require.NoError(t, rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk))
+		if name == "bookmarked" {
+			return
+		}
+	}
+	require.NoError(t, rows.Err())
+
+	_, err = db.Exec(`ALTER TABLE chat_messages ADD COLUMN bookmarked bool NOT NULL DEFAULT false`)
+	require.NoError(t, err)
+}
+
 // newTestDatastore opens an in-memory sqlite DB, applies the given schema-creation funcs in
 // order, and wraps it in a Datastore. Schema funcs like createMemoryImportTestSchema take
 // dependencies as ordering (parent tables before child FKs) — see each func's doc comment.
@@ -26,6 +56,7 @@ func newTestDatastore(t *testing.T, schemas ...func(*testing.T, *sql.DB)) (*Data
 	for _, schema := range schemas {
 		schema(t, db)
 	}
+	ensureChatMessageBookmarkedTestColumn(t, db)
 
 	drv := entsql.OpenDB(dialect.SQLite, db)
 	client := ent.NewClient(ent.Driver(drv))


### PR DESCRIPTION
## Summary

The Go PR validation suite is currently red on backend PRs because the shared hand-built SQLite datastore test schema does not include the `chat_messages.bookmarked` column that exists in the current Ent `ChatMessage` schema.

This is a test-infrastructure/schema-parity fix only. Production schema and production behavior are unchanged.

## Evidence

- PR #56 and PR #57 both pass their targeted packages, mock E2E, and local-LLM E2E, then fail the full Go test suite across many datastore tests with `table chat_messages has no column named bookmarked`.
- `ent/schema/chatmessage.go` defines `bookmarked` with a default of `false`.
- The shared SQLite test schemas are manually assembled, and the `chat_messages` fragment predates that field.

## Fix

The shared datastore test harness now checks whether a composed `chat_messages` table exists and, when needed, adds the missing `bookmarked bool NOT NULL DEFAULT false` column before Ent queries run. Test schemas that do not create `chat_messages` are untouched, and schemas already containing the field are left unchanged.

BSD was used before mutation as a bounded action-plan check. It kept stale generated code, missing production migration, and per-test schema changes as alternatives. The source and CI evidence support shared test-schema drift as the narrow failure mechanism.

A green CI run will verify this reproduced missing-column failure is removed; it is not proof that every manually maintained SQLite test schema can never drift again.

## BSD rerun — latest engine

Reran the merged PR slice through the latest BSD engine using the schema patch and regression behavior as observable anchors. The task is `BOUNDED`; the mechanistic chain is `CERTIFIED_WITH_LIMITS` with structural reliability `0.583333`; evidence mass is `1.0` as evidence engagement/coverage; PPI is `UNAVAILABLE` (`CANONICAL_SUPPORT_UNAVAILABLE`); provenance quality is `NOT_MEASURED`; and the response policy is `QUALIFIED`.

The implementation and its tests/CI observations are not counted as independent sources merely because they are separate artifacts. BSD supports the narrow test-schema-drift mechanism represented by this PR while preserving stale generation, production migration, and per-test schema changes as considered alternatives. This does not generalize to all manually maintained SQLite test schemas or convert the merged outcome into independent causal proof.