### PR TITLE
Normalize uploaded images before provider handoff

### DIFF
--- a/internal/handlers/handlerutils/fileattachment.go
+++ b/internal/handlers/handlerutils/fileattachment.go
@@ -6,9 +6,12 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/theimaginaryfoundation/what-iff/internal/agent/filechunker"
+	"github.com/theimaginaryfoundation/what-iff/internal/imageutil"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
 	"github.com/theimaginaryfoundation/what-iff/internal/storage"
 	"github.com/theimaginaryfoundation/what-iff/internal/utils"
@@ -64,8 +67,8 @@ type FileAttachmentUploader interface {
 }
 
 // UploadFileAttachment parses a multipart file upload, validates the file type,
-// streams it to a temp file, uploads to OpenAI from disk, and returns the
-// attachment model plus temp file path for optional async chunking.
+// streams it to a temp file, normalizes image uploads, uploads from disk, and
+// returns the attachment model plus temp file path for optional async chunking.
 func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Logger, a FileAttachmentUploader, userID uuid.UUID, attrs map[string]string) (models.FileAttachment, string, error) {
 	// Validate file size
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
@@ -83,7 +86,8 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 	defer file.Close()
 
 	// Check file extension
-	fileTypeInfo, err := utils.GetFileType(header.Filename)
+	fileName := header.Filename
+	fileTypeInfo, err := utils.GetFileType(fileName)
 	if err != nil {
 		RespondWithError(w, logger, http.StatusBadRequest, CodeNotSet, "Unsupported file type", err)
 		return models.FileAttachment{}, "", err
@@ -95,12 +99,47 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 		return models.FileAttachment{}, "", err
 	}
 	tempFilePath := tempFile.Name()
-	defer tempFile.Close()
 
 	if _, err := io.Copy(tempFile, file); err != nil {
+		_ = tempFile.Close()
 		_ = os.Remove(tempFilePath)
 		RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error buffering file", err)
 		return models.FileAttachment{}, "", err
+	}
+	if err := tempFile.Close(); err != nil {
+		_ = os.Remove(tempFilePath)
+		RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error closing temp file", err)
+		return models.FileAttachment{}, "", err
+	}
+
+	if strings.HasPrefix(fileTypeInfo.ContentType, models.ImageMIMEPrefix) {
+		imageBytes, err := os.ReadFile(tempFilePath)
+		if err != nil {
+			_ = os.Remove(tempFilePath)
+			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error reading image upload", err)
+			return models.FileAttachment{}, "", err
+		}
+
+		normalized, err := imageutil.NormalizeForUpload(imageBytes, imageutil.DefaultUploadImageMaxPx)
+		if err != nil {
+			_ = os.Remove(tempFilePath)
+			RespondWithError(w, logger, http.StatusBadRequest, CodeNotSet, "Invalid image", err)
+			return models.FileAttachment{}, "", err
+		}
+		if err := os.WriteFile(tempFilePath, normalized, 0o600); err != nil {
+			_ = os.Remove(tempFilePath)
+			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error normalizing image", err)
+			return models.FileAttachment{}, "", err
+		}
+
+		ext := filepath.Ext(fileName)
+		fileName = strings.TrimSuffix(fileName, ext) + ".png"
+		fileTypeInfo, err = utils.GetFileType(fileName)
+		if err != nil {
+			_ = os.Remove(tempFilePath)
+			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error resolving normalized image type", err)
+			return models.FileAttachment{}, "", err
+		}
 	}
 
 	uploadReader, err := os.Open(tempFilePath)
@@ -111,7 +150,7 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 	}
 	defer uploadReader.Close()
 
-	fileId, err := a.UploadFileAttachment(r.Context(), userID, attrs, uploadReader, header.Filename, fileTypeInfo)
+	fileId, err := a.UploadFileAttachment(r.Context(), userID, attrs, uploadReader, fileName, fileTypeInfo)
 	if err != nil {
 		_ = os.Remove(tempFilePath)
 		RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error uploading file", err)
@@ -121,7 +160,7 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 	return models.FileAttachment{
 		UserID:   userID,
 		FileID:   &fileId,
-		Name:     header.Filename,
+		Name:     fileName,
 		FileType: fileTypeInfo.ContentType,
 	}, tempFilePath, nil
 }

--- a/internal/handlers/handlerutils/fileattachment.go
+++ b/internal/handlers/handlerutils/fileattachment.go
@@ -132,7 +132,7 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 
 		// The upload cap bounds disk usage; stream image data between temp files
 		// so the raw upload is not also buffered in application memory.
-		err = imageutil.NormalizeForUpload(imageFile, normalizedTempFile, imageutil.DefaultUploadImageMaxPx)
+		fileName, err = imageutil.NormalizeForUpload(imageFile, normalizedTempFile, fileName, imageutil.DefaultUploadImageMaxPx)
 		if closeErr := imageFile.Close(); closeErr != nil && err == nil {
 			err = closeErr
 		}
@@ -152,13 +152,9 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 			return models.FileAttachment{}, "", err
 		}
 
-		ext := filepath.Ext(fileName)
-		fileName = strings.TrimSuffix(fileName, ext) + ".png"
-		fileTypeInfo, err = utils.GetFileType(fileName)
-		if err != nil {
-			_ = os.Remove(tempFilePath)
-			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error resolving normalized image type", err)
-			return models.FileAttachment{}, "", err
+		fileTypeInfo = utils.FileTypeInfo{
+			ContentType: imageutil.NormalizedUploadContentType,
+			Extension:   ".png",
 		}
 	}
 

--- a/internal/handlers/handlerutils/fileattachment.go
+++ b/internal/handlers/handlerutils/fileattachment.go
@@ -113,22 +113,42 @@ func UploadFileAttachment(w http.ResponseWriter, r *http.Request, logger *zap.Lo
 	}
 
 	if strings.HasPrefix(fileTypeInfo.ContentType, models.ImageMIMEPrefix) {
-		imageBytes, err := os.ReadFile(tempFilePath)
+		normalizedTempFile, err := os.CreateTemp(filepath.Dir(tempFilePath), "chat-app-upload-normalized-*")
 		if err != nil {
 			_ = os.Remove(tempFilePath)
-			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error reading image upload", err)
+			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error creating normalized image buffer", err)
+			return models.FileAttachment{}, "", err
+		}
+		normalizedTempFilePath := normalizedTempFile.Name()
+
+		imageFile, err := os.Open(tempFilePath)
+		if err != nil {
+			_ = normalizedTempFile.Close()
+			_ = os.Remove(normalizedTempFilePath)
+			_ = os.Remove(tempFilePath)
+			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error opening image upload", err)
 			return models.FileAttachment{}, "", err
 		}
 
-		normalized, err := imageutil.NormalizeForUpload(imageBytes, imageutil.DefaultUploadImageMaxPx)
+		// The upload cap bounds disk usage; stream image data between temp files
+		// so the raw upload is not also buffered in application memory.
+		err = imageutil.NormalizeForUpload(imageFile, normalizedTempFile, imageutil.DefaultUploadImageMaxPx)
+		if closeErr := imageFile.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		if closeErr := normalizedTempFile.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
 		if err != nil {
+			_ = os.Remove(normalizedTempFilePath)
 			_ = os.Remove(tempFilePath)
 			RespondWithError(w, logger, http.StatusBadRequest, CodeNotSet, "Invalid image", err)
 			return models.FileAttachment{}, "", err
 		}
-		if err := os.WriteFile(tempFilePath, normalized, 0o600); err != nil {
+		if err := os.Rename(normalizedTempFilePath, tempFilePath); err != nil {
+			_ = os.Remove(normalizedTempFilePath)
 			_ = os.Remove(tempFilePath)
-			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error normalizing image", err)
+			RespondWithError(w, logger, http.StatusInternalServerError, CodeNotSet, "Error replacing normalized image", err)
 			return models.FileAttachment{}, "", err
 		}
 

--- a/internal/handlers/handlerutils/fileattachment_image_normalization_test.go
+++ b/internal/handlers/handlerutils/fileattachment_image_normalization_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"image"
 	"image/color"
+	"image/jpeg"
 	"image/png"
 	"io"
 	"mime/multipart"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -21,8 +23,10 @@ import (
 type capturingFileAttachmentUploader struct {
 	filename    string
 	contentType string
+	format      string
 	width       int
 	height      int
+	data        []byte
 }
 
 func (u *capturingFileAttachmentUploader) UploadFileAttachment(
@@ -33,16 +37,40 @@ func (u *capturingFileAttachmentUploader) UploadFileAttachment(
 	fileName string,
 	fileTypeInfo utils.FileTypeInfo,
 ) (string, error) {
-	img, _, err := image.Decode(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return "", err
 	}
-	bounds := img.Bounds()
 	u.filename = fileName
 	u.contentType = fileTypeInfo.ContentType
-	u.width = bounds.Dx()
-	u.height = bounds.Dy()
+	u.data = data
+
+	if strings.HasPrefix(fileTypeInfo.ContentType, "image/") {
+		img, format, err := image.Decode(bytes.NewReader(data))
+		if err != nil {
+			return "", err
+		}
+		bounds := img.Bounds()
+		u.format = format
+		u.width = bounds.Dx()
+		u.height = bounds.Dy()
+	}
 	return "file-normalized", nil
+}
+
+func multipartUploadRequest(t *testing.T, filename string, data []byte) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("attachment", filename)
+	require.NoError(t, err)
+	_, err = part.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest("POST", "/attachments", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
 }
 
 func TestUploadFileAttachmentNormalizesOversizedImageBeforeProviderUpload(t *testing.T) {
@@ -51,26 +79,12 @@ func TestUploadFileAttachmentNormalizesOversizedImageBeforeProviderUpload(t *tes
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
 	require.NoError(t, png.Encode(&imageBytes, img))
 
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("attachment", "wide.png")
-	require.NoError(t, err)
-	_, err = part.Write(imageBytes.Bytes())
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
-
-	req := httptest.NewRequest("POST", "/attachments", &body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
 	response := httptest.NewRecorder()
 	uploader := &capturingFileAttachmentUploader{}
-
 	attachment, tempPath, err := UploadFileAttachment(
 		response,
-		req,
-		zap.NewNop(),
-		uploader,
-		uuid.New(),
-		nil,
+		multipartUploadRequest(t, "wide.png", imageBytes.Bytes()),
+		zap.NewNop(), uploader, uuid.New(), nil,
 	)
 	if tempPath != "" {
 		defer os.Remove(tempPath)
@@ -79,8 +93,66 @@ func TestUploadFileAttachmentNormalizesOversizedImageBeforeProviderUpload(t *tes
 	require.NoError(t, err)
 	require.Equal(t, 2048, uploader.width)
 	require.Equal(t, 1024, uploader.height)
+	require.Equal(t, "png", uploader.format)
 	require.Equal(t, "wide.png", uploader.filename)
 	require.Equal(t, "image/png", uploader.contentType)
 	require.Equal(t, "wide.png", attachment.Name)
 	require.Equal(t, "image/png", attachment.FileType)
+
+	tempBytes, err := os.ReadFile(tempPath)
+	require.NoError(t, err)
+	_, tempFormat, err := image.Decode(bytes.NewReader(tempBytes))
+	require.NoError(t, err)
+	require.Equal(t, "png", tempFormat)
+}
+
+func TestUploadFileAttachmentReencodesJPEGAsPNGWithoutUpscaling(t *testing.T) {
+	var imageBytes bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 640, 320))
+	require.NoError(t, jpeg.Encode(&imageBytes, img, &jpeg.Options{Quality: 90}))
+
+	response := httptest.NewRecorder()
+	uploader := &capturingFileAttachmentUploader{}
+	attachment, tempPath, err := UploadFileAttachment(
+		response,
+		multipartUploadRequest(t, "photo.jpg", imageBytes.Bytes()),
+		zap.NewNop(), uploader, uuid.New(), nil,
+	)
+	if tempPath != "" {
+		defer os.Remove(tempPath)
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, 640, uploader.width)
+	require.Equal(t, 320, uploader.height)
+	require.Equal(t, "png", uploader.format)
+	require.Equal(t, "photo.png", uploader.filename)
+	require.Equal(t, "image/png", uploader.contentType)
+	require.Equal(t, "photo.png", attachment.Name)
+	require.Equal(t, "image/png", attachment.FileType)
+}
+
+func TestUploadFileAttachmentLeavesNonImageBytesAndMetadataUnchanged(t *testing.T) {
+	original := []byte("plain text upload\n")
+	response := httptest.NewRecorder()
+	uploader := &capturingFileAttachmentUploader{}
+	attachment, tempPath, err := UploadFileAttachment(
+		response,
+		multipartUploadRequest(t, "notes.txt", original),
+		zap.NewNop(), uploader, uuid.New(), nil,
+	)
+	if tempPath != "" {
+		defer os.Remove(tempPath)
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, "notes.txt", uploader.filename)
+	require.Equal(t, "text/plain", uploader.contentType)
+	require.Equal(t, original, uploader.data)
+	require.Equal(t, "notes.txt", attachment.Name)
+	require.Equal(t, "text/plain", attachment.FileType)
+
+	tempBytes, err := os.ReadFile(tempPath)
+	require.NoError(t, err)
+	require.Equal(t, original, tempBytes)
 }

--- a/internal/handlers/handlerutils/fileattachment_image_normalization_test.go
+++ b/internal/handlers/handlerutils/fileattachment_image_normalization_test.go
@@ -1,0 +1,86 @@
+package handlerutils
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"mime/multipart"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/utils"
+	"go.uber.org/zap"
+)
+
+type capturingFileAttachmentUploader struct {
+	filename    string
+	contentType string
+	width       int
+	height      int
+}
+
+func (u *capturingFileAttachmentUploader) UploadFileAttachment(
+	_ context.Context,
+	_ uuid.UUID,
+	_ map[string]string,
+	file io.Reader,
+	fileName string,
+	fileTypeInfo utils.FileTypeInfo,
+) (string, error) {
+	img, _, err := image.Decode(file)
+	if err != nil {
+		return "", err
+	}
+	bounds := img.Bounds()
+	u.filename = fileName
+	u.contentType = fileTypeInfo.ContentType
+	u.width = bounds.Dx()
+	u.height = bounds.Dy()
+	return "file-normalized", nil
+}
+
+func TestUploadFileAttachmentNormalizesOversizedImageBeforeProviderUpload(t *testing.T) {
+	var imageBytes bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 4000, 2000))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	require.NoError(t, png.Encode(&imageBytes, img))
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("attachment", "wide.png")
+	require.NoError(t, err)
+	_, err = part.Write(imageBytes.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest("POST", "/attachments", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	response := httptest.NewRecorder()
+	uploader := &capturingFileAttachmentUploader{}
+
+	attachment, tempPath, err := UploadFileAttachment(
+		response,
+		req,
+		zap.NewNop(),
+		uploader,
+		uuid.New(),
+		nil,
+	)
+	if tempPath != "" {
+		defer os.Remove(tempPath)
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, 2048, uploader.width)
+	require.Equal(t, 1024, uploader.height)
+	require.Equal(t, "wide.png", uploader.filename)
+	require.Equal(t, "image/png", uploader.contentType)
+	require.Equal(t, "wide.png", attachment.Name)
+	require.Equal(t, "image/png", attachment.FileType)
+}

--- a/internal/handlers/handlerutils/fileattachment_image_normalization_test.go
+++ b/internal/handlers/handlerutils/fileattachment_image_normalization_test.go
@@ -9,6 +9,7 @@ import (
 	"image/png"
 	"io"
 	"mime/multipart"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"

--- a/internal/imageutil/imageutil.go
+++ b/internal/imageutil/imageutil.go
@@ -10,7 +10,7 @@ import (
 	"image"
 	_ "image/gif" // register GIF decoder
 	"image/jpeg"
-	_ "image/png" // register PNG decoder
+	"image/png"
 
 	"github.com/google/uuid"
 	"github.com/theimaginaryfoundation/what-iff/internal/storage"
@@ -18,11 +18,54 @@ import (
 	xdraw "golang.org/x/image/draw"
 )
 
-const DefaultThumbnailMaxPx = 256
+const (
+	DefaultThumbnailMaxPx   = 256
+	DefaultUploadImageMaxPx = 2048
+)
+
+// NormalizeForUpload decodes an accepted image, scales it down when its longest
+// edge exceeds maxPx, and encodes the result as PNG. Images that already fit
+// keep their original dimensions; normalization never upscales.
+func NormalizeForUpload(data []byte, maxPx int) ([]byte, error) {
+	if maxPx <= 0 {
+		maxPx = DefaultUploadImageMaxPx
+	}
+
+	src, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode image for upload: %w", err)
+	}
+
+	bounds := src.Bounds()
+	srcW, srcH := bounds.Dx(), bounds.Dy()
+	if srcW == 0 || srcH == 0 {
+		return nil, fmt.Errorf("image has zero dimension (%dx%d)", srcW, srcH)
+	}
+
+	dst := src
+	if srcW > maxPx || srcH > maxPx {
+		dstW, dstH := scaledDimensions(srcW, srcH, maxPx)
+		resized := image.NewRGBA(image.Rect(0, 0, dstW, dstH))
+		xdraw.BiLinear.Scale(resized, resized.Bounds(), src, bounds, xdraw.Over, nil)
+		dst = resized
+	}
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, dst); err != nil {
+		return nil, fmt.Errorf("encode upload image as PNG: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func scaledDimensions(srcW, srcH, maxPx int) (int, int) {
+	if srcW >= srcH {
+		return maxPx, max(1, srcH*maxPx/srcW)
+	}
+	return max(1, srcW*maxPx/srcH), maxPx
+}
 
 // GenerateThumbnail decodes data as an image, scales it so the longest edge is
 // at most maxPx pixels (aspect ratio preserved), and returns JPEG-encoded bytes.
-// The original is returned unchanged when both dimensions already fit within maxPx.
 func GenerateThumbnail(data []byte, maxPx int) ([]byte, error) {
 	if maxPx <= 0 {
 		maxPx = DefaultThumbnailMaxPx
@@ -41,13 +84,7 @@ func GenerateThumbnail(data []byte, maxPx int) ([]byte, error) {
 
 	dstW, dstH := srcW, srcH
 	if srcW > maxPx || srcH > maxPx {
-		if srcW >= srcH {
-			dstW = maxPx
-			dstH = max(1, srcH*maxPx/srcW)
-		} else {
-			dstH = maxPx
-			dstW = max(1, srcW*maxPx/srcH)
-		}
+		dstW, dstH = scaledDimensions(srcW, srcH, maxPx)
 	}
 
 	dst := image.NewRGBA(image.Rect(0, 0, dstW, dstH))

--- a/internal/imageutil/imageutil.go
+++ b/internal/imageutil/imageutil.go
@@ -12,6 +12,7 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/theimaginaryfoundation/what-iff/internal/storage"
@@ -20,28 +21,29 @@ import (
 )
 
 const (
-	DefaultThumbnailMaxPx   = 256
-	DefaultUploadImageMaxPx = 2048
+	DefaultThumbnailMaxPx       = 256
+	DefaultUploadImageMaxPx     = 2048
+	NormalizedUploadContentType = "image/png"
 )
 
 // NormalizeForUpload decodes an accepted image from input, scales it down when
-// its longest edge exceeds maxPx, and encodes the result as PNG to output.
-// Images that already fit keep their original dimensions; normalization never
-// upscales. Callers must update the stored filename and content type to PNG.
-func NormalizeForUpload(input io.Reader, output io.Writer, maxPx int) error {
+// its longest edge exceeds maxPx, and encodes the result as PNG to output. It
+// returns the canonical PNG filename. Images that already fit keep their
+// original dimensions; normalization never upscales.
+func NormalizeForUpload(input io.Reader, output io.Writer, fileName string, maxPx int) (string, error) {
 	if maxPx <= 0 {
 		maxPx = DefaultUploadImageMaxPx
 	}
 
 	src, _, err := image.Decode(input)
 	if err != nil {
-		return fmt.Errorf("decode image for upload: %w", err)
+		return "", fmt.Errorf("decode image for upload: %w", err)
 	}
 
 	bounds := src.Bounds()
 	srcW, srcH := bounds.Dx(), bounds.Dy()
 	if srcW == 0 || srcH == 0 {
-		return fmt.Errorf("image has zero dimension (%dx%d)", srcW, srcH)
+		return "", fmt.Errorf("image has zero dimension (%dx%d)", srcW, srcH)
 	}
 
 	dst := src
@@ -53,9 +55,9 @@ func NormalizeForUpload(input io.Reader, output io.Writer, maxPx int) error {
 	}
 
 	if err := png.Encode(output, dst); err != nil {
-		return fmt.Errorf("encode upload image as PNG: %w", err)
+		return "", fmt.Errorf("encode upload image as PNG: %w", err)
 	}
-	return nil
+	return fileName[:len(fileName)-len(filepath.Ext(fileName))] + ".png", nil
 }
 
 func scaledDimensions(srcW, srcH, maxPx int) (int, int) {

--- a/internal/imageutil/imageutil.go
+++ b/internal/imageutil/imageutil.go
@@ -11,6 +11,7 @@ import (
 	_ "image/gif" // register GIF decoder
 	"image/jpeg"
 	"image/png"
+	"io"
 
 	"github.com/google/uuid"
 	"github.com/theimaginaryfoundation/what-iff/internal/storage"
@@ -23,23 +24,24 @@ const (
 	DefaultUploadImageMaxPx = 2048
 )
 
-// NormalizeForUpload decodes an accepted image, scales it down when its longest
-// edge exceeds maxPx, and encodes the result as PNG. Images that already fit
-// keep their original dimensions; normalization never upscales.
-func NormalizeForUpload(data []byte, maxPx int) ([]byte, error) {
+// NormalizeForUpload decodes an accepted image from input, scales it down when
+// its longest edge exceeds maxPx, and encodes the result as PNG to output.
+// Images that already fit keep their original dimensions; normalization never
+// upscales. Callers must update the stored filename and content type to PNG.
+func NormalizeForUpload(input io.Reader, output io.Writer, maxPx int) error {
 	if maxPx <= 0 {
 		maxPx = DefaultUploadImageMaxPx
 	}
 
-	src, _, err := image.Decode(bytes.NewReader(data))
+	src, _, err := image.Decode(input)
 	if err != nil {
-		return nil, fmt.Errorf("decode image for upload: %w", err)
+		return fmt.Errorf("decode image for upload: %w", err)
 	}
 
 	bounds := src.Bounds()
 	srcW, srcH := bounds.Dx(), bounds.Dy()
 	if srcW == 0 || srcH == 0 {
-		return nil, fmt.Errorf("image has zero dimension (%dx%d)", srcW, srcH)
+		return fmt.Errorf("image has zero dimension (%dx%d)", srcW, srcH)
 	}
 
 	dst := src
@@ -50,11 +52,10 @@ func NormalizeForUpload(data []byte, maxPx int) ([]byte, error) {
 		dst = resized
 	}
 
-	var buf bytes.Buffer
-	if err := png.Encode(&buf, dst); err != nil {
-		return nil, fmt.Errorf("encode upload image as PNG: %w", err)
+	if err := png.Encode(output, dst); err != nil {
+		return fmt.Errorf("encode upload image as PNG: %w", err)
 	}
-	return buf.Bytes(), nil
+	return nil
 }
 
 func scaledDimensions(srcW, srcH, maxPx int) (int, int) {

--- a/internal/imageutil/imageutil_test.go
+++ b/internal/imageutil/imageutil_test.go
@@ -16,7 +16,9 @@ func TestNormalizeForUploadStreamsPNG(t *testing.T) {
 	require.NoError(t, png.Encode(&input, image.NewRGBA(image.Rect(0, 0, 4000, 2000))))
 
 	var output bytes.Buffer
-	require.NoError(t, NormalizeForUpload(&input, &output, DefaultUploadImageMaxPx))
+	fileName, err := NormalizeForUpload(&input, &output, "original.jpeg", DefaultUploadImageMaxPx)
+	require.NoError(t, err)
+	require.Equal(t, "original.png", fileName)
 
 	normalized, format, err := image.Decode(&output)
 	require.NoError(t, err)

--- a/internal/imageutil/imageutil_test.go
+++ b/internal/imageutil/imageutil_test.go
@@ -1,0 +1,50 @@
+package imageutil
+
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeForUploadStreamsPNG(t *testing.T) {
+	t.Parallel()
+
+	var input bytes.Buffer
+	require.NoError(t, png.Encode(&input, image.NewRGBA(image.Rect(0, 0, 4000, 2000))))
+
+	var output bytes.Buffer
+	require.NoError(t, NormalizeForUpload(&input, &output, DefaultUploadImageMaxPx))
+
+	normalized, format, err := image.Decode(&output)
+	require.NoError(t, err)
+	require.Equal(t, "png", format)
+	require.Equal(t, 2048, normalized.Bounds().Dx())
+	require.Equal(t, 1024, normalized.Bounds().Dy())
+}
+
+func TestScaledDimensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		srcW, srcH           int
+		maxPx                int
+		expectedW, expectedH int
+	}{
+		{name: "wide", srcW: 4000, srcH: 2000, maxPx: 2048, expectedW: 2048, expectedH: 1024},
+		{name: "tall", srcW: 2000, srcH: 4000, maxPx: 2048, expectedW: 1024, expectedH: 2048},
+		{name: "one pixel wide", srcW: 1, srcH: 4000, maxPx: 2048, expectedW: 1, expectedH: 2048},
+		{name: "one pixel tall", srcW: 4000, srcH: 1, maxPx: 2048, expectedW: 2048, expectedH: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			width, height := scaledDimensions(tt.srcW, tt.srcH, tt.maxPx)
+			require.Equal(t, tt.expectedW, width)
+			require.Equal(t, tt.expectedH, height)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #39.

Normalize uploaded images at the shared HTTP upload boundary before they are handed to a model provider. The target contract is PNG with a maximum 2048px longest edge, preserving aspect ratio and never upscaling smaller images.

## Diagnosis

`handlerutils.UploadFileAttachment` is the common boundary that buffers multipart uploads before calling the provider. Today it writes the original bytes to the temp file and passes the original image unchanged to `FileAttachmentUploader`. The OpenAI implementation likewise forwards those bytes/MIME directly to its Files API. That leaves image format and dimensions dependent on what the user uploaded, which is exactly the cross-vendor inconsistency described in #39.

BSD was used before changes to bound the fix. It favored normalization at this shared boundary rather than adding provider-specific transformations, because the issue is explicitly about consistent behavior across vendors. Non-image uploads should remain untouched.

## Normalization contract

- output format: PNG
- longest edge: at most 2048px
- aspect ratio preserved
- smaller images are not enlarged
- metadata passed downstream must describe the normalized bytes

PNG is a common supported image format across the vendors considered and avoids lossy text/screenshot degradation and transparency loss. The 2048px ceiling is an application-level normalization choice, not a claim that every provider imposes that exact limit.

## Test-first evidence

The first commit is test-only. It sends a 4000x2000 PNG through the real shared `UploadFileAttachment` boundary and requires the fake provider to receive 2048x1024 image data. Current main forwards 4000x2000 unchanged, so this regression should fail before the production patch.

A later green test will establish the encoded normalization behavior; it will not prove compatibility with every current or future vendor/model.

## BSD rerun — coding profile / current engine

Reran the shared-boundary normalization slice under the packaged `coding` engineering profile (`evidence_floor=0.40`, `ppi_base_sensitivity=4.0`) using the canonical implementation-correctness output space. The bounded mechanistic chain is `CERTIFIED_WITH_LIMITS` at structural reliability `0.833333`; evidence mass is `1.0`. The canonical mapping is configured and comparable, but PPI is `UNAVAILABLE` specifically because `INSUFFICIENT_SUPPORTED_STRUCTURES`: the competing/falsification frame did not independently earn positive support. Response policy is `DIRECT` with `MISSING_INFORMATION`, `PPI_UNAVAILABLE`, and `SCOPE_LIMITED` disclosures.

The repository source registry remains `CALLER_SUPPLIED_UNVERIFIED` / `UNVERIFIED_REGISTRY`. A direct BSD `code.github` verification attempt returned `RETRIEVAL_FAILED` because the execution environment could not resolve external DNS, so this rerun does not claim adapter-verified GitHub provenance. Implementation and tests remain one dependent evidence group; `1.0` is coverage, not independent vendor verification or truth probability. The result supports the encoded application normalization contract only; provider compatibility beyond the represented regression surface remains outside the certified slice.