### PR TITLE
Keep chat job polling through transient connectivity

### DIFF
--- a/web/app/src/app/core/services/job.service.spec.ts
+++ b/web/app/src/app/core/services/job.service.spec.ts
@@ -1,7 +1,7 @@
 import type { MockedObject } from "vitest";
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { provideHttpClient, withXhr } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
@@ -79,5 +79,49 @@ describe('JobService', () => {
 
         expect(emissions[0]?.status).toBe('cancelled');
         expect(messageService.addErrorMessage).not.toHaveBeenCalledWith('chat-1', 'Failed to process message');
+    });
+
+    it('pollJob keeps polling after a transient transport error instead of showing a false job failure', async () => {
+        vi.useFakeTimers();
+        try {
+            let polls = 0;
+            vi.spyOn(service, 'getJob').mockImplementation(() => {
+                polls += 1;
+                if (polls === 1) {
+                    return throwError(() => new Error('temporary network failure'));
+                }
+                return of({
+                    id: 'job-1',
+                    user_id: 'user-1',
+                    status: 'complete',
+                    job_type: 'chat_message',
+                    reference: 'message-1',
+                    result_id: 'm1',
+                    created_at: '',
+                    updated_at: '',
+                } as Job);
+            });
+
+            const emissions: Job[] = [];
+            let observedError: unknown;
+            let completed = false;
+            service.pollJob('job-1', 'chat-1', 10).subscribe({
+                next: value => emissions.push(value),
+                error: error => { observedError = error; },
+                complete: () => { completed = true; },
+            });
+
+            await vi.advanceTimersByTimeAsync(0);
+            expect(observedError).toBeUndefined();
+            expect(messageService.addErrorMessage).not.toHaveBeenCalledWith('chat-1', 'Failed to process message');
+            expect(service.isJobBeingPolled('job-1')).toBe(true);
+
+            await vi.advanceTimersByTimeAsync(10);
+            expect(emissions.at(-1)?.status).toBe('complete');
+            expect(completed).toBe(true);
+            expect(service.isJobBeingPolled('job-1')).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/web/app/src/app/core/services/job.service.ts
+++ b/web/app/src/app/core/services/job.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { Observable, BehaviorSubject, throwError, timer, switchMap, takeWhile, finalize, distinctUntilChanged } from 'rxjs';
+import { Observable, BehaviorSubject, EMPTY, throwError, timer, switchMap, takeWhile, finalize, distinctUntilChanged } from 'rxjs';
 import { catchError, tap, map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { Job, JobFilters, JobStatus, ActiveChatMessageJob } from '../models/job.model';
@@ -78,7 +78,17 @@ export class JobService {
 
     return timer(0, pollingInterval)
       .pipe(
-        switchMap(() => this.getJob(jobId)),
+        switchMap(() =>
+          this.getJob(jobId).pipe(
+            catchError(error => {
+              // A failed poll request says nothing authoritative about the server-side job.
+              // Keep the pending state and let the next timer tick retry instead of rendering
+              // a false terminal failure while connectivity is interrupted.
+              console.warn('Job poll request failed; retrying on next interval:', error);
+              return EMPTY;
+            }),
+          ),
+        ),
         distinctUntilChanged(
           (a, b) => {
             if (!a || !b) return a === b;


### PR DESCRIPTION
## Summary

Fixes #33.

This starts with a regression test for the reported failure mode: a transient transport error while polling an otherwise-running chat job must not be turned into a terminal UI failure. The poller should remain active and accept a later successful terminal snapshot.

## Diagnosis

`JobService.pollJob` currently routes any `getJob` error into its outer `catchError`, immediately adds `Failed to process message`, terminates the polling observable, and removes the job from the active polling set in `finalize`. That transport failure is not evidence that the server-side job failed.

Issue #37 was inspected alongside this issue because both mention jobs, but its run-now breadcrumb/navigation behavior is a separate UI flow and is not being combined into this PR.

## Test-first evidence

The first commit adds a deterministic regression: the first poll throws a temporary network error and the next poll returns `complete`. The required behavior is that no false error is inserted, the poll remains active after the transport error, and the later completion is observed.

BSD was used before code changes as a bounded diagnosis/action check. It retained backend terminal-state mismatch and stale rendered-error state as alternatives, while current source inspection supports the poll-transport termination path as the direct mechanism.

A passing regression after the production patch will establish the reproduced transport-error case only; it will not prove every connectivity failure mode is handled.

## BSD rerun — coding profile / current engine

Reran the transient-polling slice under the packaged `coding` engineering profile (`evidence_floor=0.40`, `ppi_base_sensitivity=4.0`) using the canonical implementation-correctness output space. The bounded mechanistic chain is `CERTIFIED_WITH_LIMITS` at structural reliability `0.833333`; evidence mass is `1.0`. The canonical mapping is configured and comparable, but PPI is `UNAVAILABLE` specifically because `INSUFFICIENT_SUPPORTED_STRUCTURES`: the competing/falsification frame did not independently earn positive support. Response policy is `DIRECT` with `MISSING_INFORMATION`, `PPI_UNAVAILABLE`, and `SCOPE_LIMITED` disclosures.

The repository source registry remains `CALLER_SUPPLIED_UNVERIFIED` / `UNVERIFIED_REGISTRY`. A direct BSD `code.github` verification attempt returned `RETRIEVAL_FAILED` because the execution environment could not resolve external DNS, so this rerun does not claim adapter-verified GitHub provenance. Code and regression remain one dependent evidence group; `1.0` is coverage, not truth probability. Persistent-outage/backoff behavior remains outside this slice; CI/runtime verification remains the acceptance gate.