### PR TITLE
Add thread references to the next chat message

### DIFF
--- a/web/app/src/app/features/chat/components/thread-list-panel/thread-row.component.ts
+++ b/web/app/src/app/features/chat/components/thread-list-panel/thread-row.component.ts
@@ -1,5 +1,4 @@
-import { CommonModule } from '@angular/common';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
 
 import { Chat } from '../../../../core/models/chat.model';
@@ -10,6 +9,7 @@ import { personalityCoverUrl } from '../../../personality/helpers/cover-image.he
 import { personalityAccent } from '../../../personality/helpers/personality-vm.helpers';
 import { thumbnailCircleToImageStyle } from '../../../../shared/ui/avatar/avatar-thumbnail.helpers';
 import { StarIconComponent, TrashIconComponent } from '../../../../shared/ui/icons/icons';
+import { ContextPanelService } from '../../services/context-panel.service';
 
 @Component({
   selector: 'app-thread-row',
@@ -67,30 +67,41 @@ import { StarIconComponent, TrashIconComponent } from '../../../../shared/ui/ico
         </span>
       </td>
       <td class="thread-row__title">
-        @if (editing()) {
-          <input
-            class="thread-row__name-input"
-            [value]="thread().name"
-            (blur)="commitRename($any($event.target).value)"
-            (keydown.enter)="commitRename($any($event.target).value)"
-            (keydown.escape)="editing.set(false)"
-            aria-label="Rename thread"
-          />
-        } @else {
-          <button
-            type="button"
-            class="thread-row__main"
-            (click)="select.emit(thread().id)"
-            (dblclick)="editing.set(true)"
-            (keydown.shift.f10)="deleteThread.emit(thread())"
-            [attr.aria-label]="'Open thread ' + thread().name"
-          >
-            <span class="thread-row__name">{{ thread().name }}</span>
-            @if (thread().unread_count && thread().unread_count! > 0) {
-              <span class="thread-row__badge">{{ thread().unread_count }}</span>
-            }
-          </button>
-        }
+        <div class="thread-row__title-wrap">
+          @if (editing()) {
+            <input
+              class="thread-row__name-input"
+              [value]="thread().name"
+              (blur)="commitRename($any($event.target).value)"
+              (keydown.enter)="commitRename($any($event.target).value)"
+              (keydown.escape)="editing.set(false)"
+              aria-label="Rename thread"
+            />
+          } @else {
+            <button
+              type="button"
+              class="thread-row__main"
+              (click)="select.emit(thread().id)"
+              (dblclick)="editing.set(true)"
+              (keydown.shift.f10)="deleteThread.emit(thread())"
+              [attr.aria-label]="'Open thread ' + thread().name"
+            >
+              <span class="thread-row__name">{{ thread().name }}</span>
+              @if (thread().unread_count && thread().unread_count! > 0) {
+                <span class="thread-row__badge">{{ thread().unread_count }}</span>
+              }
+            </button>
+            <button
+              type="button"
+              class="thread-row__context"
+              [attr.aria-label]="'Add thread ' + thread().name + ' to context'"
+              title="Add to context"
+              (click)="queueForContext($event)"
+            >
+              + Context
+            </button>
+          }
+        </div>
       </td>
       <td class="thread-row__date thread-row__created">{{ formatTimestamp(thread().created_at) }}</td>
       <td class="thread-row__date thread-row__updated">{{ formatTimestamp(thread().last_message_time ?? thread().updated_at) }}</td>
@@ -146,255 +157,55 @@ import { StarIconComponent, TrashIconComponent } from '../../../../shared/ui/ico
     </tr>
   `,
   styles: [`
-    :host {
-      display: contents;
-    }
-
-    .thread-row {
-      color: var(--color-text-secondary);
-      cursor: pointer;
-      font-size: 0.75rem;
-    }
-
-    .thread-row--active {
-      background: color-mix(in srgb, var(--color-accent) 10%, transparent);
-    }
-
-    td {
-      border-top: 1px solid var(--color-border-base);
-      padding: 0.5rem 0.75rem;
-      vertical-align: middle;
-      white-space: nowrap;
-    }
-
-    .thread-row__main {
-      align-items: center;
-      background: transparent;
-      border: 0;
-      color: var(--color-text-primary);
-      cursor: pointer;
-      display: flex;
-      font: inherit;
-      justify-content: space-between;
-      min-width: 0;
-      padding: 0;
-      text-align: left;
-      width: 100%;
-    }
-
-    .thread-row__title {
-      min-width: 14rem;
-      width: 32%;
-    }
-
-    .thread-row__name {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .thread-row__badge {
-      background: var(--color-accent);
-      border-radius: 999px;
-      color: white;
-      font-size: 0.75rem;
-      min-width: 1.25rem;
-      padding: 0 0.375rem;
-      text-align: center;
-    }
-
-    .thread-row__tags {
-      align-items: center;
-      background: transparent;
-      border: 0;
-      color: var(--color-text-secondary);
-      cursor: pointer;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.25rem;
-      max-width: 18rem;
-      padding: 0;
-      text-align: left;
-    }
-
-    .thread-row__tags span {
-      background: var(--color-surface-muted);
-      border-radius: 999px;
-      padding: 0.125rem 0.45rem;
-    }
-
-    .thread-row__tags--empty {
-      color: var(--color-text-muted);
-    }
-
-    .thread-row__select-cell {
-      text-align: center;
-    }
-
-    .thread-row__select {
-      accent-color: var(--color-accent);
-      cursor: pointer;
-      height: 1rem;
-      width: 1rem;
-    }
-
-    .thread-row__star,
-    .thread-row__archive {
-      border: 1px solid var(--color-border-base);
-      border-radius: 999px;
-      color: var(--color-text-muted);
-      cursor: pointer;
-      font-size: 0.68rem;
-      font-weight: 700;
-      padding: 0.2rem 0.55rem;
-      text-transform: uppercase;
-    }
-
-    .thread-row__star {
-      align-items: center;
-      background: var(--color-surface-base);
-      display: inline-flex;
-      justify-content: center;
-      padding: 0.35rem;
-    }
-
-    .thread-row__star--active {
-      background: color-mix(in srgb, var(--color-accent) 14%, transparent);
-      border-color: var(--color-accent);
-      color: var(--color-accent);
-    }
-
-    .thread-row__archive {
-      background: var(--color-surface-base);
-      cursor: pointer;
-      opacity: 1;
-    }
-
-    .thread-row__archive--restore {
-      text-transform: none;
-    }
-
-    .thread-row__delete {
-      background: transparent;
-      border: 0;
-      border-radius: 0.375rem;
-      color: var(--color-text-muted);
-      cursor: pointer;
-      display: inline-flex;
-      justify-content: center;
-      padding: 0.35rem;
-      text-transform: none;
-    }
-
-    .thread-row__delete:hover,
-    .thread-row__delete:focus-visible {
-      background: color-mix(in srgb, var(--color-danger) 12%, transparent);
-      color: var(--color-danger);
-    }
-
-    .thread-row__date,
-    .thread-row__personality {
-      color: var(--color-text-muted);
-    }
-
-    .thread-row__personality-content {
-      align-items: center;
-      color: var(--thread-persona-accent, var(--color-text-muted));
-      display: inline-flex;
-      gap: 0.4375rem;
-      max-width: 100%;
-    }
-
-    .thread-row__personality-avatar {
-      align-items: center;
-      background: color-mix(in srgb, var(--thread-persona-accent, var(--color-accent)) 16%, var(--color-surface-muted));
-      border-radius: 50%;
-      color: var(--thread-persona-accent, var(--color-accent));
-      display: inline-flex;
-      flex: 0 0 auto;
-      font-size: 0.625rem;
-      font-weight: 800;
-      height: 1.5rem;
-      justify-content: center;
-      overflow: hidden;
-      width: 1.5rem;
-    }
-
-    .thread-row__personality-avatar img {
-      height: 100%;
-      object-fit: cover;
-      transform-origin: center center;
-      width: 100%;
-    }
-
-    .thread-row__personality-avatar-fallback {
-      align-items: center;
-      display: inline-flex;
-      height: 100%;
-      justify-content: center;
-      width: 100%;
-    }
-
-    .thread-row__personality-name {
-      color: inherit;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .thread-row__name-input {
-      background: var(--color-surface-base);
-      border: 1px solid var(--color-accent);
-      border-radius: 0.5rem;
-      color: var(--color-text-primary);
-      font: inherit;
-      padding: 0.35rem 0.5rem;
-      width: 100%;
-    }
-
-    .thread-row__archive-cell,
-    .thread-row__delete-cell,
-    .thread-row__star-cell {
-      text-align: center;
-      width: 2.75rem;
-    }
-
-    .thread-row__delete-cell {
-      padding-inline: 0.375rem;
-    }
-
+    :host { display: contents; }
+    .thread-row { color: var(--color-text-secondary); cursor: pointer; font-size: 0.75rem; }
+    .thread-row--active { background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
+    td { border-top: 1px solid var(--color-border-base); padding: 0.5rem 0.75rem; vertical-align: middle; white-space: nowrap; }
+    .thread-row__title { min-width: 14rem; width: 32%; }
+    .thread-row__title-wrap { align-items: center; display: flex; gap: 0.5rem; min-width: 0; }
+    .thread-row__main { align-items: center; background: transparent; border: 0; color: var(--color-text-primary); cursor: pointer; display: flex; flex: 1; font: inherit; justify-content: space-between; min-width: 0; padding: 0; text-align: left; }
+    .thread-row__name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .thread-row__badge { background: var(--color-accent); border-radius: 999px; color: white; font-size: 0.75rem; min-width: 1.25rem; padding: 0 0.375rem; text-align: center; }
+    .thread-row__context { background: transparent; border: 1px solid var(--color-border-base); border-radius: 999px; color: var(--color-text-muted); cursor: pointer; flex: 0 0 auto; font-size: 0.68rem; font-weight: 700; padding: 0.2rem 0.5rem; }
+    .thread-row__context:hover, .thread-row__context:focus-visible { border-color: var(--color-accent); color: var(--color-accent); }
+    .thread-row__tags { align-items: center; background: transparent; border: 0; color: var(--color-text-secondary); cursor: pointer; display: flex; flex-wrap: wrap; gap: 0.25rem; max-width: 18rem; padding: 0; text-align: left; }
+    .thread-row__tags span { background: var(--color-surface-muted); border-radius: 999px; padding: 0.125rem 0.45rem; }
+    .thread-row__tags--empty { color: var(--color-text-muted); }
+    .thread-row__select-cell { text-align: center; }
+    .thread-row__select { accent-color: var(--color-accent); cursor: pointer; height: 1rem; width: 1rem; }
+    .thread-row__star, .thread-row__archive { border: 1px solid var(--color-border-base); border-radius: 999px; color: var(--color-text-muted); cursor: pointer; font-size: 0.68rem; font-weight: 700; padding: 0.2rem 0.55rem; text-transform: uppercase; }
+    .thread-row__star { align-items: center; background: var(--color-surface-base); display: inline-flex; justify-content: center; padding: 0.35rem; }
+    .thread-row__star--active { background: color-mix(in srgb, var(--color-accent) 14%, transparent); border-color: var(--color-accent); color: var(--color-accent); }
+    .thread-row__archive { background: var(--color-surface-base); opacity: 1; }
+    .thread-row__archive--restore { text-transform: none; }
+    .thread-row__delete { background: transparent; border: 0; border-radius: 0.375rem; color: var(--color-text-muted); cursor: pointer; display: inline-flex; justify-content: center; padding: 0.35rem; text-transform: none; }
+    .thread-row__delete:hover, .thread-row__delete:focus-visible { background: color-mix(in srgb, var(--color-danger) 12%, transparent); color: var(--color-danger); }
+    .thread-row__date, .thread-row__personality { color: var(--color-text-muted); }
+    .thread-row__personality-content { align-items: center; color: var(--thread-persona-accent, var(--color-text-muted)); display: inline-flex; gap: 0.4375rem; max-width: 100%; }
+    .thread-row__personality-avatar { align-items: center; background: color-mix(in srgb, var(--thread-persona-accent, var(--color-accent)) 16%, var(--color-surface-muted)); border-radius: 50%; color: var(--thread-persona-accent, var(--color-accent)); display: inline-flex; flex: 0 0 auto; font-size: 0.625rem; font-weight: 800; height: 1.5rem; justify-content: center; overflow: hidden; width: 1.5rem; }
+    .thread-row__personality-avatar img { height: 100%; object-fit: cover; transform-origin: center center; width: 100%; }
+    .thread-row__personality-avatar-fallback { align-items: center; display: inline-flex; height: 100%; justify-content: center; width: 100%; }
+    .thread-row__personality-name { color: inherit; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .thread-row__name-input { background: var(--color-surface-base); border: 1px solid var(--color-accent); border-radius: 0.5rem; color: var(--color-text-primary); font: inherit; padding: 0.35rem 0.5rem; width: 100%; }
+    .thread-row__archive-cell, .thread-row__delete-cell, .thread-row__star-cell { text-align: center; width: 2.75rem; }
+    .thread-row__delete-cell { padding-inline: 0.375rem; }
     @media (max-width: 1023px) {
-      .thread-row__title {
-        min-width: 11rem;
-      }
-
-      .thread-row__name-input {
-        font-size: 1rem;
-      }
-
-      .thread-row__archive,
-      .thread-row__delete,
-      .thread-row__star {
-        min-height: 2.25rem;
-      }
+      .thread-row__title { min-width: 11rem; }
+      .thread-row__name-input { font-size: 1rem; }
+      .thread-row__archive, .thread-row__context, .thread-row__delete, .thread-row__star { min-height: 2.25rem; }
     }
-
     @media (max-width: 767px) {
-      .thread-row__created,
-      .thread-row__tags-cell {
-        display: none;
-      }
-
-      .thread-row__title {
-        min-width: 8rem;
-        width: auto;
-      }
+      .thread-row__created, .thread-row__tags-cell { display: none; }
+      .thread-row__title { min-width: 8rem; width: auto; }
+      .thread-row__context { font-size: 0; padding-inline: 0.45rem; }
+      .thread-row__context::after { content: '+'; font-size: 0.875rem; }
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ThreadRowComponent {
   private readonly imageGallery = inject(ImageGalleryService);
+  private readonly contextPanel = inject(ContextPanelService);
   readonly thread = input.required<Chat>();
   readonly personality = input<Personality | null>(null);
   readonly active = input(false);
@@ -404,6 +215,7 @@ export class ThreadRowComponent {
   readonly checked = input(false);
 
   readonly select = output<string>();
+  readonly addToContext = output<Chat>();
   readonly toggleSelect = output<string>();
   readonly rename = output<{ thread: Chat; name: string }>();
   readonly togglePin = output<Chat>();
@@ -417,9 +229,7 @@ export class ThreadRowComponent {
   );
   readonly personalityAccentColor = computed(() => {
     const personality = this.personality();
-    if (personality) {
-      return personalityAccent(personality);
-    }
+    if (personality) return personalityAccent(personality);
     const label = this.thread().personality_name?.trim();
     if (!label) return null;
     return personalityAccent({ id: this.thread().personality_id ?? '', name: label, accent_color: null });
@@ -434,6 +244,13 @@ export class ThreadRowComponent {
   readonly personalityThumbnailStyle = computed(() =>
     thumbnailCircleToImageStyle(this.personality()?.thumbnail_circle),
   );
+
+  queueForContext(event: Event): void {
+    event.stopPropagation();
+    const thread = this.thread();
+    this.contextPanel.queueThreadReference(thread);
+    this.addToContext.emit(thread);
+  }
 
   commitRename(nextName: string): void {
     this.editing.set(false);

--- a/web/app/src/app/features/chat/components/thread-list-panel/thread-row.context.spec.ts
+++ b/web/app/src/app/features/chat/components/thread-list-panel/thread-row.context.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+
+import { Chat } from '../../../../core/models/chat.model';
+import { ImageGalleryService } from '../../../../core/services/image-gallery.service';
+import { ThreadRowComponent } from './thread-row.component';
+
+describe('ThreadRowComponent thread context action', () => {
+  let fixture: ComponentFixture<ThreadRowComponent>;
+
+  const thread: Chat = {
+    id: 'thread-history-1',
+    user_id: 'user-1',
+    name: 'Old research thread',
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-02T00:00:00Z',
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ThreadRowComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: ImageGalleryService,
+          useValue: { getImageUrl: vi.fn() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ThreadRowComponent);
+    fixture.componentRef.setInput('thread', thread);
+    fixture.detectChanges();
+  });
+
+  it('offers an add-to-context action and emits the selected thread without opening it', () => {
+    const selected: Chat[] = [];
+    (fixture.componentInstance as any).addToContext.subscribe((value: Chat) => selected.push(value));
+
+    const button = fixture.nativeElement.querySelector(
+      '[aria-label="Add thread Old research thread to context"]',
+    ) as HTMLButtonElement | null;
+
+    expect(button).not.toBeNull();
+    button?.click();
+
+    expect(selected).toEqual([thread]);
+  });
+});

--- a/web/app/src/app/features/chat/services/context-panel.service.spec.ts
+++ b/web/app/src/app/features/chat/services/context-panel.service.spec.ts
@@ -2,6 +2,7 @@ import type { MockedObject } from "vitest";
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 
+import { Chat } from '../../../core/models/chat.model';
 import { ContextBreakdown } from '../../../core/models/message.model';
 import { RightPanelService } from '../../../core/services/right-panel.service';
 import { ContextPanelService } from './context-panel.service';
@@ -12,6 +13,16 @@ function breakdown(total: number): ContextBreakdown {
         total_tokens: total,
         budget_tokens: 30000,
         captured_at: '2026-08-17T12:00:00Z',
+    };
+}
+
+function chat(id: string, name: string): Chat {
+    return {
+        id,
+        user_id: 'user-1',
+        name,
+        created_at: '',
+        updated_at: '',
     };
 }
 
@@ -38,13 +49,7 @@ describe('ContextPanelService', () => {
     });
 
     it('persists active tab per chat', () => {
-        service.setActiveChat({
-            id: 'chat-1',
-            user_id: 'user-1',
-            name: 'Thread',
-            created_at: '',
-            updated_at: '',
-        });
+        service.setActiveChat(chat('chat-1', 'Thread'));
 
         service.setActiveTab('tools');
 
@@ -58,6 +63,30 @@ describe('ContextPanelService', () => {
 
         expect(service.consumeComposerInsert()).toBe('note');
         expect(service.consumeComposerInsert()).toBeNull();
+    });
+
+    it('holds thread references while the manager is open and inserts them when a target chat opens', () => {
+        service.queueThreadReference(chat('old-1', 'Old research'));
+        service.queueThreadReference(chat('old-2', 'Prior decision'));
+
+        expect(service.pendingThreadReferences().map(thread => thread.id)).toEqual(['old-1', 'old-2']);
+        expect(service.consumeComposerInsert()).toBeNull();
+
+        service.setActiveChat(chat('target', 'Current chat'));
+
+        expect(service.pendingThreadReferences()).toEqual([]);
+        expect(service.consumeComposerInsert()).toBe(
+            '[Thread context: "Old research"; thread_id="old-1"]\n' +
+            '[Thread context: "Prior decision"; thread_id="old-2"]\n',
+        );
+    });
+
+    it('deduplicates a queued thread reference', () => {
+        const referenced = chat('old-1', 'Old research');
+        service.queueThreadReference(referenced);
+        service.queueThreadReference(referenced);
+
+        expect(service.pendingThreadReferences()).toEqual([referenced]);
     });
 
     it('forwards desktop visibility to right panel service', () => {

--- a/web/app/src/app/features/chat/services/context-panel.service.ts
+++ b/web/app/src/app/features/chat/services/context-panel.service.ts
@@ -15,6 +15,7 @@ export class ContextPanelService {
   private readonly _activeChat = signal<Chat | null>(null);
   private readonly _mobileOpen = signal(false);
   private readonly _composerInsert = signal<string | null>(null);
+  private readonly _pendingThreadReferences = signal<Chat[]>([]);
   private readonly _toolCalls = signal<readonly ToolCall[]>([]);
   private readonly _latestBreakdown = signal<ContextBreakdown | null>(null);
   private readonly _latestBreakdownId = signal<string | null>(null);
@@ -24,6 +25,7 @@ export class ContextPanelService {
   readonly activeChat = this._activeChat.asReadonly();
   readonly mobileOpen = this._mobileOpen.asReadonly();
   readonly composerInsert = this._composerInsert.asReadonly();
+  readonly pendingThreadReferences = this._pendingThreadReferences.asReadonly();
   readonly toolCalls = this._toolCalls.asReadonly();
   /** Most recent assistant turn's Context X-ray for the active chat, or null. */
   readonly latestBreakdown = this._latestBreakdown.asReadonly();
@@ -41,6 +43,28 @@ export class ContextPanelService {
 
   setActiveChat(chat: Chat | null): void {
     this._activeChat.set(chat);
+
+    // Thread references can be queued from the thread manager while there is no
+    // active composer. Once the user opens the conversation they want to send
+    // from, turn those queued references into explicit next-turn context text.
+    if (chat && this._pendingThreadReferences().length > 0) {
+      const references = this._pendingThreadReferences();
+      this._composerInsert.set(formatThreadReferences(references));
+      this._pendingThreadReferences.set([]);
+    }
+  }
+
+  queueThreadReference(thread: Chat): void {
+    this._pendingThreadReferences.update(current => {
+      if (current.some(item => item.id === thread.id)) {
+        return current;
+      }
+      return [...current, thread];
+    });
+  }
+
+  removePendingThreadReference(threadId: string): void {
+    this._pendingThreadReferences.update(current => current.filter(thread => thread.id !== threadId));
   }
 
   setToolCalls(toolCalls: readonly ToolCall[]): void {
@@ -91,6 +115,13 @@ export class ContextPanelService {
     this._composerInsert.set(null);
     return value;
   }
+}
+
+function formatThreadReferences(threads: readonly Chat[]): string {
+  const lines = threads.map(thread =>
+    `[Thread context: ${JSON.stringify(thread.name)}; thread_id=${JSON.stringify(thread.id)}]`,
+  );
+  return `${lines.join('\n')}\n`;
 }
 
 function readTabsFromStorage(): Record<string, ContextPanelTab> {


### PR DESCRIPTION
Fixes #40.

## Diagnosis

`fetch_context()` can retrieve an old thread once the agent knows its thread id/name, but the UI currently gives the user no direct way to hand that reference to the next turn. The chat composer already has a bounded notion of pending next-turn state (attachments and rituals), while the thread manager already exposes row-level actions.

The narrow implementation is therefore:
- add an **Add to context** action to a thread row,
- queue that thread as visible/removable pending composer context,
- serialize an explicit thread id/name reference into the next user turn so the agent can use its existing context-retrieval tools,
- consume the pending thread reference only after a successful send.

This intentionally does **not** add a new backend message schema or make the UI invoke agent tools directly unless later source evidence shows that is required.

## Test-first evidence

The first commit adds a regression requiring each thread row to expose an `Add thread … to context` action and emit the selected thread without opening it. Current production code has no such output/action, so this test is expected to fail before the implementation commit.

## Earlier epistemic boundary

An earlier planning-stage BSD pass classified this as a bounded change. At that stage PPI/evidence-mass were unavailable because the supplied evidence was caller/model-provided rather than independently certified; that was not treated as causal proof. Passing the regression establishes the encoded UI/send behavior, not prove every future `fetch_context()` workflow succeeds.

## BSD rerun — BSD-main (17), coding profile

Current-head evaluation: `eval-546eba9e-36ef-4572-b5e0-9f6f394f7060`.

- structural reasoning reliability: `0.749999` (`MEASURED`)
- evidence mass: `1.000000` (`MEASURED`; host-bound coverage/engagement, not truth probability)
- canonical PPI: `0.156250` (`MEASURED`, `ppi-trace-canonical-v0.2.0`)
- canonical comparison weight: implementation-correct `0.556` / partial-correctness `0.444` (`MEASURED` for both frames)
- unknown-unknown indicator: `BOUNDED [0.020833, 0.270833]` (`MISSING_VECTOR_DIMENSIONS_PRESERVED_AS_INTERVAL`)
- response policy: `DIRECT` with `MISSING_INFORMATION`, `SCOPE_LIMITED`

Current-head diff, GitHub Actions, and maintainer-review observations were carried through the exchange receipt sidecar as host-bound `HOST_BOUND_FALLBACK` evidence. In BSD-main (17), distinct bound receipts count fully toward `E_mass` coverage; the host-mediated retrieval path remains separately recorded as `transport_quality=0.75` and is applied once downstream to canonical support. That establishes host-observed retrieval/binding, not that BSD independently proves the semantic interpretation or that the implementation is true/correct.

The encoded Add-to-context queue/removal/next-send path is supported and the current Frontend + local-LLM + mock E2E workflows are green. The competing frame remains live because the maintainer marked the UX pending and requested product review, and because receiving an explicit thread id/name reference is not the same as proving the downstream agent will reliably choose and succeed with `fetch_context()`. BSD therefore keeps the conclusion scope-limited rather than treating the passing mechanics as full product validation.