### PR TITLE
Give Run Now a durable chat breadcrumb

### DIFF
--- a/web/app/src/app/features/agent-job/agent-job-detail.component.spec.ts
+++ b/web/app/src/app/features/agent-job/agent-job-detail.component.spec.ts
@@ -404,15 +404,20 @@ describe('AgentJobDetailComponent', () => {
             expect(mockAgentJobService.updateAgentJobStatus).not.toHaveBeenCalled();
         });
 
-        it('runs job now for active/paused statuses and refreshes details', () => {
-            const refreshed = { ...mockJob, run_count: 4 };
-            mockAgentJobService.getAgentJob.mockReturnValueOnce(of(mockJob)).mockReturnValueOnce(of(refreshed));
+        it('runs job now without a chat and refreshes details', () => {
+            const noChatJob = { ...mockJob, chat_id: null };
+            const refreshed = { ...noChatJob, run_count: 4 };
+            component.job.set(noChatJob);
+            mockAgentJobService.getAgentJob.mockReturnValue(of(refreshed));
+            mockRouter.navigate.mockClear();
+            mockChatService.setLastChatId.mockClear();
 
-            component.ngOnInit();
             component.runNow();
 
             expect(mockAgentJobService.runNow).toHaveBeenCalledWith('job-1');
             expect(component.job()?.run_count).toBe(4);
+            expect(mockChatService.setLastChatId).not.toHaveBeenCalled();
+            expect(mockRouter.navigate).not.toHaveBeenCalledWith(['/chat']);
             expect(component.successMessage()).toBe('Job run triggered.');
             expect(component.isRunningNow()).toBe(false);
         });

--- a/web/app/src/app/features/agent-job/agent-job-detail.component.ts
+++ b/web/app/src/app/features/agent-job/agent-job-detail.component.ts
@@ -547,8 +547,12 @@ export class AgentJobDetailComponent implements OnInit, OnDestroy {
     ).subscribe({
       next: () => {
         this.successMessage.set('Job run triggered.');
-        this.refreshJobAfterRunNow();
         this.isRunningNow.set(false);
+        if (this.job()?.chat_id) {
+          this.openChat();
+          return;
+        }
+        this.refreshJobAfterRunNow();
       },
       error: (error) => {
         console.error('Failed to run job now:', error);
@@ -674,4 +678,3 @@ export class AgentJobDetailComponent implements OnInit, OnDestroy {
     return new Date(dateString).toLocaleString();
   }
 }
-

--- a/web/app/src/app/features/agent-job/agent-job-detail.run-now.spec.ts
+++ b/web/app/src/app/features/agent-job/agent-job-detail.run-now.spec.ts
@@ -1,0 +1,91 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { AgentJobDetailComponent } from './agent-job-detail.component';
+import { AgentJobService } from '../../core/services/agent-job.service';
+import { ChatService } from '../../core/services/chat.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
+import { ModelService } from '../../core/services/model.service';
+import { PersonalityService } from '../../core/services/personality.service';
+import { RitualService } from '../../core/services/ritual.service';
+import { AgentJob } from '../../core/models/agent-job.model';
+import { Chat } from '../../core/models/chat.model';
+
+describe('AgentJobDetailComponent run-now breadcrumb', () => {
+  const chat: Chat = {
+    id: 'chat-1',
+    user_id: 'user-1',
+    name: 'Morning Chat',
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+  };
+
+  const job: AgentJob = {
+    id: 'job-1',
+    user_id: 'user-1',
+    chat_id: chat.id,
+    title: 'Morning check-in',
+    prompt: 'Send me a concise morning summary.',
+    schedule_input: 'every day at 8 AM',
+    schedule_type: 'cron',
+    schedule: '0 0 8 ? * *',
+    run_at: null,
+    timezone: 'UTC',
+    status: 'active',
+    next_run_at: null,
+    last_run_at: null,
+    last_error: null,
+    run_count: 3,
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-20T00:00:00Z',
+  };
+
+  it('opens the associated chat after a successful run-now trigger', async () => {
+    const agentJobService = {
+      getAgentJob: vi.fn().mockReturnValue(of(job)),
+      runNow: vi.fn().mockReturnValue(of({ status: 'triggered' })),
+      updateAgentJob: vi.fn().mockReturnValue(of(job)),
+      updateAgentJobStatus: vi.fn().mockReturnValue(of(job)),
+      deleteAgentJob: vi.fn().mockReturnValue(of(void 0)),
+      parseSchedule: vi.fn(),
+      addRitual: vi.fn(),
+      removeRitual: vi.fn(),
+    };
+    const chatService = {
+      setLastChatId: vi.fn(),
+      getChat: vi.fn().mockReturnValue(of(chat)),
+      listChats: vi.fn().mockReturnValue(of({ results: [chat], total_count: 1, page: 1 })),
+    };
+    const router = {
+      navigate: vi.fn().mockResolvedValue(true),
+      createUrlTree: vi.fn(),
+      serializeUrl: vi.fn().mockReturnValue(''),
+      events: of(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AgentJobDetailComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AgentJobService, useValue: agentJobService },
+        { provide: ChatService, useValue: chatService },
+        { provide: ConfirmationService, useValue: { confirm: vi.fn() } },
+        { provide: ModelService, useValue: { getModels: vi.fn().mockReturnValue(of([])) } },
+        { provide: PersonalityService, useValue: { listPersonalities: vi.fn().mockReturnValue(of({ results: [], total_count: 0, page: 1 })) } },
+        { provide: RitualService, useValue: { listRituals: vi.fn().mockReturnValue(of({ results: [], total_count: 0, page: 1 })) } },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => 'job-1' } } } },
+      ],
+    }).compileComponents();
+
+    const component = TestBed.createComponent(AgentJobDetailComponent).componentInstance;
+    component.ngOnInit();
+    component.runNow();
+
+    expect(agentJobService.runNow).toHaveBeenCalledWith('job-1');
+    expect(chatService.setLastChatId).toHaveBeenCalledWith('chat-1');
+    expect(router.navigate).toHaveBeenCalledWith(['/chat']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #37.

This PR starts with a regression test for the missing Run Now breadcrumb. When a scheduled agent job is associated with a chat and the Run Now trigger succeeds, the UI should take the user to that chat so there is a durable place to see the resulting turn instead of only flashing the button state for less than a second.

## Diagnosis

The current `runNow()` flow sets `isRunningNow`, calls the API, sets `successMessage = "Job run triggered."`, refreshes the job, and immediately clears `isRunningNow`. The API currently returns only `{ status: string }`, so there is no execution/job identifier available to build a new live-running execution UI without expanding backend state plumbing.

The detail page already has an `openChat()` path for jobs with `chat_id`, so reusing that existing navigation is the narrowest supported breadcrumb. Jobs without an associated chat should remain on the detail page and keep the success acknowledgement.

BSD was run before code changes as a bounded diagnosis/action check. It kept persistent inline feedback and new execution tracking as alternatives, but the existing chat association and navigation path support the narrower chat breadcrumb without inventing new execution state.

## Test-first evidence

The first commit is test-only. It asserts that a successful Run Now on a job with `chat_id` sets that chat as active and navigates to `/chat`. Current main does not do that, so the regression should fail before the production patch.

A later green test will establish this associated-chat breadcrumb behavior only; it will not imply that live scheduled-job execution state is implemented.

## BSD rerun — coding profile / current engine

Reran the associated-chat breadcrumb slice under the packaged `coding` engineering profile (`evidence_floor=0.40`, `ppi_base_sensitivity=4.0`) using the canonical implementation-correctness output space. The bounded mechanistic chain is `CERTIFIED_WITH_LIMITS` at structural reliability `0.833333`; evidence mass is `1.0`. The canonical mapping is configured and comparable, but PPI is `UNAVAILABLE` specifically because `INSUFFICIENT_SUPPORTED_STRUCTURES`: the competing/falsification frame did not independently earn positive support. Response policy is `DIRECT` with `MISSING_INFORMATION`, `PPI_UNAVAILABLE`, and `SCOPE_LIMITED` disclosures.

The repository source registry remains `CALLER_SUPPLIED_UNVERIFIED` / `UNVERIFIED_REGISTRY`. A direct BSD `code.github` verification attempt returned `RETRIEVAL_FAILED` because the execution environment could not resolve external DNS, so this rerun does not claim adapter-verified GitHub provenance. Implementation and regression evidence remain one dependent group; `1.0` is coverage, not truth probability. The result supports the represented breadcrumb mechanism only and does not certify live execution-state tracking; repository CI/runtime verification remains the acceptance gate.