### PR TITLE
Explain summary and scratchpad checkpoint changes

### DIFF
--- a/ent/schema/compaction_event.go
+++ b/ent/schema/compaction_event.go
@@ -53,6 +53,12 @@ func (CompactionEvent) Fields() []ent.Field {
 		field.String("reason").
 			Optional().
 			Comment("Checkpoint decision reason (token budget / message count / etc.)"),
+		field.Text("summary_explanation").
+			Optional().
+			Comment("Short model-generated explanation of what changed in the conversation summary"),
+		field.Text("scratchpad_explanation").
+			Optional().
+			Comment("Short model-generated explanation of what changed in the personality scratchpad"),
 		// FK columns to CheckpointSnapshot, surfaced through the edges below.
 		field.UUID("old_summary_id", uuid.UUID{}).Optional().Nillable(),
 		field.UUID("new_summary_id", uuid.UUID{}).Optional().Nillable(),

--- a/internal/agent/compaction_event_log.go
+++ b/internal/agent/compaction_event_log.go
@@ -35,15 +35,27 @@ func (a *Agent) beginCompactionEvent(
 		return nil
 	}
 
+	scratchpadExplanation := ""
+	if hasScratchpad {
+		if explanation, err := a.explainCheckpointChange(ctx, userID, "personality scratchpad", chatCtx.chat.Scratchpad, newScratchpad); err != nil {
+			a.logger.Warn("failed to explain scratchpad checkpoint change; continuing without explanation",
+				zap.String("chat_id", chatID.String()),
+				zap.Error(err))
+		} else {
+			scratchpadExplanation = explanation
+		}
+	}
+
 	input := models.CompactionEventInput{
-		ChatID:         chatID,
-		Provider:       providerName,
-		Reason:         reason,
-		OldSummary:     chatCtx.chat.CheckpointSummary,
-		OldScratchpad:  chatCtx.chat.Scratchpad,
-		NewScratchpad:  newScratchpad,
-		HasScratchpad:  hasScratchpad,
-		LoadedMemories: loadedMemoriesSnapshot(inferenceModelContext, chatCtx.liveMemories),
+		ChatID:                chatID,
+		Provider:              providerName,
+		Reason:                reason,
+		OldSummary:            chatCtx.chat.CheckpointSummary,
+		OldScratchpad:         chatCtx.chat.Scratchpad,
+		NewScratchpad:         newScratchpad,
+		ScratchpadExplanation: scratchpadExplanation,
+		HasScratchpad:         hasScratchpad,
+		LoadedMemories:        loadedMemoriesSnapshot(inferenceModelContext, chatCtx.liveMemories),
 	}
 	if chatCtx.chat.PersonalityID != uuid.Nil {
 		pid := chatCtx.chat.PersonalityID
@@ -65,22 +77,35 @@ func (a *Agent) beginCompactionEvent(
 	return &id
 }
 
-// finishCompactionEvent attaches the post-checkpoint summary to an open compaction event. No-op when
-// eventID is nil (compaction was not being logged).
+// finishCompactionEvent attaches the post-checkpoint summary and a best-effort transition
+// explanation to an open compaction event. No-op when eventID is nil.
 func (a *Agent) finishCompactionEvent(ctx context.Context, userID uuid.UUID, eventID *uuid.UUID, newSummary string) {
 	if eventID == nil {
 		return
 	}
-	if err := a.ds.SetCompactionEventNewSummary(ctx, userID, *eventID, newSummary); err != nil {
+
+	summaryExplanation := ""
+	if event, err := a.ds.GetCompactionEvent(ctx, userID, *eventID); err != nil {
+		a.logger.Warn("failed to load compaction event for summary explanation; continuing without explanation",
+			zap.String("compaction_event_id", eventID.String()),
+			zap.Error(err))
+	} else if event.OldSummary != nil {
+		if explanation, err := a.explainCheckpointChange(ctx, userID, "conversation summary", event.OldSummary.Content, newSummary); err != nil {
+			a.logger.Warn("failed to explain summary checkpoint change; continuing without explanation",
+				zap.String("compaction_event_id", eventID.String()),
+				zap.Error(err))
+		} else {
+			summaryExplanation = explanation
+		}
+	}
+
+	if err := a.ds.SetCompactionEventNewSummary(ctx, userID, *eventID, newSummary, summaryExplanation); err != nil {
 		a.logger.Warn("failed to attach new summary to compaction event",
 			zap.String("compaction_event_id", eventID.String()),
 			zap.Error(err))
 	}
 }
 
-// loadedMemoriesSnapshot flattens the same segment-wide loaded set used by the memory merger into
-// the audit shape. ModelContext.MemoryRefs carries prior turns' persisted additional_context;
-// liveMemories adds current-turn prefetch and tool-loaded rows that are not in that frozen snapshot.
 func loadedMemoriesSnapshot(modelContext *provider.ModelContext, liveMemories []*models.Memory) []models.CompactionLoadedMemory {
 	candidates := buildMemoryMergeCandidates(modelContext, liveMemories, nil)
 	if len(candidates) == 0 {

--- a/internal/agent/compaction_explanation.go
+++ b/internal/agent/compaction_explanation.go
@@ -23,6 +23,9 @@ func (a *Agent) explainCheckpointChange(ctx context.Context, userID uuid.UUID, k
 	if before == after {
 		return "No change.", nil
 	}
+	if a == nil || a.OpenAIProvider == nil {
+		return "", fmt.Errorf("checkpoint explanation provider unavailable")
+	}
 
 	prompt := fmt.Sprintf(`Explain the meaningful change between the BEFORE and AFTER %s states in one short sentence for the user.
 Focus on what information was added, removed, clarified, consolidated, or reprioritized.

--- a/internal/agent/compaction_explanation.go
+++ b/internal/agent/compaction_explanation.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/telemetry"
+)
+
+const checkpointExplanationMaxTokens = 256
+
+// explainCheckpointChange asks the archival model for a short user-facing account of a state
+// transition. It is audit metadata only: callers deliberately treat failure as best-effort so an
+// explanation outage can never block the checkpoint that owns the authoritative before/after data.
+func (a *Agent) explainCheckpointChange(ctx context.Context, userID uuid.UUID, kind, before, after string) (string, error) {
+	before = strings.TrimSpace(before)
+	after = strings.TrimSpace(after)
+	if before == after {
+		return "No change.", nil
+	}
+
+	prompt := fmt.Sprintf(`Explain the meaningful change between the BEFORE and AFTER %s states in one short sentence for the user.
+Focus on what information was added, removed, clarified, consolidated, or reprioritized.
+Do not judge whether the change was correct. Do not quote large passages. Respond with only the explanation sentence.
+
+BEFORE:
+%s
+
+AFTER:
+%s`, kind, before, after)
+
+	params := responses.ResponseNewParams{
+		Model:            archivalOpenAIModel,
+		SafetyIdentifier: openai.String(userID.String()),
+		MaxOutputTokens:  openai.Int(checkpointExplanationMaxTokens),
+		ServiceTier:      responses.ResponseNewParamsServiceTierFlex,
+		Instructions:     openai.String("You explain checkpoint audit changes concisely and literally."),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: []responses.ResponseInputItemUnionParam{
+				responses.ResponseInputItemParamOfMessage(prompt, provider.RoleUser),
+			},
+		},
+	}
+
+	resp, err := a.OpenAIProvider.CallWithRetry(telemetry.WithCallPath(ctx, telemetry.CallPathScratchpad), params)
+	if err != nil {
+		return "", err
+	}
+	explanation := strings.TrimSpace(resp.OutputText())
+	if explanation == "" {
+		return "", fmt.Errorf("checkpoint explanation returned empty content")
+	}
+	return explanation, nil
+}

--- a/internal/datastore/compaction_event.go
+++ b/internal/datastore/compaction_event.go
@@ -22,8 +22,12 @@ import (
 )
 
 var (
+	// ErrCompactionEventNotFound is returned when a compaction event does not exist for the user.
 	ErrCompactionEventNotFound = fmt.Errorf("compaction event not found")
+	// ErrCheckpointSnapshotNotFound is returned when a snapshot does not exist for the user.
 	ErrCheckpointSnapshotNotFound = fmt.Errorf("checkpoint snapshot not found")
+	// ErrCheckpointSnapshotOwnerMissing is returned when a snapshot lacks the owner reference (chat
+	// for summary, personality for scratchpad) needed to revert it.
 	ErrCheckpointSnapshotOwnerMissing = fmt.Errorf("checkpoint snapshot missing owner reference")
 )
 
@@ -34,86 +38,225 @@ func contentHash(content string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func (d *Datastore) getOrCreateCheckpointSnapshotTx(ctx context.Context, tx *ent.Tx, userID uuid.UUID, kind entsnap.Kind, chatID *uuid.UUID, personalityID *uuid.UUID, content string) (*ent.CheckpointSnapshot, error) {
+// getOrCreateCheckpointSnapshotTx returns the content-addressed snapshot row for the given
+// (user, kind, owner, content), creating it if absent. Because rows are reused, the snapshot a
+// compaction records as "new" is the same row the next compaction records as "old" — no duplication.
+func (d *Datastore) getOrCreateCheckpointSnapshotTx(
+	ctx context.Context,
+	tx *ent.Tx,
+	userID uuid.UUID,
+	kind entsnap.Kind,
+	chatID *uuid.UUID,
+	personalityID *uuid.UUID,
+	content string,
+) (*ent.CheckpointSnapshot, error) {
 	hash := contentHash(content)
-	q := tx.CheckpointSnapshot.Query().Where(entsnap.UserID(userID), entsnap.KindEQ(kind), entsnap.ContentHash(hash))
-	if chatID != nil { q = q.Where(entsnap.ChatID(*chatID)) } else { q = q.Where(entsnap.ChatIDIsNil()) }
-	if personalityID != nil { q = q.Where(entsnap.PersonalityID(*personalityID)) } else { q = q.Where(entsnap.PersonalityIDIsNil()) }
+	q := tx.CheckpointSnapshot.Query().Where(
+		entsnap.UserID(userID),
+		entsnap.KindEQ(kind),
+		entsnap.ContentHash(hash),
+	)
+	if chatID != nil {
+		q = q.Where(entsnap.ChatID(*chatID))
+	} else {
+		q = q.Where(entsnap.ChatIDIsNil())
+	}
+	if personalityID != nil {
+		q = q.Where(entsnap.PersonalityID(*personalityID))
+	} else {
+		q = q.Where(entsnap.PersonalityIDIsNil())
+	}
+
 	existing, err := q.First(ctx)
-	if err == nil { return existing, nil }
-	if !ent.IsNotFound(err) { return nil, err }
-	create := tx.CheckpointSnapshot.Create().SetUserID(userID).SetKind(kind).SetContent(content).SetContentHash(hash)
-	if chatID != nil { create = create.SetChatID(*chatID) }
-	if personalityID != nil { create = create.SetPersonalityID(*personalityID) }
+	if err == nil {
+		return existing, nil
+	}
+	if !ent.IsNotFound(err) {
+		return nil, err
+	}
+
+	create := tx.CheckpointSnapshot.Create().
+		SetUserID(userID).
+		SetKind(kind).
+		SetContent(content).
+		SetContentHash(hash)
+	if chatID != nil {
+		create = create.SetChatID(*chatID)
+	}
+	if personalityID != nil {
+		create = create.SetPersonalityID(*personalityID)
+	}
 	return create.Save(ctx)
 }
 
+// CreateCompactionEvent records the start of a compaction: old summary, old/new scratchpad, loaded
+// memories and metadata. The new summary is unknown at this point and is attached later via
+// SetCompactionEventNewSummary. Returns the event so its ID can be threaded into the merge events.
 func (d *Datastore) CreateCompactionEvent(ctx context.Context, userID uuid.UUID, input models.CompactionEventInput) (*models.CompactionEvent, error) {
 	tx, err := d.dbClient.Tx(ctx)
-	if err != nil { return nil, err }
-	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if v := recover(); v != nil {
+			_ = tx.Rollback()
+			panic(v)
+		}
+	}()
+
 	chatID := input.ChatID
+
 	oldSummary, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindSummary, &chatID, nil, input.OldSummary)
-	if err != nil { _ = tx.Rollback(); return nil, err }
-	create := tx.CompactionEvent.Create().SetUserID(userID).SetChatID(chatID).SetNillablePersonalityID(input.PersonalityID).SetNillableAssistantMessageID(input.AssistantMessageID).SetProvider(input.Provider).SetReason(input.Reason).SetOldSummaryID(oldSummary.ID).SetLoadedMemories(toEntLoadedMemories(input.LoadedMemories))
-	if input.ScratchpadExplanation != "" { create = create.SetScratchpadExplanation(input.ScratchpadExplanation) }
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+
+	create := tx.CompactionEvent.Create().
+		SetUserID(userID).
+		SetChatID(chatID).
+		SetNillablePersonalityID(input.PersonalityID).
+		SetNillableAssistantMessageID(input.AssistantMessageID).
+		SetProvider(input.Provider).
+		SetReason(input.Reason).
+		SetOldSummaryID(oldSummary.ID).
+		SetLoadedMemories(toEntLoadedMemories(input.LoadedMemories))
+	if input.ScratchpadExplanation != "" {
+		create = create.SetScratchpadExplanation(input.ScratchpadExplanation)
+	}
+
+	// Scratchpad snapshots only exist when the checkpoint had a personality to update.
 	if input.HasScratchpad && input.PersonalityID != nil {
 		oldScratch, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindScratchpad, nil, input.PersonalityID, input.OldScratchpad)
-		if err != nil { _ = tx.Rollback(); return nil, err }
+		if err != nil {
+			_ = tx.Rollback()
+			return nil, err
+		}
 		newScratch, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindScratchpad, nil, input.PersonalityID, input.NewScratchpad)
-		if err != nil { _ = tx.Rollback(); return nil, err }
+		if err != nil {
+			_ = tx.Rollback()
+			return nil, err
+		}
 		create = create.SetOldScratchpadID(oldScratch.ID).SetNewScratchpadID(newScratch.ID)
 	}
+
 	event, err := create.Save(ctx)
-	if err != nil { _ = tx.Rollback(); return nil, err }
-	if err := tx.Commit(); err != nil { return nil, err }
-	return d.loadCompactionEvent(ctx, userID, event.ID)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	full, err := d.loadCompactionEvent(ctx, userID, event.ID)
+	if err != nil {
+		return nil, err
+	}
+	return full, nil
 }
 
+// AppendCompactionEventCreatedMemories appends newly created memory snapshots onto a compaction
+// audit record. Empty inputs are no-ops. Missing/pruned compaction events are best-effort: the
+// helper returns nil so memory persistence is never blocked by audit attach.
 func (d *Datastore) AppendCompactionEventCreatedMemories(ctx context.Context, userID, eventID uuid.UUID, memories []models.CompactionLoadedMemory) error {
-	if len(memories) == 0 { return nil }
+	if len(memories) == 0 {
+		return nil
+	}
 	tx, err := d.dbClient.Tx(ctx)
-	if err != nil { return err }
-	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if v := recover(); v != nil {
+			_ = tx.Rollback()
+			panic(v)
+		}
+	}()
 	if err := d.appendCompactionEventCreatedMemoriesTx(ctx, tx, userID, eventID, memories); err != nil {
 		_ = tx.Rollback()
-		if errors.Is(err, ErrCompactionEventNotFound) { return nil }
+		if errors.Is(err, ErrCompactionEventNotFound) {
+			return nil
+		}
 		return err
 	}
 	return tx.Commit()
 }
 
+// appendCompactionEventCreatedMemoriesTx uses Ent's sqljson.Append so concurrent writers for the
+// same compaction event do not clobber each other via read-modify-write.
 func (d *Datastore) appendCompactionEventCreatedMemoriesTx(ctx context.Context, tx *ent.Tx, userID, eventID uuid.UUID, memories []models.CompactionLoadedMemory) error {
-	if len(memories) == 0 { return nil }
-	n, err := tx.CompactionEvent.Update().Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).AppendCreatedMemories(toEntLoadedMemories(memories)).Save(ctx)
-	if err != nil { return err }
-	if n == 0 { return ErrCompactionEventNotFound }
+	if len(memories) == 0 {
+		return nil
+	}
+	n, err := tx.CompactionEvent.Update().
+		Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).
+		AppendCreatedMemories(toEntLoadedMemories(memories)).
+		Save(ctx)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrCompactionEventNotFound
+	}
 	return nil
 }
 
-// SetCompactionEventNewSummary attaches the post-checkpoint summary snapshot and its transition explanation.
+// SetCompactionEventNewSummary attaches the post-checkpoint summary snapshot and explanation to an existing event.
 func (d *Datastore) SetCompactionEventNewSummary(ctx context.Context, userID, eventID uuid.UUID, newSummary, explanation string) error {
 	tx, err := d.dbClient.Tx(ctx)
-	if err != nil { return err }
-	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
-	event, err := tx.CompactionEvent.Query().Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).Only(ctx)
 	if err != nil {
-		_ = tx.Rollback()
-		if ent.IsNotFound(err) { return ErrCompactionEventNotFound }
 		return err
 	}
+	defer func() {
+		if v := recover(); v != nil {
+			_ = tx.Rollback()
+			panic(v)
+		}
+	}()
+
+	event, err := tx.CompactionEvent.Query().
+		Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).
+		Only(ctx)
+	if err != nil {
+		_ = tx.Rollback()
+		if ent.IsNotFound(err) {
+			return ErrCompactionEventNotFound
+		}
+		return err
+	}
+
 	snap, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindSummary, &event.ChatID, nil, newSummary)
-	if err != nil { _ = tx.Rollback(); return err }
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
 	update := tx.CompactionEvent.UpdateOneID(event.ID).SetNewSummaryID(snap.ID)
-	if explanation != "" { update = update.SetSummaryExplanation(explanation) }
-	if _, err := update.Save(ctx); err != nil { _ = tx.Rollback(); return err }
+	if explanation != "" {
+		update = update.SetSummaryExplanation(explanation)
+	}
+	if _, err := update.Save(ctx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
 	return tx.Commit()
 }
 
 func (d *Datastore) loadCompactionEvent(ctx context.Context, userID, eventID uuid.UUID) (*models.CompactionEvent, error) {
-	row, err := d.dbClient.CompactionEvent.Query().Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).WithOldSummary().WithNewSummary().WithOldScratchpad().WithNewScratchpad().WithMergeEvents(func(q *ent.MemoryMergeEventQuery) { q.Order(ent.Asc(entmerge.FieldCreatedAt)) }).Only(ctx)
+	row, err := d.dbClient.CompactionEvent.Query().
+		Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).
+		WithOldSummary().
+		WithNewSummary().
+		WithOldScratchpad().
+		WithNewScratchpad().
+		WithMergeEvents(func(q *ent.MemoryMergeEventQuery) {
+			q.Order(ent.Asc(entmerge.FieldCreatedAt))
+		}).
+		Only(ctx)
 	if err != nil {
-		if ent.IsNotFound(err) { return nil, ErrCompactionEventNotFound }
+		if ent.IsNotFound(err) {
+			return nil, ErrCompactionEventNotFound
+		}
 		return nil, err
 	}
 	event := toCompactionEventModel(row)
@@ -121,77 +264,265 @@ func (d *Datastore) loadCompactionEvent(ctx context.Context, userID, eventID uui
 	return event, nil
 }
 
-func (d *Datastore) GetCompactionEvent(ctx context.Context, userID, eventID uuid.UUID) (*models.CompactionEvent, error) { return d.loadCompactionEvent(ctx, userID, eventID) }
+// GetCompactionEvent returns one compaction event with all snapshots and merge events resolved.
+func (d *Datastore) GetCompactionEvent(ctx context.Context, userID, eventID uuid.UUID) (*models.CompactionEvent, error) {
+	return d.loadCompactionEvent(ctx, userID, eventID)
+}
 
+// ListCompactionEvents returns paginated compaction events (newest first) with snapshots and merge
+// events resolved.
 func (d *Datastore) ListCompactionEvents(ctx context.Context, userID uuid.UUID, pageNum, pageSize int, chatID, personalityID *uuid.UUID) (*models.PaginatedResponse, error) {
-	if pageNum < 1 { pageNum = 1 }
-	if pageSize < 1 { pageSize = 20 }
-	if pageSize > maxCompactionEventsPageSize { pageSize = maxCompactionEventsPageSize }
+	if pageNum < 1 {
+		pageNum = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > maxCompactionEventsPageSize {
+		pageSize = maxCompactionEventsPageSize
+	}
+
 	query := d.dbClient.CompactionEvent.Query().Where(entcompaction.UserID(userID))
-	if chatID != nil { query = query.Where(entcompaction.ChatID(*chatID)) }
-	if personalityID != nil { query = query.Where(entcompaction.PersonalityID(*personalityID)) }
+	if chatID != nil {
+		query = query.Where(entcompaction.ChatID(*chatID))
+	}
+	if personalityID != nil {
+		query = query.Where(entcompaction.PersonalityID(*personalityID))
+	}
 	totalCount, err := query.Clone().Count(ctx)
-	if err != nil { return nil, err }
-	rows, err := query.Order(ent.Desc(entcompaction.FieldCreatedAt)).Offset((pageNum - 1) * pageSize).Limit(pageSize).WithOldSummary().WithNewSummary().WithOldScratchpad().WithNewScratchpad().WithMergeEvents(func(q *ent.MemoryMergeEventQuery) { q.Order(ent.Asc(entmerge.FieldCreatedAt)) }).All(ctx)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := query.
+		Order(ent.Desc(entcompaction.FieldCreatedAt)).
+		Offset((pageNum - 1) * pageSize).
+		Limit(pageSize).
+		WithOldSummary().
+		WithNewSummary().
+		WithOldScratchpad().
+		WithNewScratchpad().
+		WithMergeEvents(func(q *ent.MemoryMergeEventQuery) {
+			q.Order(ent.Asc(entmerge.FieldCreatedAt))
+		}).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	events := make([]*models.CompactionEvent, len(rows))
-	for i, row := range rows { events[i] = toCompactionEventModel(row) }
+	for i, row := range rows {
+		events[i] = toCompactionEventModel(row)
+	}
 	d.populateCompactionEventChatNames(ctx, userID, events)
+
 	results := make([]any, len(events))
-	for i, event := range events { results[i] = event }
-	return &models.PaginatedResponse{Results: results, TotalCount: totalCount, Page: pageNum}, nil
+	for i, event := range events {
+		results[i] = event
+	}
+	return &models.PaginatedResponse{
+		Results:    results,
+		TotalCount: totalCount,
+		Page:       pageNum,
+	}, nil
 }
 
+// populateCompactionEventChatNames best-effort enriches audit events with their current chat names.
+// The event audit record remains useful when a chat has been deleted or this optional lookup fails.
 func (d *Datastore) populateCompactionEventChatNames(ctx context.Context, userID uuid.UUID, events []*models.CompactionEvent) {
-	chatIDs := make([]uuid.UUID, 0, len(events)); seen := make(map[uuid.UUID]struct{}, len(events))
-	for _, event := range events { if event == nil { continue }; if _, ok := seen[event.ChatID]; ok { continue }; seen[event.ChatID] = struct{}{}; chatIDs = append(chatIDs, event.ChatID) }
-	if len(chatIDs) == 0 { return }
-	chats, err := d.dbClient.Chat.Query().Where(entchat.IDIn(chatIDs...), entchat.HasOwnerWith(user.ID(userID))).Select(entchat.FieldID, entchat.FieldName).All(ctx)
-	if err != nil { d.logger.Warn("failed to load chat names for compaction events", zap.String("user_id", userID.String()), zap.Error(err)); return }
-	names := make(map[uuid.UUID]string, len(chats)); for _, chat := range chats { names[chat.ID] = chat.Name }
-	for _, event := range events { if event != nil { event.ChatName = names[event.ChatID] } }
+	chatIDs := make([]uuid.UUID, 0, len(events))
+	seen := make(map[uuid.UUID]struct{}, len(events))
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		if _, ok := seen[event.ChatID]; ok {
+			continue
+		}
+		seen[event.ChatID] = struct{}{}
+		chatIDs = append(chatIDs, event.ChatID)
+	}
+	if len(chatIDs) == 0 {
+		return
+	}
+
+	chats, err := d.dbClient.Chat.Query().
+		Where(entchat.IDIn(chatIDs...), entchat.HasOwnerWith(user.ID(userID))).
+		Select(entchat.FieldID, entchat.FieldName).
+		All(ctx)
+	if err != nil {
+		d.logger.Warn("failed to load chat names for compaction events",
+			zap.String("user_id", userID.String()),
+			zap.Error(err))
+		return
+	}
+	names := make(map[uuid.UUID]string, len(chats))
+	for _, chat := range chats {
+		names[chat.ID] = chat.Name
+	}
+	for _, event := range events {
+		if event != nil {
+			event.ChatName = names[event.ChatID]
+		}
+	}
 }
 
+// RevertCheckpointSnapshot restores a snapshot's content to the live summary or scratchpad it came
+// from. Summary snapshots restore Chat.checkpoint_summary; scratchpad snapshots restore
+// Personality.scratchpad (which is shared across that personality's chats). Snapshot rows are never
+// mutated or deleted — reverting only rewrites the live value.
 func (d *Datastore) RevertCheckpointSnapshot(ctx context.Context, userID, snapshotID uuid.UUID) (*models.CheckpointSnapshot, error) {
-	tx, err := d.dbClient.Tx(ctx); if err != nil { return nil, err }
-	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
-	snap, err := tx.CheckpointSnapshot.Query().Where(entsnap.ID(snapshotID), entsnap.UserID(userID)).Only(ctx)
-	if err != nil { _ = tx.Rollback(); if ent.IsNotFound(err) { return nil, ErrCheckpointSnapshotNotFound }; return nil, err }
+	tx, err := d.dbClient.Tx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if v := recover(); v != nil {
+			_ = tx.Rollback()
+			panic(v)
+		}
+	}()
+
+	snap, err := tx.CheckpointSnapshot.Query().
+		Where(entsnap.ID(snapshotID), entsnap.UserID(userID)).
+		Only(ctx)
+	if err != nil {
+		_ = tx.Rollback()
+		if ent.IsNotFound(err) {
+			return nil, ErrCheckpointSnapshotNotFound
+		}
+		return nil, err
+	}
+
 	switch snap.Kind {
 	case entsnap.KindSummary:
-		if snap.ChatID == nil { _ = tx.Rollback(); return nil, ErrCheckpointSnapshotOwnerMissing }
-		updated, err := tx.Chat.Update().Where(entchat.ID(*snap.ChatID), entchat.HasOwnerWith(user.ID(userID))).SetCheckpointSummary(snap.Content).Save(ctx)
-		if err != nil { _ = tx.Rollback(); return nil, err }; if updated == 0 { _ = tx.Rollback(); return nil, ErrChatNotFound }
+		if snap.ChatID == nil {
+			_ = tx.Rollback()
+			return nil, ErrCheckpointSnapshotOwnerMissing
+		}
+		updated, err := tx.Chat.Update().
+			Where(entchat.ID(*snap.ChatID), entchat.HasOwnerWith(user.ID(userID))).
+			SetCheckpointSummary(snap.Content).
+			Save(ctx)
+		if err != nil {
+			_ = tx.Rollback()
+			return nil, err
+		}
+		if updated == 0 {
+			_ = tx.Rollback()
+			return nil, ErrChatNotFound
+		}
 	case entsnap.KindScratchpad:
-		if snap.PersonalityID == nil { _ = tx.Rollback(); return nil, ErrCheckpointSnapshotOwnerMissing }
-		updated, err := tx.Personality.Update().Where(entpersonality.ID(*snap.PersonalityID), entpersonality.HasUserWith(user.ID(userID))).SetScratchpad(snap.Content).Save(ctx)
-		if err != nil { _ = tx.Rollback(); return nil, err }; if updated == 0 { _ = tx.Rollback(); return nil, ErrPersonalityNotFound }
+		if snap.PersonalityID == nil {
+			_ = tx.Rollback()
+			return nil, ErrCheckpointSnapshotOwnerMissing
+		}
+		updated, err := tx.Personality.Update().
+			Where(entpersonality.ID(*snap.PersonalityID), entpersonality.HasUserWith(user.ID(userID))).
+			SetScratchpad(snap.Content).
+			Save(ctx)
+		if err != nil {
+			_ = tx.Rollback()
+			return nil, err
+		}
+		if updated == 0 {
+			_ = tx.Rollback()
+			return nil, ErrPersonalityNotFound
+		}
 	default:
-		_ = tx.Rollback(); return nil, fmt.Errorf("unsupported snapshot kind: %s", snap.Kind)
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("unsupported snapshot kind: %s", snap.Kind)
 	}
-	if err := tx.Commit(); err != nil { return nil, err }
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
 	return toCheckpointSnapshotModel(snap), nil
 }
 
 func toEntLoadedMemories(memories []models.CompactionLoadedMemory) []entschema.CompactionLoadedMemory {
-	if len(memories) == 0 { return nil }
-	out := make([]entschema.CompactionLoadedMemory, len(memories)); for i, m := range memories { out[i] = entschema.CompactionLoadedMemory{MemoryID: m.MemoryID, Content: m.Content, Scope: m.Scope, Confidence: m.Confidence} }; return out
+	if len(memories) == 0 {
+		return nil
+	}
+	out := make([]entschema.CompactionLoadedMemory, len(memories))
+	for i, m := range memories {
+		out[i] = entschema.CompactionLoadedMemory{
+			MemoryID:   m.MemoryID,
+			Content:    m.Content,
+			Scope:      m.Scope,
+			Confidence: m.Confidence,
+		}
+	}
+	return out
 }
+
 func loadedMemoriesToModel(memories []entschema.CompactionLoadedMemory) []models.CompactionLoadedMemory {
-	if len(memories) == 0 { return nil }
-	out := make([]models.CompactionLoadedMemory, len(memories)); for i, m := range memories { out[i] = models.CompactionLoadedMemory{MemoryID: m.MemoryID, Content: m.Content, Scope: m.Scope, Confidence: m.Confidence} }; return out
+	if len(memories) == 0 {
+		return nil
+	}
+	out := make([]models.CompactionLoadedMemory, len(memories))
+	for i, m := range memories {
+		out[i] = models.CompactionLoadedMemory{
+			MemoryID:   m.MemoryID,
+			Content:    m.Content,
+			Scope:      m.Scope,
+			Confidence: m.Confidence,
+		}
+	}
+	return out
 }
+
 func toCheckpointSnapshotModel(row *ent.CheckpointSnapshot) *models.CheckpointSnapshot {
-	if row == nil { return nil }
-	return &models.CheckpointSnapshot{ID: row.ID, Kind: models.CheckpointSnapshotKind(row.Kind), ChatID: row.ChatID, PersonalityID: row.PersonalityID, Content: row.Content, CreatedAt: row.CreatedAt}
+	if row == nil {
+		return nil
+	}
+	return &models.CheckpointSnapshot{
+		ID:            row.ID,
+		Kind:          models.CheckpointSnapshotKind(row.Kind),
+		ChatID:        row.ChatID,
+		PersonalityID: row.PersonalityID,
+		Content:       row.Content,
+		CreatedAt:     row.CreatedAt,
+	}
 }
+
 func toCompactionEventModel(row *ent.CompactionEvent) *models.CompactionEvent {
-	if row == nil { return nil }
-	event := &models.CompactionEvent{ID: row.ID, ChatID: row.ChatID, PersonalityID: row.PersonalityID, AssistantMessageID: row.AssistantMessageID, Provider: row.Provider, Reason: row.Reason, SummaryExplanation: row.SummaryExplanation, ScratchpadExplanation: row.ScratchpadExplanation, LoadedMemories: loadedMemoriesToModel(row.LoadedMemories), CreatedMemories: loadedMemoriesToModel(row.CreatedMemories), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
-	if row.Edges.OldSummary != nil { event.OldSummary = toCheckpointSnapshotModel(row.Edges.OldSummary) }
-	if row.Edges.NewSummary != nil { event.NewSummary = toCheckpointSnapshotModel(row.Edges.NewSummary) }
-	if row.Edges.OldScratchpad != nil { event.OldScratchpad = toCheckpointSnapshotModel(row.Edges.OldScratchpad) }
-	if row.Edges.NewScratchpad != nil { event.NewScratchpad = toCheckpointSnapshotModel(row.Edges.NewScratchpad) }
-	if len(row.Edges.MergeEvents) > 0 { event.MergeEvents = make([]models.MemoryMergeEvent, 0, len(row.Edges.MergeEvents)); for _, me := range row.Edges.MergeEvents { if m := toMemoryMergeEventModel(me); m != nil { event.MergeEvents = append(event.MergeEvents, *m) } } }
+	if row == nil {
+		return nil
+	}
+	event := &models.CompactionEvent{
+		ID:                    row.ID,
+		ChatID:                row.ChatID,
+		PersonalityID:         row.PersonalityID,
+		AssistantMessageID:    row.AssistantMessageID,
+		Provider:              row.Provider,
+		Reason:                row.Reason,
+		SummaryExplanation:    row.SummaryExplanation,
+		ScratchpadExplanation: row.ScratchpadExplanation,
+		LoadedMemories:        loadedMemoriesToModel(row.LoadedMemories),
+		CreatedMemories:       loadedMemoriesToModel(row.CreatedMemories),
+		CreatedAt:             row.CreatedAt,
+		UpdatedAt:             row.UpdatedAt,
+	}
+	if row.Edges.OldSummary != nil {
+		event.OldSummary = toCheckpointSnapshotModel(row.Edges.OldSummary)
+	}
+	if row.Edges.NewSummary != nil {
+		event.NewSummary = toCheckpointSnapshotModel(row.Edges.NewSummary)
+	}
+	if row.Edges.OldScratchpad != nil {
+		event.OldScratchpad = toCheckpointSnapshotModel(row.Edges.OldScratchpad)
+	}
+	if row.Edges.NewScratchpad != nil {
+		event.NewScratchpad = toCheckpointSnapshotModel(row.Edges.NewScratchpad)
+	}
+	if len(row.Edges.MergeEvents) > 0 {
+		event.MergeEvents = make([]models.MemoryMergeEvent, 0, len(row.Edges.MergeEvents))
+		for _, me := range row.Edges.MergeEvents {
+			if m := toMemoryMergeEventModel(me); m != nil {
+				event.MergeEvents = append(event.MergeEvents, *m)
+			}
+		}
+	}
 	return event
 }

--- a/internal/datastore/compaction_event.go
+++ b/internal/datastore/compaction_event.go
@@ -22,12 +22,8 @@ import (
 )
 
 var (
-	// ErrCompactionEventNotFound is returned when a compaction event does not exist for the user.
 	ErrCompactionEventNotFound = fmt.Errorf("compaction event not found")
-	// ErrCheckpointSnapshotNotFound is returned when a snapshot does not exist for the user.
 	ErrCheckpointSnapshotNotFound = fmt.Errorf("checkpoint snapshot not found")
-	// ErrCheckpointSnapshotOwnerMissing is returned when a snapshot lacks the owner reference (chat
-	// for summary, personality for scratchpad) needed to revert it.
 	ErrCheckpointSnapshotOwnerMissing = fmt.Errorf("checkpoint snapshot missing owner reference")
 )
 
@@ -38,218 +34,86 @@ func contentHash(content string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// getOrCreateCheckpointSnapshotTx returns the content-addressed snapshot row for the given
-// (user, kind, owner, content), creating it if absent. Because rows are reused, the snapshot a
-// compaction records as "new" is the same row the next compaction records as "old" — no duplication.
-func (d *Datastore) getOrCreateCheckpointSnapshotTx(
-	ctx context.Context,
-	tx *ent.Tx,
-	userID uuid.UUID,
-	kind entsnap.Kind,
-	chatID *uuid.UUID,
-	personalityID *uuid.UUID,
-	content string,
-) (*ent.CheckpointSnapshot, error) {
+func (d *Datastore) getOrCreateCheckpointSnapshotTx(ctx context.Context, tx *ent.Tx, userID uuid.UUID, kind entsnap.Kind, chatID *uuid.UUID, personalityID *uuid.UUID, content string) (*ent.CheckpointSnapshot, error) {
 	hash := contentHash(content)
-	q := tx.CheckpointSnapshot.Query().Where(
-		entsnap.UserID(userID),
-		entsnap.KindEQ(kind),
-		entsnap.ContentHash(hash),
-	)
-	if chatID != nil {
-		q = q.Where(entsnap.ChatID(*chatID))
-	} else {
-		q = q.Where(entsnap.ChatIDIsNil())
-	}
-	if personalityID != nil {
-		q = q.Where(entsnap.PersonalityID(*personalityID))
-	} else {
-		q = q.Where(entsnap.PersonalityIDIsNil())
-	}
-
+	q := tx.CheckpointSnapshot.Query().Where(entsnap.UserID(userID), entsnap.KindEQ(kind), entsnap.ContentHash(hash))
+	if chatID != nil { q = q.Where(entsnap.ChatID(*chatID)) } else { q = q.Where(entsnap.ChatIDIsNil()) }
+	if personalityID != nil { q = q.Where(entsnap.PersonalityID(*personalityID)) } else { q = q.Where(entsnap.PersonalityIDIsNil()) }
 	existing, err := q.First(ctx)
-	if err == nil {
-		return existing, nil
-	}
-	if !ent.IsNotFound(err) {
-		return nil, err
-	}
-
-	create := tx.CheckpointSnapshot.Create().
-		SetUserID(userID).
-		SetKind(kind).
-		SetContent(content).
-		SetContentHash(hash)
-	if chatID != nil {
-		create = create.SetChatID(*chatID)
-	}
-	if personalityID != nil {
-		create = create.SetPersonalityID(*personalityID)
-	}
+	if err == nil { return existing, nil }
+	if !ent.IsNotFound(err) { return nil, err }
+	create := tx.CheckpointSnapshot.Create().SetUserID(userID).SetKind(kind).SetContent(content).SetContentHash(hash)
+	if chatID != nil { create = create.SetChatID(*chatID) }
+	if personalityID != nil { create = create.SetPersonalityID(*personalityID) }
 	return create.Save(ctx)
 }
 
-// CreateCompactionEvent records the start of a compaction: old summary, old/new scratchpad, loaded
-// memories and metadata. The new summary is unknown at this point and is attached later via
-// SetCompactionEventNewSummary. Returns the event so its ID can be threaded into the merge events.
 func (d *Datastore) CreateCompactionEvent(ctx context.Context, userID uuid.UUID, input models.CompactionEventInput) (*models.CompactionEvent, error) {
 	tx, err := d.dbClient.Tx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if v := recover(); v != nil {
-			_ = tx.Rollback()
-			panic(v)
-		}
-	}()
-
+	if err != nil { return nil, err }
+	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
 	chatID := input.ChatID
-
 	oldSummary, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindSummary, &chatID, nil, input.OldSummary)
-	if err != nil {
-		_ = tx.Rollback()
-		return nil, err
-	}
-
-	create := tx.CompactionEvent.Create().
-		SetUserID(userID).
-		SetChatID(chatID).
-		SetNillablePersonalityID(input.PersonalityID).
-		SetNillableAssistantMessageID(input.AssistantMessageID).
-		SetProvider(input.Provider).
-		SetReason(input.Reason).
-		SetOldSummaryID(oldSummary.ID).
-		SetLoadedMemories(toEntLoadedMemories(input.LoadedMemories))
-
-	// Scratchpad snapshots only exist when the checkpoint had a personality to update.
+	if err != nil { _ = tx.Rollback(); return nil, err }
+	create := tx.CompactionEvent.Create().SetUserID(userID).SetChatID(chatID).SetNillablePersonalityID(input.PersonalityID).SetNillableAssistantMessageID(input.AssistantMessageID).SetProvider(input.Provider).SetReason(input.Reason).SetOldSummaryID(oldSummary.ID).SetLoadedMemories(toEntLoadedMemories(input.LoadedMemories))
+	if input.ScratchpadExplanation != "" { create = create.SetScratchpadExplanation(input.ScratchpadExplanation) }
 	if input.HasScratchpad && input.PersonalityID != nil {
 		oldScratch, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindScratchpad, nil, input.PersonalityID, input.OldScratchpad)
-		if err != nil {
-			_ = tx.Rollback()
-			return nil, err
-		}
+		if err != nil { _ = tx.Rollback(); return nil, err }
 		newScratch, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindScratchpad, nil, input.PersonalityID, input.NewScratchpad)
-		if err != nil {
-			_ = tx.Rollback()
-			return nil, err
-		}
+		if err != nil { _ = tx.Rollback(); return nil, err }
 		create = create.SetOldScratchpadID(oldScratch.ID).SetNewScratchpadID(newScratch.ID)
 	}
-
 	event, err := create.Save(ctx)
-	if err != nil {
-		_ = tx.Rollback()
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	full, err := d.loadCompactionEvent(ctx, userID, event.ID)
-	if err != nil {
-		return nil, err
-	}
-	return full, nil
+	if err != nil { _ = tx.Rollback(); return nil, err }
+	if err := tx.Commit(); err != nil { return nil, err }
+	return d.loadCompactionEvent(ctx, userID, event.ID)
 }
 
-// AppendCompactionEventCreatedMemories appends newly created memory snapshots onto a compaction
-// audit record. Empty inputs are no-ops. Missing/pruned compaction events are best-effort: the
-// helper returns nil so memory persistence is never blocked by audit attach.
 func (d *Datastore) AppendCompactionEventCreatedMemories(ctx context.Context, userID, eventID uuid.UUID, memories []models.CompactionLoadedMemory) error {
-	if len(memories) == 0 {
-		return nil
-	}
+	if len(memories) == 0 { return nil }
 	tx, err := d.dbClient.Tx(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if v := recover(); v != nil {
-			_ = tx.Rollback()
-			panic(v)
-		}
-	}()
+	if err != nil { return err }
+	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
 	if err := d.appendCompactionEventCreatedMemoriesTx(ctx, tx, userID, eventID, memories); err != nil {
 		_ = tx.Rollback()
-		if errors.Is(err, ErrCompactionEventNotFound) {
-			return nil
-		}
+		if errors.Is(err, ErrCompactionEventNotFound) { return nil }
 		return err
 	}
 	return tx.Commit()
 }
 
-// appendCompactionEventCreatedMemoriesTx uses Ent's sqljson.Append so concurrent writers for the
-// same compaction event do not clobber each other via read-modify-write.
 func (d *Datastore) appendCompactionEventCreatedMemoriesTx(ctx context.Context, tx *ent.Tx, userID, eventID uuid.UUID, memories []models.CompactionLoadedMemory) error {
-	if len(memories) == 0 {
-		return nil
-	}
-	n, err := tx.CompactionEvent.Update().
-		Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).
-		AppendCreatedMemories(toEntLoadedMemories(memories)).
-		Save(ctx)
-	if err != nil {
-		return err
-	}
-	if n == 0 {
-		return ErrCompactionEventNotFound
-	}
+	if len(memories) == 0 { return nil }
+	n, err := tx.CompactionEvent.Update().Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).AppendCreatedMemories(toEntLoadedMemories(memories)).Save(ctx)
+	if err != nil { return err }
+	if n == 0 { return ErrCompactionEventNotFound }
 	return nil
 }
 
-// SetCompactionEventNewSummary attaches the post-checkpoint summary snapshot to an existing event.
-func (d *Datastore) SetCompactionEventNewSummary(ctx context.Context, userID, eventID uuid.UUID, newSummary string) error {
+// SetCompactionEventNewSummary attaches the post-checkpoint summary snapshot and its transition explanation.
+func (d *Datastore) SetCompactionEventNewSummary(ctx context.Context, userID, eventID uuid.UUID, newSummary, explanation string) error {
 	tx, err := d.dbClient.Tx(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if v := recover(); v != nil {
-			_ = tx.Rollback()
-			panic(v)
-		}
-	}()
-
-	event, err := tx.CompactionEvent.Query().
-		Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).
-		Only(ctx)
+	if err != nil { return err }
+	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
+	event, err := tx.CompactionEvent.Query().Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).Only(ctx)
 	if err != nil {
 		_ = tx.Rollback()
-		if ent.IsNotFound(err) {
-			return ErrCompactionEventNotFound
-		}
+		if ent.IsNotFound(err) { return ErrCompactionEventNotFound }
 		return err
 	}
-
 	snap, err := d.getOrCreateCheckpointSnapshotTx(ctx, tx, userID, entsnap.KindSummary, &event.ChatID, nil, newSummary)
-	if err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	if _, err := tx.CompactionEvent.UpdateOneID(event.ID).SetNewSummaryID(snap.ID).Save(ctx); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
+	if err != nil { _ = tx.Rollback(); return err }
+	update := tx.CompactionEvent.UpdateOneID(event.ID).SetNewSummaryID(snap.ID)
+	if explanation != "" { update = update.SetSummaryExplanation(explanation) }
+	if _, err := update.Save(ctx); err != nil { _ = tx.Rollback(); return err }
 	return tx.Commit()
 }
 
 func (d *Datastore) loadCompactionEvent(ctx context.Context, userID, eventID uuid.UUID) (*models.CompactionEvent, error) {
-	row, err := d.dbClient.CompactionEvent.Query().
-		Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).
-		WithOldSummary().
-		WithNewSummary().
-		WithOldScratchpad().
-		WithNewScratchpad().
-		WithMergeEvents(func(q *ent.MemoryMergeEventQuery) {
-			q.Order(ent.Asc(entmerge.FieldCreatedAt))
-		}).
-		Only(ctx)
+	row, err := d.dbClient.CompactionEvent.Query().Where(entcompaction.ID(eventID), entcompaction.UserID(userID)).WithOldSummary().WithNewSummary().WithOldScratchpad().WithNewScratchpad().WithMergeEvents(func(q *ent.MemoryMergeEventQuery) { q.Order(ent.Asc(entmerge.FieldCreatedAt)) }).Only(ctx)
 	if err != nil {
-		if ent.IsNotFound(err) {
-			return nil, ErrCompactionEventNotFound
-		}
+		if ent.IsNotFound(err) { return nil, ErrCompactionEventNotFound }
 		return nil, err
 	}
 	event := toCompactionEventModel(row)
@@ -257,263 +121,77 @@ func (d *Datastore) loadCompactionEvent(ctx context.Context, userID, eventID uui
 	return event, nil
 }
 
-// GetCompactionEvent returns one compaction event with all snapshots and merge events resolved.
-func (d *Datastore) GetCompactionEvent(ctx context.Context, userID, eventID uuid.UUID) (*models.CompactionEvent, error) {
-	return d.loadCompactionEvent(ctx, userID, eventID)
-}
+func (d *Datastore) GetCompactionEvent(ctx context.Context, userID, eventID uuid.UUID) (*models.CompactionEvent, error) { return d.loadCompactionEvent(ctx, userID, eventID) }
 
-// ListCompactionEvents returns paginated compaction events (newest first) with snapshots and merge
-// events resolved.
 func (d *Datastore) ListCompactionEvents(ctx context.Context, userID uuid.UUID, pageNum, pageSize int, chatID, personalityID *uuid.UUID) (*models.PaginatedResponse, error) {
-	if pageNum < 1 {
-		pageNum = 1
-	}
-	if pageSize < 1 {
-		pageSize = 20
-	}
-	if pageSize > maxCompactionEventsPageSize {
-		pageSize = maxCompactionEventsPageSize
-	}
-
+	if pageNum < 1 { pageNum = 1 }
+	if pageSize < 1 { pageSize = 20 }
+	if pageSize > maxCompactionEventsPageSize { pageSize = maxCompactionEventsPageSize }
 	query := d.dbClient.CompactionEvent.Query().Where(entcompaction.UserID(userID))
-	if chatID != nil {
-		query = query.Where(entcompaction.ChatID(*chatID))
-	}
-	if personalityID != nil {
-		query = query.Where(entcompaction.PersonalityID(*personalityID))
-	}
+	if chatID != nil { query = query.Where(entcompaction.ChatID(*chatID)) }
+	if personalityID != nil { query = query.Where(entcompaction.PersonalityID(*personalityID)) }
 	totalCount, err := query.Clone().Count(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	rows, err := query.
-		Order(ent.Desc(entcompaction.FieldCreatedAt)).
-		Offset((pageNum - 1) * pageSize).
-		Limit(pageSize).
-		WithOldSummary().
-		WithNewSummary().
-		WithOldScratchpad().
-		WithNewScratchpad().
-		WithMergeEvents(func(q *ent.MemoryMergeEventQuery) {
-			q.Order(ent.Asc(entmerge.FieldCreatedAt))
-		}).
-		All(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+	if err != nil { return nil, err }
+	rows, err := query.Order(ent.Desc(entcompaction.FieldCreatedAt)).Offset((pageNum - 1) * pageSize).Limit(pageSize).WithOldSummary().WithNewSummary().WithOldScratchpad().WithNewScratchpad().WithMergeEvents(func(q *ent.MemoryMergeEventQuery) { q.Order(ent.Asc(entmerge.FieldCreatedAt)) }).All(ctx)
+	if err != nil { return nil, err }
 	events := make([]*models.CompactionEvent, len(rows))
-	for i, row := range rows {
-		events[i] = toCompactionEventModel(row)
-	}
+	for i, row := range rows { events[i] = toCompactionEventModel(row) }
 	d.populateCompactionEventChatNames(ctx, userID, events)
-
 	results := make([]any, len(events))
-	for i, event := range events {
-		results[i] = event
-	}
-	return &models.PaginatedResponse{
-		Results:    results,
-		TotalCount: totalCount,
-		Page:       pageNum,
-	}, nil
+	for i, event := range events { results[i] = event }
+	return &models.PaginatedResponse{Results: results, TotalCount: totalCount, Page: pageNum}, nil
 }
 
-// populateCompactionEventChatNames best-effort enriches audit events with their current chat names.
-// The event audit record remains useful when a chat has been deleted or this optional lookup fails.
 func (d *Datastore) populateCompactionEventChatNames(ctx context.Context, userID uuid.UUID, events []*models.CompactionEvent) {
-	chatIDs := make([]uuid.UUID, 0, len(events))
-	seen := make(map[uuid.UUID]struct{}, len(events))
-	for _, event := range events {
-		if event == nil {
-			continue
-		}
-		if _, ok := seen[event.ChatID]; ok {
-			continue
-		}
-		seen[event.ChatID] = struct{}{}
-		chatIDs = append(chatIDs, event.ChatID)
-	}
-	if len(chatIDs) == 0 {
-		return
-	}
-
-	chats, err := d.dbClient.Chat.Query().
-		Where(entchat.IDIn(chatIDs...), entchat.HasOwnerWith(user.ID(userID))).
-		Select(entchat.FieldID, entchat.FieldName).
-		All(ctx)
-	if err != nil {
-		d.logger.Warn("failed to load chat names for compaction events",
-			zap.String("user_id", userID.String()),
-			zap.Error(err))
-		return
-	}
-	names := make(map[uuid.UUID]string, len(chats))
-	for _, chat := range chats {
-		names[chat.ID] = chat.Name
-	}
-	for _, event := range events {
-		if event != nil {
-			event.ChatName = names[event.ChatID]
-		}
-	}
+	chatIDs := make([]uuid.UUID, 0, len(events)); seen := make(map[uuid.UUID]struct{}, len(events))
+	for _, event := range events { if event == nil { continue }; if _, ok := seen[event.ChatID]; ok { continue }; seen[event.ChatID] = struct{}{}; chatIDs = append(chatIDs, event.ChatID) }
+	if len(chatIDs) == 0 { return }
+	chats, err := d.dbClient.Chat.Query().Where(entchat.IDIn(chatIDs...), entchat.HasOwnerWith(user.ID(userID))).Select(entchat.FieldID, entchat.FieldName).All(ctx)
+	if err != nil { d.logger.Warn("failed to load chat names for compaction events", zap.String("user_id", userID.String()), zap.Error(err)); return }
+	names := make(map[uuid.UUID]string, len(chats)); for _, chat := range chats { names[chat.ID] = chat.Name }
+	for _, event := range events { if event != nil { event.ChatName = names[event.ChatID] } }
 }
 
-// RevertCheckpointSnapshot restores a snapshot's content to the live summary or scratchpad it came
-// from. Summary snapshots restore Chat.checkpoint_summary; scratchpad snapshots restore
-// Personality.scratchpad (which is shared across that personality's chats). Snapshot rows are never
-// mutated or deleted — reverting only rewrites the live value.
 func (d *Datastore) RevertCheckpointSnapshot(ctx context.Context, userID, snapshotID uuid.UUID) (*models.CheckpointSnapshot, error) {
-	tx, err := d.dbClient.Tx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if v := recover(); v != nil {
-			_ = tx.Rollback()
-			panic(v)
-		}
-	}()
-
-	snap, err := tx.CheckpointSnapshot.Query().
-		Where(entsnap.ID(snapshotID), entsnap.UserID(userID)).
-		Only(ctx)
-	if err != nil {
-		_ = tx.Rollback()
-		if ent.IsNotFound(err) {
-			return nil, ErrCheckpointSnapshotNotFound
-		}
-		return nil, err
-	}
-
+	tx, err := d.dbClient.Tx(ctx); if err != nil { return nil, err }
+	defer func() { if v := recover(); v != nil { _ = tx.Rollback(); panic(v) } }()
+	snap, err := tx.CheckpointSnapshot.Query().Where(entsnap.ID(snapshotID), entsnap.UserID(userID)).Only(ctx)
+	if err != nil { _ = tx.Rollback(); if ent.IsNotFound(err) { return nil, ErrCheckpointSnapshotNotFound }; return nil, err }
 	switch snap.Kind {
 	case entsnap.KindSummary:
-		if snap.ChatID == nil {
-			_ = tx.Rollback()
-			return nil, ErrCheckpointSnapshotOwnerMissing
-		}
-		updated, err := tx.Chat.Update().
-			Where(entchat.ID(*snap.ChatID), entchat.HasOwnerWith(user.ID(userID))).
-			SetCheckpointSummary(snap.Content).
-			Save(ctx)
-		if err != nil {
-			_ = tx.Rollback()
-			return nil, err
-		}
-		if updated == 0 {
-			_ = tx.Rollback()
-			return nil, ErrChatNotFound
-		}
+		if snap.ChatID == nil { _ = tx.Rollback(); return nil, ErrCheckpointSnapshotOwnerMissing }
+		updated, err := tx.Chat.Update().Where(entchat.ID(*snap.ChatID), entchat.HasOwnerWith(user.ID(userID))).SetCheckpointSummary(snap.Content).Save(ctx)
+		if err != nil { _ = tx.Rollback(); return nil, err }; if updated == 0 { _ = tx.Rollback(); return nil, ErrChatNotFound }
 	case entsnap.KindScratchpad:
-		if snap.PersonalityID == nil {
-			_ = tx.Rollback()
-			return nil, ErrCheckpointSnapshotOwnerMissing
-		}
-		updated, err := tx.Personality.Update().
-			Where(entpersonality.ID(*snap.PersonalityID), entpersonality.HasUserWith(user.ID(userID))).
-			SetScratchpad(snap.Content).
-			Save(ctx)
-		if err != nil {
-			_ = tx.Rollback()
-			return nil, err
-		}
-		if updated == 0 {
-			_ = tx.Rollback()
-			return nil, ErrPersonalityNotFound
-		}
+		if snap.PersonalityID == nil { _ = tx.Rollback(); return nil, ErrCheckpointSnapshotOwnerMissing }
+		updated, err := tx.Personality.Update().Where(entpersonality.ID(*snap.PersonalityID), entpersonality.HasUserWith(user.ID(userID))).SetScratchpad(snap.Content).Save(ctx)
+		if err != nil { _ = tx.Rollback(); return nil, err }; if updated == 0 { _ = tx.Rollback(); return nil, ErrPersonalityNotFound }
 	default:
-		_ = tx.Rollback()
-		return nil, fmt.Errorf("unsupported snapshot kind: %s", snap.Kind)
+		_ = tx.Rollback(); return nil, fmt.Errorf("unsupported snapshot kind: %s", snap.Kind)
 	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
+	if err := tx.Commit(); err != nil { return nil, err }
 	return toCheckpointSnapshotModel(snap), nil
 }
 
 func toEntLoadedMemories(memories []models.CompactionLoadedMemory) []entschema.CompactionLoadedMemory {
-	if len(memories) == 0 {
-		return nil
-	}
-	out := make([]entschema.CompactionLoadedMemory, len(memories))
-	for i, m := range memories {
-		out[i] = entschema.CompactionLoadedMemory{
-			MemoryID:   m.MemoryID,
-			Content:    m.Content,
-			Scope:      m.Scope,
-			Confidence: m.Confidence,
-		}
-	}
-	return out
+	if len(memories) == 0 { return nil }
+	out := make([]entschema.CompactionLoadedMemory, len(memories)); for i, m := range memories { out[i] = entschema.CompactionLoadedMemory{MemoryID: m.MemoryID, Content: m.Content, Scope: m.Scope, Confidence: m.Confidence} }; return out
 }
-
 func loadedMemoriesToModel(memories []entschema.CompactionLoadedMemory) []models.CompactionLoadedMemory {
-	if len(memories) == 0 {
-		return nil
-	}
-	out := make([]models.CompactionLoadedMemory, len(memories))
-	for i, m := range memories {
-		out[i] = models.CompactionLoadedMemory{
-			MemoryID:   m.MemoryID,
-			Content:    m.Content,
-			Scope:      m.Scope,
-			Confidence: m.Confidence,
-		}
-	}
-	return out
+	if len(memories) == 0 { return nil }
+	out := make([]models.CompactionLoadedMemory, len(memories)); for i, m := range memories { out[i] = models.CompactionLoadedMemory{MemoryID: m.MemoryID, Content: m.Content, Scope: m.Scope, Confidence: m.Confidence} }; return out
 }
-
 func toCheckpointSnapshotModel(row *ent.CheckpointSnapshot) *models.CheckpointSnapshot {
-	if row == nil {
-		return nil
-	}
-	return &models.CheckpointSnapshot{
-		ID:            row.ID,
-		Kind:          models.CheckpointSnapshotKind(row.Kind),
-		ChatID:        row.ChatID,
-		PersonalityID: row.PersonalityID,
-		Content:       row.Content,
-		CreatedAt:     row.CreatedAt,
-	}
+	if row == nil { return nil }
+	return &models.CheckpointSnapshot{ID: row.ID, Kind: models.CheckpointSnapshotKind(row.Kind), ChatID: row.ChatID, PersonalityID: row.PersonalityID, Content: row.Content, CreatedAt: row.CreatedAt}
 }
-
 func toCompactionEventModel(row *ent.CompactionEvent) *models.CompactionEvent {
-	if row == nil {
-		return nil
-	}
-	event := &models.CompactionEvent{
-		ID:                 row.ID,
-		ChatID:             row.ChatID,
-		PersonalityID:      row.PersonalityID,
-		AssistantMessageID: row.AssistantMessageID,
-		Provider:           row.Provider,
-		Reason:             row.Reason,
-		LoadedMemories:     loadedMemoriesToModel(row.LoadedMemories),
-		CreatedMemories:    loadedMemoriesToModel(row.CreatedMemories),
-		CreatedAt:          row.CreatedAt,
-		UpdatedAt:          row.UpdatedAt,
-	}
-	if row.Edges.OldSummary != nil {
-		event.OldSummary = toCheckpointSnapshotModel(row.Edges.OldSummary)
-	}
-	if row.Edges.NewSummary != nil {
-		event.NewSummary = toCheckpointSnapshotModel(row.Edges.NewSummary)
-	}
-	if row.Edges.OldScratchpad != nil {
-		event.OldScratchpad = toCheckpointSnapshotModel(row.Edges.OldScratchpad)
-	}
-	if row.Edges.NewScratchpad != nil {
-		event.NewScratchpad = toCheckpointSnapshotModel(row.Edges.NewScratchpad)
-	}
-	if len(row.Edges.MergeEvents) > 0 {
-		event.MergeEvents = make([]models.MemoryMergeEvent, 0, len(row.Edges.MergeEvents))
-		for _, me := range row.Edges.MergeEvents {
-			if m := toMemoryMergeEventModel(me); m != nil {
-				event.MergeEvents = append(event.MergeEvents, *m)
-			}
-		}
-	}
+	if row == nil { return nil }
+	event := &models.CompactionEvent{ID: row.ID, ChatID: row.ChatID, PersonalityID: row.PersonalityID, AssistantMessageID: row.AssistantMessageID, Provider: row.Provider, Reason: row.Reason, SummaryExplanation: row.SummaryExplanation, ScratchpadExplanation: row.ScratchpadExplanation, LoadedMemories: loadedMemoriesToModel(row.LoadedMemories), CreatedMemories: loadedMemoriesToModel(row.CreatedMemories), CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt}
+	if row.Edges.OldSummary != nil { event.OldSummary = toCheckpointSnapshotModel(row.Edges.OldSummary) }
+	if row.Edges.NewSummary != nil { event.NewSummary = toCheckpointSnapshotModel(row.Edges.NewSummary) }
+	if row.Edges.OldScratchpad != nil { event.OldScratchpad = toCheckpointSnapshotModel(row.Edges.OldScratchpad) }
+	if row.Edges.NewScratchpad != nil { event.NewScratchpad = toCheckpointSnapshotModel(row.Edges.NewScratchpad) }
+	if len(row.Edges.MergeEvents) > 0 { event.MergeEvents = make([]models.MemoryMergeEvent, 0, len(row.Edges.MergeEvents)); for _, me := range row.Edges.MergeEvents { if m := toMemoryMergeEventModel(me); m != nil { event.MergeEvents = append(event.MergeEvents, *m) } } }
 	return event
 }

--- a/internal/datastore/compaction_event_test.go
+++ b/internal/datastore/compaction_event_test.go
@@ -14,8 +14,6 @@ import (
 
 func newCompactionEventTestDatastore(t *testing.T) (*Datastore, func()) {
 	t.Helper()
-	// Parent (compaction_events) before child (memory_merge_events) so the FK + ON DELETE SET NULL
-	// in createMemoryMergeEventTestSchema can be applied — mirrors production ent schema order.
 	return newTestDatastore(t, createMemoryImportTestSchema, createCompactionEventTestSchema, createMemoryMergeEventTestSchema)
 }
 
@@ -43,6 +41,8 @@ func createCompactionEventTestSchema(t *testing.T, db *sql.DB) {
 			assistant_message_id uuid,
 			provider text,
 			reason text,
+			summary_explanation text,
+			scratchpad_explanation text,
 			loaded_memories json,
 			created_memories json,
 			old_summary_id uuid,
@@ -60,229 +60,51 @@ func createCompactionEventTestSchema(t *testing.T, db *sql.DB) {
 func insertCompactionTestPersonality(t *testing.T, ds *Datastore, userID, personalityID uuid.UUID, scratchpad string) {
 	t.Helper()
 	now := time.Now().UTC()
-	_, err := ds.dbClient.Personality.Create().
-		SetID(personalityID).
-		SetName("p-" + personalityID.String()[:8]).
-		SetSystemPrompt("system").
-		SetScratchpad(scratchpad).
-		SetUserID(userID).
-		SetCreatedAt(now).
-		SetUpdatedAt(now).
-		Save(context.Background())
+	_, err := ds.dbClient.Personality.Create().SetID(personalityID).SetName("p-" + personalityID.String()[:8]).SetSystemPrompt("system").SetScratchpad(scratchpad).SetUserID(userID).SetCreatedAt(now).SetUpdatedAt(now).Save(context.Background())
 	require.NoError(t, err)
 }
 
-// TestCompactionEventContentAddressing pins the core dedup guarantee: the snapshot a compaction
-// records as its "new" state is the SAME row the next compaction records as its "old" state, so the
-// old/new pair never duplicates identical text.
 func TestCompactionEventContentAddressing(t *testing.T) {
 	ds, cleanup := newCompactionEventTestDatastore(t)
 	defer cleanup()
-
 	ctx := context.Background()
-	userID := uuid.New()
-	chatID := uuid.New()
-	personalityID := uuid.New()
-	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
-	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-	insertCompactionTestPersonality(t, ds, userID, personalityID, "scratch v1")
-
-	// Compaction 1: summary "" -> (new set later), scratchpad "scratch v0" -> "scratch v1".
-	ev1, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
-		ChatID:        chatID,
-		PersonalityID: &personalityID,
-		Provider:      "Claude",
-		Reason:        "token_budget",
-		OldSummary:    "",
-		OldScratchpad: "scratch v0",
-		NewScratchpad: "scratch v1",
-		HasScratchpad: true,
-	})
+	userID := uuid.New(); chatID := uuid.New(); personalityID := uuid.New()
+	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID)); insertCompactionTestPersonality(t, ds, userID, personalityID, "scratch v1")
+	ev1, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, PersonalityID: &personalityID, Provider: "Claude", Reason: "token_budget", OldSummary: "", OldScratchpad: "scratch v0", NewScratchpad: "scratch v1", ScratchpadExplanation: "Added the latest working preference.", HasScratchpad: true})
+	require.NoError(t, err); require.NotNil(t, ev1.OldSummary); require.NotNil(t, ev1.OldScratchpad); require.NotNil(t, ev1.NewScratchpad); require.Equal(t, "scratch v1", ev1.NewScratchpad.Content); require.Equal(t, "Added the latest working preference.", ev1.ScratchpadExplanation); require.Equal(t, "chat", ev1.ChatName)
+	require.NoError(t, ds.SetCompactionEventNewSummary(ctx, userID, ev1.ID, "summary A", "Captured the current project state."))
+	ev2, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, PersonalityID: &personalityID, Provider: "Claude", OldSummary: "summary A", OldScratchpad: "scratch v1", NewScratchpad: "scratch v2", HasScratchpad: true})
 	require.NoError(t, err)
-	require.NotNil(t, ev1.OldSummary)
-	require.NotNil(t, ev1.OldScratchpad)
-	require.NotNil(t, ev1.NewScratchpad)
-	require.Equal(t, "scratch v1", ev1.NewScratchpad.Content)
-	require.Equal(t, "chat", ev1.ChatName)
-	require.NoError(t, ds.SetCompactionEventNewSummary(ctx, userID, ev1.ID, "summary A"))
-
-	// Compaction 2: old summary is now "summary A" (== ev1 new summary); old scratchpad is
-	// "scratch v1" (== ev1 new scratchpad). Both must reuse ev1's snapshot rows.
-	ev2, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
-		ChatID:        chatID,
-		PersonalityID: &personalityID,
-		Provider:      "Claude",
-		OldSummary:    "summary A",
-		OldScratchpad: "scratch v1",
-		NewScratchpad: "scratch v2",
-		HasScratchpad: true,
-	})
-	require.NoError(t, err)
-
-	// ev1's new summary row is reused as ev2's old summary row.
-	ev1Reloaded, err := ds.GetCompactionEvent(ctx, userID, ev1.ID)
-	require.NoError(t, err)
-	require.NotNil(t, ev1Reloaded.NewSummary)
-	require.Equal(t, "chat", ev1Reloaded.ChatName)
-	require.Equal(t, ev1Reloaded.NewSummary.ID, ev2.OldSummary.ID, "new summary of ev1 is old summary of ev2")
-	require.Equal(t, ev1.NewScratchpad.ID, ev2.OldScratchpad.ID, "new scratchpad of ev1 is old scratchpad of ev2")
-
-	// Distinct summary states created: "" , "summary A", (scratchpads) "scratch v0","v1","v2".
-	summaryCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindSummary)).Count(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 2, summaryCount, `only "" and "summary A" exist; the shared row is not duplicated`)
-
-	scratchCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindScratchpad)).Count(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 3, scratchCount, "scratch v0, v1, v2 — v1 shared between the two events, not duplicated")
+	ev1Reloaded, err := ds.GetCompactionEvent(ctx, userID, ev1.ID); require.NoError(t, err); require.NotNil(t, ev1Reloaded.NewSummary); require.Equal(t, "Captured the current project state.", ev1Reloaded.SummaryExplanation); require.Equal(t, "chat", ev1Reloaded.ChatName); require.Equal(t, ev1Reloaded.NewSummary.ID, ev2.OldSummary.ID); require.Equal(t, ev1.NewScratchpad.ID, ev2.OldScratchpad.ID)
+	summaryCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindSummary)).Count(ctx); require.NoError(t, err); require.Equal(t, 2, summaryCount)
+	scratchCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindScratchpad)).Count(ctx); require.NoError(t, err); require.Equal(t, 3, scratchCount)
 }
 
 func TestListCompactionEventsCapsPageSize(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	userID := uuid.New()
-	chatID := uuid.New()
-	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
-	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-
-	for range maxCompactionEventsPageSize + 1 {
-		_, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
-			ChatID:     chatID,
-			Provider:   "OpenAI",
-			OldSummary: "before",
-		})
-		require.NoError(t, err)
-	}
-
-	events, err := ds.ListCompactionEvents(ctx, userID, 1, maxCompactionEventsPageSize+1, nil, nil)
-	require.NoError(t, err)
-	require.Len(t, events.Results, maxCompactionEventsPageSize)
-	require.Equal(t, maxCompactionEventsPageSize+1, events.TotalCount)
+	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+	for range maxCompactionEventsPageSize + 1 { _, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, Provider: "OpenAI", OldSummary: "before"}); require.NoError(t, err) }
+	events, err := ds.ListCompactionEvents(ctx, userID, 1, maxCompactionEventsPageSize+1, nil, nil); require.NoError(t, err); require.Len(t, events.Results, maxCompactionEventsPageSize); require.Equal(t, maxCompactionEventsPageSize+1, events.TotalCount)
 }
 
-// TestCompactionEventRecordsCreatedMemories verifies a new-only persist under a compaction attaches
-// the row to created_memories and does NOT emit a create-type merge event.
 func TestCompactionEventRecordsCreatedMemories(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	userID := uuid.New()
-	chatID := uuid.New()
-	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
-	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-
-	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
-		ChatID:     chatID,
-		Provider:   "OpenAI",
-		OldSummary: "before",
-	})
-	require.NoError(t, err)
-
-	mem, err := ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{
-		MemberIndices:    []int{0},
-		Relation:         models.MemoryMergeRelationMerge,
-		CanonicalContent: "User prefers dark mode",
-		Scope:            "User",
-		Confidence:       models.MemoryConfidenceMedium,
-	}, 1, nil, nil, testEmbeddingVector(), uuid.Nil, nil, &ev.ID)
-	require.NoError(t, err)
-	require.NotNil(t, mem)
-
-	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID)
-	require.NoError(t, err)
-	require.Empty(t, loaded.MergeEvents, "new-only creates are not merge events")
-	require.Len(t, loaded.CreatedMemories, 1)
-	require.Equal(t, "User prefers dark mode", loaded.CreatedMemories[0].Content)
-	require.NotNil(t, loaded.CreatedMemories[0].MemoryID)
-	require.Equal(t, mem.ID, *loaded.CreatedMemories[0].MemoryID)
+	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, Provider: "OpenAI", OldSummary: "before"}); require.NoError(t, err)
+	mem, err := ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{MemberIndices: []int{0}, Relation: models.MemoryMergeRelationMerge, CanonicalContent: "User prefers dark mode", Scope: "User", Confidence: models.MemoryConfidenceMedium}, 1, nil, nil, testEmbeddingVector(), uuid.Nil, nil, &ev.ID); require.NoError(t, err); require.NotNil(t, mem)
+	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID); require.NoError(t, err); require.Empty(t, loaded.MergeEvents); require.Len(t, loaded.CreatedMemories, 1); require.Equal(t, "User prefers dark mode", loaded.CreatedMemories[0].Content); require.NotNil(t, loaded.CreatedMemories[0].MemoryID); require.Equal(t, mem.ID, *loaded.CreatedMemories[0].MemoryID)
 }
 
-// TestCompactionEventDeleteNullsMergeEventFK pins ON DELETE SET NULL: pruning a compaction event
-// must leave merge history intact with compaction_event_id cleared (ent CompactionEvent.merge_events).
 func TestCompactionEventDeleteNullsMergeEventFK(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	userID := uuid.New()
-	chatID := uuid.New()
-	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
-	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-
-	survivor, err := ds.CreateMemory(ctx, userID, models.Memory{
-		ChatID:     chatID,
-		Content:    "User prefers dark mode",
-		Scope:      "User",
-		Confidence: 0.7,
-		Status:     models.MemoryStatusActive,
-	}, testEmbeddingVector(), uuid.Nil)
-	require.NoError(t, err)
-
-	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
-		ChatID:     chatID,
-		Provider:   "OpenAI",
-		OldSummary: "before",
-	})
-	require.NoError(t, err)
-
-	survivorID := survivor.ID
-	_, err = ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{
-		MemberIndices:    []int{0, 1},
-		Relation:         models.MemoryMergeRelationMerge,
-		CanonicalContent: "User prefers dark mode",
-		Scope:            "User",
-		Confidence:       models.MemoryConfidenceMedium,
-	}, 2, &survivorID, nil, nil, uuid.Nil, nil, &ev.ID)
-	require.NoError(t, err)
-
-	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID)
-	require.NoError(t, err)
-	require.Len(t, loaded.MergeEvents, 1)
-	require.Equal(t, models.MemoryMergeTypeFoldLive, loaded.MergeEvents[0].MergeType)
-	mergeEventID := loaded.MergeEvents[0].ID
-
-	require.NoError(t, ds.dbClient.CompactionEvent.DeleteOneID(ev.ID).Exec(ctx))
-
-	row, err := ds.dbClient.MemoryMergeEvent.Get(ctx, mergeEventID)
-	require.NoError(t, err, "merge event must survive compaction prune")
-	require.Nil(t, row.CompactionEventID, "FK must SET NULL on compaction delete")
+	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+	survivor, err := ds.CreateMemory(ctx, userID, models.Memory{ChatID: chatID, Content: "User prefers dark mode", Scope: "User", Confidence: 0.7, Status: models.MemoryStatusActive}, testEmbeddingVector(), uuid.Nil); require.NoError(t, err)
+	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, Provider: "OpenAI", OldSummary: "before"}); require.NoError(t, err)
+	survivorID := survivor.ID; _, err = ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{MemberIndices: []int{0, 1}, Relation: models.MemoryMergeRelationMerge, CanonicalContent: "User prefers dark mode", Scope: "User", Confidence: models.MemoryConfidenceMedium}, 2, &survivorID, nil, nil, uuid.Nil, nil, &ev.ID); require.NoError(t, err)
+	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID); require.NoError(t, err); require.Len(t, loaded.MergeEvents, 1); require.Equal(t, models.MemoryMergeTypeFoldLive, loaded.MergeEvents[0].MergeType); mergeEventID := loaded.MergeEvents[0].ID
+	require.NoError(t, ds.dbClient.CompactionEvent.DeleteOneID(ev.ID).Exec(ctx)); row, err := ds.dbClient.MemoryMergeEvent.Get(ctx, mergeEventID); require.NoError(t, err); require.Nil(t, row.CompactionEventID)
 }
 
-// TestRevertCheckpointSnapshotScratchpad checks that reverting a scratchpad snapshot rewrites the
-// personality's live scratchpad.
 func TestRevertCheckpointSnapshotScratchpad(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	userID := uuid.New()
-	chatID := uuid.New()
-	personalityID := uuid.New()
-	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
-	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-	insertCompactionTestPersonality(t, ds, userID, personalityID, "current scratch")
-
-	// Capture a known-good scratchpad state.
-	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
-		ChatID:        chatID,
-		PersonalityID: &personalityID,
-		OldSummary:    "",
-		OldScratchpad: "known good scratch",
-		NewScratchpad: "current scratch",
-		HasScratchpad: true,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, ev.OldScratchpad)
-
-	// The live scratchpad drifted; revert to the known-good snapshot.
-	reverted, err := ds.RevertCheckpointSnapshot(ctx, userID, ev.OldScratchpad.ID)
-	require.NoError(t, err)
-	require.Equal(t, models.CheckpointSnapshotKindScratchpad, reverted.Kind)
-
-	p, err := ds.dbClient.Personality.Get(ctx, personalityID)
-	require.NoError(t, err)
-	require.Equal(t, "known good scratch", p.Scratchpad, "scratchpad reverted to the snapshot content")
+	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); personalityID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID)); insertCompactionTestPersonality(t, ds, userID, personalityID, "current scratch")
+	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, PersonalityID: &personalityID, OldSummary: "", OldScratchpad: "known good scratch", NewScratchpad: "current scratch", HasScratchpad: true}); require.NoError(t, err); require.NotNil(t, ev.OldScratchpad)
+	reverted, err := ds.RevertCheckpointSnapshot(ctx, userID, ev.OldScratchpad.ID); require.NoError(t, err); require.Equal(t, models.CheckpointSnapshotKindScratchpad, reverted.Kind)
+	p, err := ds.dbClient.Personality.Get(ctx, personalityID); require.NoError(t, err); require.Equal(t, "known good scratch", p.Scratchpad)
 }

--- a/internal/datastore/compaction_event_test.go
+++ b/internal/datastore/compaction_event_test.go
@@ -14,6 +14,8 @@ import (
 
 func newCompactionEventTestDatastore(t *testing.T) (*Datastore, func()) {
 	t.Helper()
+	// Parent (compaction_events) before child (memory_merge_events) so the FK + ON DELETE SET NULL
+	// in createMemoryMergeEventTestSchema can be applied — mirrors production ent schema order.
 	return newTestDatastore(t, createMemoryImportTestSchema, createCompactionEventTestSchema, createMemoryMergeEventTestSchema)
 }
 
@@ -60,51 +62,232 @@ func createCompactionEventTestSchema(t *testing.T, db *sql.DB) {
 func insertCompactionTestPersonality(t *testing.T, ds *Datastore, userID, personalityID uuid.UUID, scratchpad string) {
 	t.Helper()
 	now := time.Now().UTC()
-	_, err := ds.dbClient.Personality.Create().SetID(personalityID).SetName("p-" + personalityID.String()[:8]).SetSystemPrompt("system").SetScratchpad(scratchpad).SetUserID(userID).SetCreatedAt(now).SetUpdatedAt(now).Save(context.Background())
+	_, err := ds.dbClient.Personality.Create().
+		SetID(personalityID).
+		SetName("p-" + personalityID.String()[:8]).
+		SetSystemPrompt("system").
+		SetScratchpad(scratchpad).
+		SetUserID(userID).
+		SetCreatedAt(now).
+		SetUpdatedAt(now).
+		Save(context.Background())
 	require.NoError(t, err)
 }
 
+// TestCompactionEventContentAddressing pins the core dedup guarantee: the snapshot a compaction
+// records as its "new" state is the SAME row the next compaction records as its "old" state, so the
+// old/new pair never duplicates identical text.
 func TestCompactionEventContentAddressing(t *testing.T) {
 	ds, cleanup := newCompactionEventTestDatastore(t)
 	defer cleanup()
+
 	ctx := context.Background()
-	userID := uuid.New(); chatID := uuid.New(); personalityID := uuid.New()
-	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID)); insertCompactionTestPersonality(t, ds, userID, personalityID, "scratch v1")
-	ev1, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, PersonalityID: &personalityID, Provider: "Claude", Reason: "token_budget", OldSummary: "", OldScratchpad: "scratch v0", NewScratchpad: "scratch v1", ScratchpadExplanation: "Added the latest working preference.", HasScratchpad: true})
-	require.NoError(t, err); require.NotNil(t, ev1.OldSummary); require.NotNil(t, ev1.OldScratchpad); require.NotNil(t, ev1.NewScratchpad); require.Equal(t, "scratch v1", ev1.NewScratchpad.Content); require.Equal(t, "Added the latest working preference.", ev1.ScratchpadExplanation); require.Equal(t, "chat", ev1.ChatName)
-	require.NoError(t, ds.SetCompactionEventNewSummary(ctx, userID, ev1.ID, "summary A", "Captured the current project state."))
-	ev2, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, PersonalityID: &personalityID, Provider: "Claude", OldSummary: "summary A", OldScratchpad: "scratch v1", NewScratchpad: "scratch v2", HasScratchpad: true})
+	userID := uuid.New()
+	chatID := uuid.New()
+	personalityID := uuid.New()
+	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
+	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+	insertCompactionTestPersonality(t, ds, userID, personalityID, "scratch v1")
+
+	// Compaction 1: summary "" -> (new set later), scratchpad "scratch v0" -> "scratch v1".
+	ev1, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
+		ChatID:                chatID,
+		PersonalityID:         &personalityID,
+		Provider:              "Claude",
+		Reason:                "token_budget",
+		OldSummary:            "",
+		OldScratchpad:         "scratch v0",
+		NewScratchpad:         "scratch v1",
+		ScratchpadExplanation: "Added the latest working preference.",
+		HasScratchpad:         true,
+	})
 	require.NoError(t, err)
-	ev1Reloaded, err := ds.GetCompactionEvent(ctx, userID, ev1.ID); require.NoError(t, err); require.NotNil(t, ev1Reloaded.NewSummary); require.Equal(t, "Captured the current project state.", ev1Reloaded.SummaryExplanation); require.Equal(t, "chat", ev1Reloaded.ChatName); require.Equal(t, ev1Reloaded.NewSummary.ID, ev2.OldSummary.ID); require.Equal(t, ev1.NewScratchpad.ID, ev2.OldScratchpad.ID)
-	summaryCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindSummary)).Count(ctx); require.NoError(t, err); require.Equal(t, 2, summaryCount)
-	scratchCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindScratchpad)).Count(ctx); require.NoError(t, err); require.Equal(t, 3, scratchCount)
+	require.NotNil(t, ev1.OldSummary)
+	require.NotNil(t, ev1.OldScratchpad)
+	require.NotNil(t, ev1.NewScratchpad)
+	require.Equal(t, "scratch v1", ev1.NewScratchpad.Content)
+	require.Equal(t, "Added the latest working preference.", ev1.ScratchpadExplanation)
+	require.Equal(t, "chat", ev1.ChatName)
+	require.NoError(t, ds.SetCompactionEventNewSummary(ctx, userID, ev1.ID, "summary A", "Captured the current project state."))
+
+	// Compaction 2: old summary is now "summary A" (== ev1 new summary); old scratchpad is
+	// "scratch v1" (== ev1 new scratchpad). Both must reuse ev1's snapshot rows.
+	ev2, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
+		ChatID:        chatID,
+		PersonalityID: &personalityID,
+		Provider:      "Claude",
+		OldSummary:    "summary A",
+		OldScratchpad: "scratch v1",
+		NewScratchpad: "scratch v2",
+		HasScratchpad: true,
+	})
+	require.NoError(t, err)
+
+	// ev1's new summary row is reused as ev2's old summary row.
+	ev1Reloaded, err := ds.GetCompactionEvent(ctx, userID, ev1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, ev1Reloaded.NewSummary)
+	require.Equal(t, "Captured the current project state.", ev1Reloaded.SummaryExplanation)
+	require.Equal(t, "chat", ev1Reloaded.ChatName)
+	require.Equal(t, ev1Reloaded.NewSummary.ID, ev2.OldSummary.ID, "new summary of ev1 is old summary of ev2")
+	require.Equal(t, ev1.NewScratchpad.ID, ev2.OldScratchpad.ID, "new scratchpad of ev1 is old scratchpad of ev2")
+
+	// Distinct summary states created: "" , "summary A", (scratchpads) "scratch v0","v1","v2".
+	summaryCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindSummary)).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, summaryCount, `only "" and "summary A" exist; the shared row is not duplicated`)
+
+	scratchCount, err := ds.dbClient.CheckpointSnapshot.Query().Where(entsnap.KindEQ(entsnap.KindScratchpad)).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 3, scratchCount, "scratch v0, v1, v2 — v1 shared between the two events, not duplicated")
 }
 
 func TestListCompactionEventsCapsPageSize(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-	for range maxCompactionEventsPageSize + 1 { _, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, Provider: "OpenAI", OldSummary: "before"}); require.NoError(t, err) }
-	events, err := ds.ListCompactionEvents(ctx, userID, 1, maxCompactionEventsPageSize+1, nil, nil); require.NoError(t, err); require.Len(t, events.Results, maxCompactionEventsPageSize); require.Equal(t, maxCompactionEventsPageSize+1, events.TotalCount)
+	ds, cleanup := newCompactionEventTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := uuid.New()
+	chatID := uuid.New()
+	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
+	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+
+	for range maxCompactionEventsPageSize + 1 {
+		_, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
+			ChatID:     chatID,
+			Provider:   "OpenAI",
+			OldSummary: "before",
+		})
+		require.NoError(t, err)
+	}
+
+	events, err := ds.ListCompactionEvents(ctx, userID, 1, maxCompactionEventsPageSize+1, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, events.Results, maxCompactionEventsPageSize)
+	require.Equal(t, maxCompactionEventsPageSize+1, events.TotalCount)
 }
 
+// TestCompactionEventRecordsCreatedMemories verifies a new-only persist under a compaction attaches
+// the row to created_memories and does NOT emit a create-type merge event.
 func TestCompactionEventRecordsCreatedMemories(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, Provider: "OpenAI", OldSummary: "before"}); require.NoError(t, err)
-	mem, err := ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{MemberIndices: []int{0}, Relation: models.MemoryMergeRelationMerge, CanonicalContent: "User prefers dark mode", Scope: "User", Confidence: models.MemoryConfidenceMedium}, 1, nil, nil, testEmbeddingVector(), uuid.Nil, nil, &ev.ID); require.NoError(t, err); require.NotNil(t, mem)
-	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID); require.NoError(t, err); require.Empty(t, loaded.MergeEvents); require.Len(t, loaded.CreatedMemories, 1); require.Equal(t, "User prefers dark mode", loaded.CreatedMemories[0].Content); require.NotNil(t, loaded.CreatedMemories[0].MemoryID); require.Equal(t, mem.ID, *loaded.CreatedMemories[0].MemoryID)
+	ds, cleanup := newCompactionEventTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := uuid.New()
+	chatID := uuid.New()
+	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
+	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+
+	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
+		ChatID:     chatID,
+		Provider:   "OpenAI",
+		OldSummary: "before",
+	})
+	require.NoError(t, err)
+
+	mem, err := ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{
+		MemberIndices:    []int{0},
+		Relation:         models.MemoryMergeRelationMerge,
+		CanonicalContent: "User prefers dark mode",
+		Scope:            "User",
+		Confidence:       models.MemoryConfidenceMedium,
+	}, 1, nil, nil, testEmbeddingVector(), uuid.Nil, nil, &ev.ID)
+	require.NoError(t, err)
+	require.NotNil(t, mem)
+
+	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID)
+	require.NoError(t, err)
+	require.Empty(t, loaded.MergeEvents, "new-only creates are not merge events")
+	require.Len(t, loaded.CreatedMemories, 1)
+	require.Equal(t, "User prefers dark mode", loaded.CreatedMemories[0].Content)
+	require.NotNil(t, loaded.CreatedMemories[0].MemoryID)
+	require.Equal(t, mem.ID, *loaded.CreatedMemories[0].MemoryID)
 }
 
+// TestCompactionEventDeleteNullsMergeEventFK pins ON DELETE SET NULL: pruning a compaction event
+// must leave merge history intact with compaction_event_id cleared (ent CompactionEvent.merge_events).
 func TestCompactionEventDeleteNullsMergeEventFK(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
-	survivor, err := ds.CreateMemory(ctx, userID, models.Memory{ChatID: chatID, Content: "User prefers dark mode", Scope: "User", Confidence: 0.7, Status: models.MemoryStatusActive}, testEmbeddingVector(), uuid.Nil); require.NoError(t, err)
-	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, Provider: "OpenAI", OldSummary: "before"}); require.NoError(t, err)
-	survivorID := survivor.ID; _, err = ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{MemberIndices: []int{0, 1}, Relation: models.MemoryMergeRelationMerge, CanonicalContent: "User prefers dark mode", Scope: "User", Confidence: models.MemoryConfidenceMedium}, 2, &survivorID, nil, nil, uuid.Nil, nil, &ev.ID); require.NoError(t, err)
-	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID); require.NoError(t, err); require.Len(t, loaded.MergeEvents, 1); require.Equal(t, models.MemoryMergeTypeFoldLive, loaded.MergeEvents[0].MergeType); mergeEventID := loaded.MergeEvents[0].ID
-	require.NoError(t, ds.dbClient.CompactionEvent.DeleteOneID(ev.ID).Exec(ctx)); row, err := ds.dbClient.MemoryMergeEvent.Get(ctx, mergeEventID); require.NoError(t, err); require.Nil(t, row.CompactionEventID)
+	ds, cleanup := newCompactionEventTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := uuid.New()
+	chatID := uuid.New()
+	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
+	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+
+	survivor, err := ds.CreateMemory(ctx, userID, models.Memory{
+		ChatID:     chatID,
+		Content:    "User prefers dark mode",
+		Scope:      "User",
+		Confidence: 0.7,
+		Status:     models.MemoryStatusActive,
+	}, testEmbeddingVector(), uuid.Nil)
+	require.NoError(t, err)
+
+	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
+		ChatID:     chatID,
+		Provider:   "OpenAI",
+		OldSummary: "before",
+	})
+	require.NoError(t, err)
+
+	survivorID := survivor.ID
+	_, err = ds.PersistMemoryMergeGroup(ctx, userID, chatID, models.MemoryMergeGroupProposal{
+		MemberIndices:    []int{0, 1},
+		Relation:         models.MemoryMergeRelationMerge,
+		CanonicalContent: "User prefers dark mode",
+		Scope:            "User",
+		Confidence:       models.MemoryConfidenceMedium,
+	}, 2, &survivorID, nil, nil, uuid.Nil, nil, &ev.ID)
+	require.NoError(t, err)
+
+	loaded, err := ds.GetCompactionEvent(ctx, userID, ev.ID)
+	require.NoError(t, err)
+	require.Len(t, loaded.MergeEvents, 1)
+	require.Equal(t, models.MemoryMergeTypeFoldLive, loaded.MergeEvents[0].MergeType)
+	mergeEventID := loaded.MergeEvents[0].ID
+
+	require.NoError(t, ds.dbClient.CompactionEvent.DeleteOneID(ev.ID).Exec(ctx))
+
+	row, err := ds.dbClient.MemoryMergeEvent.Get(ctx, mergeEventID)
+	require.NoError(t, err, "merge event must survive compaction prune")
+	require.Nil(t, row.CompactionEventID, "FK must SET NULL on compaction delete")
 }
 
+// TestRevertCheckpointSnapshotScratchpad checks that reverting a scratchpad snapshot rewrites the
+// personality's live scratchpad.
 func TestRevertCheckpointSnapshotScratchpad(t *testing.T) {
-	ds, cleanup := newCompactionEventTestDatastore(t); defer cleanup(); ctx := context.Background(); userID := uuid.New(); chatID := uuid.New(); personalityID := uuid.New(); require.NoError(t, insertMemoryMergeTestUser(t, ds, userID)); require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID)); insertCompactionTestPersonality(t, ds, userID, personalityID, "current scratch")
-	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{ChatID: chatID, PersonalityID: &personalityID, OldSummary: "", OldScratchpad: "known good scratch", NewScratchpad: "current scratch", HasScratchpad: true}); require.NoError(t, err); require.NotNil(t, ev.OldScratchpad)
-	reverted, err := ds.RevertCheckpointSnapshot(ctx, userID, ev.OldScratchpad.ID); require.NoError(t, err); require.Equal(t, models.CheckpointSnapshotKindScratchpad, reverted.Kind)
-	p, err := ds.dbClient.Personality.Get(ctx, personalityID); require.NoError(t, err); require.Equal(t, "known good scratch", p.Scratchpad)
+	ds, cleanup := newCompactionEventTestDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := uuid.New()
+	chatID := uuid.New()
+	personalityID := uuid.New()
+	require.NoError(t, insertMemoryMergeTestUser(t, ds, userID))
+	require.NoError(t, insertMemoryMergeTestChat(t, ds, userID, chatID))
+	insertCompactionTestPersonality(t, ds, userID, personalityID, "current scratch")
+
+	// Capture a known-good scratchpad state.
+	ev, err := ds.CreateCompactionEvent(ctx, userID, models.CompactionEventInput{
+		ChatID:        chatID,
+		PersonalityID: &personalityID,
+		OldSummary:    "",
+		OldScratchpad: "known good scratch",
+		NewScratchpad: "current scratch",
+		HasScratchpad: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ev.OldScratchpad)
+
+	// The live scratchpad drifted; revert to the known-good snapshot.
+	reverted, err := ds.RevertCheckpointSnapshot(ctx, userID, ev.OldScratchpad.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.CheckpointSnapshotKindScratchpad, reverted.Kind)
+
+	p, err := ds.dbClient.Personality.Get(ctx, personalityID)
+	require.NoError(t, err)
+	require.Equal(t, "known good scratch", p.Scratchpad, "scratchpad reverted to the snapshot content")
 }

--- a/internal/models/compaction_event.go
+++ b/internal/models/compaction_event.go
@@ -36,6 +36,8 @@ type CompactionLoadedMemory struct {
 // CompactionEvent is the audit record for one conversation checkpoint. It captures the before/after
 // of both the conversation summary and the personality scratchpad, the loaded-memory set, memories
 // newly created during the compaction, and merge/link actions that changed existing agent state.
+// Explanation fields describe the transition and therefore live on the event rather than on the
+// content-addressed snapshots, which can be reused by adjacent events.
 type CompactionEvent struct {
 	ID                 uuid.UUID  `json:"id"`
 	ChatID             uuid.UUID  `json:"chat_id"`
@@ -44,6 +46,8 @@ type CompactionEvent struct {
 	AssistantMessageID *uuid.UUID `json:"assistant_message_id,omitempty"`
 	Provider           string     `json:"provider,omitempty"`
 	Reason             string     `json:"reason,omitempty"`
+	SummaryExplanation string     `json:"summary_explanation,omitempty"`
+	ScratchpadExplanation string  `json:"scratchpad_explanation,omitempty"`
 
 	OldSummary    *CheckpointSnapshot `json:"old_summary,omitempty"`
 	NewSummary    *CheckpointSnapshot `json:"new_summary,omitempty"`
@@ -59,16 +63,17 @@ type CompactionEvent struct {
 }
 
 // CompactionEventInput carries everything known when a compaction begins (before the new summary is
-// produced). NewSummary is filled in via SetCompactionEventNewSummary once summarization completes.
+// produced). NewSummary and its explanation are filled in once summarization completes.
 type CompactionEventInput struct {
-	ChatID             uuid.UUID
-	PersonalityID      *uuid.UUID
-	AssistantMessageID *uuid.UUID
-	Provider           string
-	Reason             string
-	OldSummary         string
-	OldScratchpad      string
-	NewScratchpad      string
+	ChatID                 uuid.UUID
+	PersonalityID          *uuid.UUID
+	AssistantMessageID     *uuid.UUID
+	Provider               string
+	Reason                 string
+	OldSummary             string
+	OldScratchpad          string
+	NewScratchpad          string
+	ScratchpadExplanation  string
 	// HasScratchpad is false when the checkpoint had no personality (so no scratchpad snapshots are
 	// recorded). It disambiguates "scratchpad was genuinely empty" from "no scratchpad step ran".
 	HasScratchpad  bool

--- a/internal/models/compaction_event.go
+++ b/internal/models/compaction_event.go
@@ -39,15 +39,15 @@ type CompactionLoadedMemory struct {
 // Explanation fields describe the transition and therefore live on the event rather than on the
 // content-addressed snapshots, which can be reused by adjacent events.
 type CompactionEvent struct {
-	ID                 uuid.UUID  `json:"id"`
-	ChatID             uuid.UUID  `json:"chat_id"`
-	ChatName           string     `json:"chat_name,omitempty"`
-	PersonalityID      *uuid.UUID `json:"personality_id,omitempty"`
-	AssistantMessageID *uuid.UUID `json:"assistant_message_id,omitempty"`
-	Provider           string     `json:"provider,omitempty"`
-	Reason             string     `json:"reason,omitempty"`
-	SummaryExplanation string     `json:"summary_explanation,omitempty"`
-	ScratchpadExplanation string  `json:"scratchpad_explanation,omitempty"`
+	ID                    uuid.UUID  `json:"id"`
+	ChatID                uuid.UUID  `json:"chat_id"`
+	ChatName              string     `json:"chat_name,omitempty"`
+	PersonalityID         *uuid.UUID `json:"personality_id,omitempty"`
+	AssistantMessageID    *uuid.UUID `json:"assistant_message_id,omitempty"`
+	Provider              string     `json:"provider,omitempty"`
+	Reason                string     `json:"reason,omitempty"`
+	SummaryExplanation    string     `json:"summary_explanation,omitempty"`
+	ScratchpadExplanation string     `json:"scratchpad_explanation,omitempty"`
 
 	OldSummary    *CheckpointSnapshot `json:"old_summary,omitempty"`
 	NewSummary    *CheckpointSnapshot `json:"new_summary,omitempty"`
@@ -65,15 +65,15 @@ type CompactionEvent struct {
 // CompactionEventInput carries everything known when a compaction begins (before the new summary is
 // produced). NewSummary and its explanation are filled in once summarization completes.
 type CompactionEventInput struct {
-	ChatID                 uuid.UUID
-	PersonalityID          *uuid.UUID
-	AssistantMessageID     *uuid.UUID
-	Provider               string
-	Reason                 string
-	OldSummary             string
-	OldScratchpad          string
-	NewScratchpad          string
-	ScratchpadExplanation  string
+	ChatID                uuid.UUID
+	PersonalityID         *uuid.UUID
+	AssistantMessageID    *uuid.UUID
+	Provider              string
+	Reason                string
+	OldSummary            string
+	OldScratchpad         string
+	NewScratchpad         string
+	ScratchpadExplanation string
 	// HasScratchpad is false when the checkpoint had no personality (so no scratchpad snapshots are
 	// recorded). It disambiguates "scratchpad was genuinely empty" from "no scratchpad step ran".
 	HasScratchpad  bool

--- a/web/app/src/app/core/models/memory.model.ts
+++ b/web/app/src/app/core/models/memory.model.ts
@@ -6,8 +6,6 @@ export interface Memory {
   level: 'global' | 'personality' | 'thread' | 'summary';
   type: 'Context';
   status: 'active' | 'inactive';
-  // Stored confidence is a float in [0,1] (LLM buckets map to anchors 0.3/0.6/0.9; other signals
-  // can refine it). Create/patch still accept the coarse buckets below.
   confidence: number;
   chain_metadata?: {
     duplicate_count: number;
@@ -15,7 +13,6 @@ export interface Memory {
     verified_timestamps_last?: string[];
     merged_from_memory_ids?: string[];
   } | null;
-  /** Set when this memory is cross-referenced with related-but-distinct memories (link, not merge). */
   link_group_id?: string | null;
   starred: boolean;
   pinned_personality_id?: string | null;
@@ -56,13 +53,8 @@ export interface CreateMemoryInput {
   confidence?: 'low' | 'medium' | 'high';
 }
 
-export interface BatchCreateMemoryInput {
-  memories: CreateMemoryInput[];
-}
-
-export interface BatchCreateMemoryResponse {
-  memories: Memory[];
-}
+export interface BatchCreateMemoryInput { memories: CreateMemoryInput[]; }
+export interface BatchCreateMemoryResponse { memories: Memory[]; }
 
 export interface MemoryPatch {
   content?: string;
@@ -98,9 +90,7 @@ export interface MemoryMergeEvent {
   merge_type: MemoryMergeType;
   content: string;
   duplicates_folded: number;
-  /** Set for link events: the shared id assigned to the cross-referenced members. */
   link_group_id?: string | null;
-  /** The compaction (checkpoint) that produced this merge event, if any. */
   compaction_event_id?: string | null;
   source_members?: MemoryMergeSourceMember[];
   reverted_at?: string | null;
@@ -116,7 +106,6 @@ export interface PaginatedMemoryMergeEventResponse {
 
 export type CheckpointSnapshotKind = 'summary' | 'scratchpad';
 
-/** A content-addressed capture of a conversation summary or personality scratchpad. */
 export interface CheckpointSnapshot {
   id: string;
   kind: CheckpointSnapshotKind;
@@ -126,7 +115,6 @@ export interface CheckpointSnapshot {
   created_at: string;
 }
 
-/** One memory that was live in the compacted segment. */
 export interface CompactionLoadedMemory {
   memory_id?: string | null;
   content: string;
@@ -134,7 +122,6 @@ export interface CompactionLoadedMemory {
   confidence?: number;
 }
 
-/** The audit record for one conversation checkpoint ("compaction"). */
 export interface CompactionEvent {
   id: string;
   chat_id: string;
@@ -143,6 +130,8 @@ export interface CompactionEvent {
   assistant_message_id?: string | null;
   provider?: string;
   reason?: string;
+  summary_explanation?: string;
+  scratchpad_explanation?: string;
   old_summary?: CheckpointSnapshot | null;
   new_summary?: CheckpointSnapshot | null;
   old_scratchpad?: CheckpointSnapshot | null;

--- a/web/app/src/app/features/memory/compaction-log-explanation.spec.ts
+++ b/web/app/src/app/features/memory/compaction-log-explanation.spec.ts
@@ -13,7 +13,7 @@ import { CompactionLogPageComponent } from './compaction-log-page.component';
 describe('CompactionLogPageComponent explanation snippets', () => {
   let fixture: ComponentFixture<CompactionLogPageComponent>;
 
-  const event = {
+  const event: CompactionEvent = {
     id: 'checkpoint-explanation',
     chat_id: 'chat-1',
     chat_name: 'Project thread',
@@ -49,9 +49,6 @@ describe('CompactionLogPageComponent explanation snippets', () => {
     },
     created_at: '2026-08-29T13:00:00Z',
     updated_at: '2026-08-29T13:00:00Z',
-  } as CompactionEvent & {
-    summary_explanation: string;
-    scratchpad_explanation: string;
   };
 
   beforeEach(async () => {
@@ -89,5 +86,22 @@ describe('CompactionLogPageComponent explanation snippets', () => {
 
     expect(text).toContain(event.summary_explanation);
     expect(text).toContain(event.scratchpad_explanation);
+  });
+
+  it('keeps full before/after text out of the page until the user opens the change', () => {
+    const initialText = fixture.nativeElement.textContent as string;
+    expect(initialText).not.toContain(event.old_summary?.content);
+    expect(initialText).not.toContain(event.new_summary?.content);
+
+    const openButtons = fixture.nativeElement.querySelectorAll('.change-summary__open') as NodeListOf<HTMLButtonElement>;
+    expect(openButtons.length).toBe(2);
+    openButtons[0].click();
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('[role="dialog"]') as HTMLElement | null;
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain(event.old_summary?.content);
+    expect(dialog?.textContent).toContain(event.new_summary?.content);
+    expect(dialog?.textContent).toContain(event.summary_explanation);
   });
 });

--- a/web/app/src/app/features/memory/compaction-log-explanation.spec.ts
+++ b/web/app/src/app/features/memory/compaction-log-explanation.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ChatService } from '../../core/services/chat.service';
+import { ConfirmationService } from '../../core/services/confirmation.service';
+import { MemoryService } from '../../core/services/memory.service';
+import { PersonalityService } from '../../core/services/personality.service';
+import { CompactionEvent } from '../../core/models/memory.model';
+import { CompactionLogPageComponent } from './compaction-log-page.component';
+
+describe('CompactionLogPageComponent explanation snippets', () => {
+  let fixture: ComponentFixture<CompactionLogPageComponent>;
+
+  const event = {
+    id: 'checkpoint-explanation',
+    chat_id: 'chat-1',
+    chat_name: 'Project thread',
+    summary_explanation: 'Added the newly confirmed launch date and removed stale scheduling detail.',
+    scratchpad_explanation: 'Recorded that the user now prefers the shorter onboarding flow.',
+    old_summary: {
+      id: 'summary-old',
+      kind: 'summary',
+      chat_id: 'chat-1',
+      content: 'Launch timing is undecided.',
+      created_at: '2026-08-29T12:00:00Z',
+    },
+    new_summary: {
+      id: 'summary-new',
+      kind: 'summary',
+      chat_id: 'chat-1',
+      content: 'Launch is scheduled for September 15 after the final QA pass.',
+      created_at: '2026-08-29T13:00:00Z',
+    },
+    old_scratchpad: {
+      id: 'scratch-old',
+      kind: 'scratchpad',
+      personality_id: 'personality-1',
+      content: 'User is evaluating onboarding options.',
+      created_at: '2026-08-29T12:00:00Z',
+    },
+    new_scratchpad: {
+      id: 'scratch-new',
+      kind: 'scratchpad',
+      personality_id: 'personality-1',
+      content: 'User prefers the shorter onboarding flow.',
+      created_at: '2026-08-29T13:00:00Z',
+    },
+    created_at: '2026-08-29T13:00:00Z',
+    updated_at: '2026-08-29T13:00:00Z',
+  } as CompactionEvent & {
+    summary_explanation: string;
+    scratchpad_explanation: string;
+  };
+
+  beforeEach(async () => {
+    const memoryService = {
+      listCompactionEvents: vi.fn().mockReturnValue(of({ results: [event], total_count: 1, page: 1 })),
+      revertSnapshot: vi.fn(),
+    };
+    const chatService = {
+      listChats: vi.fn().mockReturnValue(of({ results: [], total_count: 0, page: 1 })),
+    };
+    const personalityService = {
+      listPersonalities: vi.fn().mockReturnValue(of({ results: [], total_count: 0, page: 1 })),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CompactionLogPageComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        { provide: MemoryService, useValue: memoryService },
+        { provide: ChatService, useValue: chatService },
+        { provide: PersonalityService, useValue: personalityService },
+        { provide: ConfirmationService, useValue: { confirm: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CompactionLogPageComponent);
+    fixture.detectChanges();
+    fixture.componentInstance.toggleExpanded(event);
+    fixture.detectChanges();
+  });
+
+  it('shows human-readable summary and scratchpad explanations for the checkpoint', () => {
+    const text = fixture.nativeElement.textContent as string;
+
+    expect(text).toContain(event.summary_explanation);
+    expect(text).toContain(event.scratchpad_explanation);
+  });
+});

--- a/web/app/src/app/features/memory/compaction-log-page.component.html
+++ b/web/app/src/app/features/memory/compaction-log-page.component.html
@@ -3,9 +3,9 @@
     <a routerLink="/memories" class="compaction-log-header__back">← Back to memories</a>
     <h1>Compaction log</h1>
     <p>
-      Every conversation checkpoint, captured like a diff: the summary and scratchpad before and after,
+      Every conversation checkpoint, captured like a diff: what changed in the summary and scratchpad,
       which memories were loaded into the segment, and every dedupe/merge/link action it produced.
-      Revert a summary or scratchpad to roll back to a known-good checkpoint.
+      Open a change to inspect the full before/after state or restore a known-good checkpoint.
     </p>
   </header>
 
@@ -18,18 +18,14 @@
       Thread
       <select #chatFilter [value]="selectedChatID()" (change)="updateFilters(chatFilter.value, personalityFilter.value)">
         <option value="">All threads</option>
-        @for (chat of chats(); track chat.id) {
-          <option [value]="chat.id">{{ chat.name }}</option>
-        }
+        @for (chat of chats(); track chat.id) { <option [value]="chat.id">{{ chat.name }}</option> }
       </select>
     </label>
     <label>
       Personality
       <select #personalityFilter [value]="selectedPersonalityID()" (change)="updateFilters(chatFilter.value, personalityFilter.value)">
         <option value="">All personalities</option>
-        @for (personality of personalities(); track personality.id) {
-          <option [value]="personality.id">{{ personality.name }}</option>
-        }
+        @for (personality of personalities(); track personality.id) { <option [value]="personality.id">{{ personality.name }}</option> }
       </select>
     </label>
   </div>
@@ -48,19 +44,16 @@
             <div class="compaction-card__badges">
               @if (event.chat_name) {
                 <span class="compaction-card__badge compaction-card__badge--muted compaction-card__badge--chat" [title]="event.chat_name">
-                  <span class="compaction-card__badge-label">Thread</span>
-                  <span class="compaction-card__badge-value">{{ event.chat_name }}</span>
+                  <span class="compaction-card__badge-label">Thread</span><span class="compaction-card__badge-value">{{ event.chat_name }}</span>
                 </span>
               }
               @if (event.reason) {
                 <span class="compaction-card__badge compaction-card__badge--muted">
-                  <span class="compaction-card__badge-label">Checkpoint</span>
-                  <span class="compaction-card__badge-value">{{ checkpointReasonLabel(event.reason) }}</span>
+                  <span class="compaction-card__badge-label">Checkpoint</span><span class="compaction-card__badge-value">{{ checkpointReasonLabel(event.reason) }}</span>
                 </span>
               }
               <span class="compaction-card__badge compaction-card__badge--muted">
-                <span class="compaction-card__badge-label">Memory changes</span>
-                <span class="compaction-card__badge-value">{{ mergeSummary(event) }}</span>
+                <span class="compaction-card__badge-label">Memory changes</span><span class="compaction-card__badge-value">{{ mergeSummary(event) }}</span>
               </span>
             </div>
             <div class="compaction-card__meta">
@@ -70,196 +63,104 @@
             </div>
           </div>
 
-          <button
-            type="button"
-            class="compaction-card__toggle"
-            [attr.aria-expanded]="isExpanded(event)"
-            (click)="toggleExpanded(event)">
-            <span class="compaction-toggle__label">Details</span>
-            <span class="compaction-toggle__chevron" aria-hidden="true"></span>
+          <button type="button" class="compaction-card__toggle" [attr.aria-expanded]="isExpanded(event)" (click)="toggleExpanded(event)">
+            <span class="compaction-toggle__label">Details</span><span class="compaction-toggle__chevron" aria-hidden="true"></span>
           </button>
 
           @if (isExpanded(event)) {
             <div class="compaction-card__body">
-
               <button type="button" class="compaction-section-toggle" [attr.aria-expanded]="!isSectionCollapsed(event, 'summary')" (click)="toggleSection(event, 'summary')">
-                <span>Summaries</span>
-                <span class="compaction-toggle__chevron" aria-hidden="true"></span>
+                <span>Summaries</span><span class="compaction-toggle__chevron" aria-hidden="true"></span>
               </button>
               @if (!isSectionCollapsed(event, 'summary')) {
-              <!-- Conversation summary -->
-              <section class="diff-block">
-                <div class="diff-block__title-row">
-                  <h3 class="diff-block__title">Conversation summary</h3>
-                  @if (!summaryChanged(event)) {
-                    <span class="diff-block__unchanged">unchanged</span>
-                  }
-                </div>
-                <div class="diff-grid">
-                  <div class="diff-pane diff-pane--old">
-                    <div class="diff-pane__head">
-                      <span class="diff-pane__label">Before</span>
-                      @if (event.old_summary && summaryChanged(event)) {
-                        <button
-                          type="button"
-                          class="diff-pane__revert"
-                          [disabled]="revertingId() === event.old_summary?.id || isSnapshotReverted(event.old_summary)"
-                          (click)="revert(event.old_summary)">
-                          {{ isSnapshotReverted(event.old_summary) ? 'Restored' : (revertingId() === event.old_summary?.id ? 'Reverting…' : 'Revert to this') }}
-                        </button>
-                      }
-                    </div>
-                    <pre class="diff-pane__content">{{ event.old_summary?.content || '(empty)' }}</pre>
-                  </div>
-                  <div class="diff-pane diff-pane--new">
-                    <div class="diff-pane__head">
-                      <span class="diff-pane__label">After</span>
-                      @if (event.new_summary && summaryChanged(event)) {
-                        <button
-                          type="button"
-                          class="diff-pane__revert"
-                          [disabled]="revertingId() === event.new_summary?.id || isSnapshotReverted(event.new_summary)"
-                          (click)="revert(event.new_summary)">
-                          {{ isSnapshotReverted(event.new_summary) ? 'Restored' : (revertingId() === event.new_summary?.id ? 'Reverting…' : 'Revert to this') }}
-                        </button>
-                      }
-                    </div>
-                    <pre class="diff-pane__content">{{ event.new_summary?.content || '(empty)' }}</pre>
-                  </div>
-                </div>
-              </section>
-
-              <!-- Scratchpad -->
-              @if (event.old_scratchpad || event.new_scratchpad) {
-                <section class="diff-block">
+                <section class="diff-block change-summary">
                   <div class="diff-block__title-row">
-                    <h3 class="diff-block__title">Scratchpad <span class="diff-block__hint">(personality-wide)</span></h3>
-                    @if (!scratchpadChanged(event)) {
-                      <span class="diff-block__unchanged">unchanged</span>
-                    }
+                    <h3 class="diff-block__title">Conversation summary</h3>
+                    @if (!summaryChanged(event)) { <span class="diff-block__unchanged">unchanged</span> }
                   </div>
-                  <div class="diff-grid">
-                    <div class="diff-pane diff-pane--old">
-                      <div class="diff-pane__head">
-                        <span class="diff-pane__label">Before</span>
-                        @if (event.old_scratchpad && scratchpadChanged(event)) {
-                          <button
-                            type="button"
-                            class="diff-pane__revert"
-                            [disabled]="revertingId() === event.old_scratchpad?.id || isSnapshotReverted(event.old_scratchpad)"
-                            (click)="revert(event.old_scratchpad)">
-                            {{ isSnapshotReverted(event.old_scratchpad) ? 'Restored' : (revertingId() === event.old_scratchpad?.id ? 'Reverting…' : 'Revert to this') }}
-                          </button>
-                        }
-                      </div>
-                      <pre class="diff-pane__content">{{ event.old_scratchpad?.content || '(empty)' }}</pre>
-                    </div>
-                    <div class="diff-pane diff-pane--new">
-                      <div class="diff-pane__head">
-                        <span class="diff-pane__label">After</span>
-                        @if (event.new_scratchpad && scratchpadChanged(event)) {
-                          <button
-                            type="button"
-                            class="diff-pane__revert"
-                            [disabled]="revertingId() === event.new_scratchpad?.id || isSnapshotReverted(event.new_scratchpad)"
-                            (click)="revert(event.new_scratchpad)">
-                            {{ isSnapshotReverted(event.new_scratchpad) ? 'Restored' : (revertingId() === event.new_scratchpad?.id ? 'Reverting…' : 'Revert to this') }}
-                          </button>
-                        }
-                      </div>
-                      <pre class="diff-pane__content">{{ event.new_scratchpad?.content || '(empty)' }}</pre>
-                    </div>
-                  </div>
+                  <p class="change-summary__explanation">{{ changeExplanation(event, 'summary') }}</p>
+                  <button type="button" class="change-summary__open" (click)="openChangeDetail(event, 'summary')">View full change</button>
                 </section>
-              }
+
+                @if (event.old_scratchpad || event.new_scratchpad) {
+                  <section class="diff-block change-summary">
+                    <div class="diff-block__title-row">
+                      <h3 class="diff-block__title">Scratchpad <span class="diff-block__hint">(personality-wide)</span></h3>
+                      @if (!scratchpadChanged(event)) { <span class="diff-block__unchanged">unchanged</span> }
+                    </div>
+                    <p class="change-summary__explanation">{{ changeExplanation(event, 'scratchpad') }}</p>
+                    <button type="button" class="change-summary__open" (click)="openChangeDetail(event, 'scratchpad')">View full change</button>
+                  </section>
+                }
               }
 
               <button type="button" class="compaction-section-toggle" [attr.aria-expanded]="!isSectionCollapsed(event, 'memory')" (click)="toggleSection(event, 'memory')">
-                <span>Memory</span>
-                <span class="compaction-toggle__chevron" aria-hidden="true"></span>
+                <span>Memory</span><span class="compaction-toggle__chevron" aria-hidden="true"></span>
               </button>
               @if (!isSectionCollapsed(event, 'memory')) {
-              <!-- Loaded memories -->
-              <section class="detail-block">
-                <button
-                  type="button"
-                  class="loaded-memories-toggle"
-                  [attr.aria-expanded]="!isLoadedMemoriesCollapsed(event)"
-                  (click)="toggleLoadedMemories(event)">
-                  <span>Loaded memories ({{ event.loaded_memories?.length ?? 0 }})</span>
-                  <span class="compaction-toggle__chevron" aria-hidden="true"></span>
-                </button>
-                @if (!isLoadedMemoriesCollapsed(event)) {
-                  @if ((event.loaded_memories?.length ?? 0) === 0) {
-                    <p class="detail-block__empty">No memories were loaded into this segment.</p>
+                <section class="detail-block">
+                  <button type="button" class="loaded-memories-toggle" [attr.aria-expanded]="!isLoadedMemoriesCollapsed(event)" (click)="toggleLoadedMemories(event)">
+                    <span>Loaded memories ({{ event.loaded_memories?.length ?? 0 }})</span><span class="compaction-toggle__chevron" aria-hidden="true"></span>
+                  </button>
+                  @if (!isLoadedMemoriesCollapsed(event)) {
+                    @if ((event.loaded_memories?.length ?? 0) === 0) {
+                      <p class="detail-block__empty">No memories were loaded into this segment.</p>
+                    } @else {
+                      <ul class="loaded-list" role="list">
+                        @for (mem of event.loaded_memories; track $index) {
+                          <li class="loaded-item">
+                            <div class="loaded-item__head">
+                              <span class="loaded-item__scope">{{ mem.scope }}</span>
+                              @if (mem.confidence) { <span class="loaded-item__confidence">conf {{ mem.confidence | number:'1.2-2' }}</span> }
+                              @if (mem.memory_id) { <button type="button" class="loaded-item__link" (click)="openMemory(mem.memory_id)">View</button> }
+                            </div>
+                            <p class="loaded-item__content">{{ mem.content }}</p>
+                          </li>
+                        }
+                      </ul>
+                    }
+                  }
+                </section>
+
+                <section class="detail-block">
+                  <h3 class="detail-block__title">New memories ({{ createdMemories(event).length }})</h3>
+                  @if (createdMemories(event).length === 0) {
+                    <p class="detail-block__empty">No new memories created in this compaction.</p>
                   } @else {
-                    <ul class="loaded-list" role="list">
-                      @for (mem of event.loaded_memories; track $index) {
-                        <li class="loaded-item">
-                          <div class="loaded-item__head">
-                            <span class="loaded-item__scope">{{ mem.scope }}</span>
-                            @if (mem.confidence) {
-                              <span class="loaded-item__confidence">conf {{ mem.confidence | number:'1.2-2' }}</span>
-                            }
-                            @if (mem.memory_id) {
-                              <button type="button" class="loaded-item__link" (click)="openMemory(mem.memory_id)">View</button>
-                            }
+                    <ul class="merge-list" role="list">
+                      @for (mem of createdMemories(event); track mem.memory_id ?? mem.content) {
+                        <li class="merge-item">
+                          <div class="merge-item__head">
+                            <span class="merge-item__type">Created</span>
+                            @if (mem.memory_id) { <button type="button" class="merge-item__link" (click)="openMemory(mem.memory_id)">View memory</button> }
                           </div>
-                          <p class="loaded-item__content">{{ mem.content }}</p>
+                          <p class="merge-item__content">{{ mem.content }}</p>
                         </li>
                       }
                     </ul>
                   }
-                }
-              </section>
-
-              <!-- New and updated memory operations -->
-              <section class="detail-block">
-                <h3 class="detail-block__title">New memories ({{ createdMemories(event).length }})</h3>
-                @if (createdMemories(event).length === 0) {
-                  <p class="detail-block__empty">No new memories created in this compaction.</p>
-                } @else {
-                  <ul class="merge-list" role="list">
-                    @for (mem of createdMemories(event); track mem.memory_id ?? mem.content) {
-                      <li class="merge-item">
-                        <div class="merge-item__head">
-                          <span class="merge-item__type">Created</span>
-                          @if (mem.memory_id) {
-                            <button type="button" class="merge-item__link" (click)="openMemory(mem.memory_id)">View memory</button>
-                          }
-                        </div>
-                        <p class="merge-item__content">{{ mem.content }}</p>
-                      </li>
-                    }
-                  </ul>
-                }
-              </section>
-              <section class="detail-block">
-                <h3 class="detail-block__title">Memory updates ({{ updatedMemoryEvents(event).length }})</h3>
-                @if (updatedMemoryEvents(event).length === 0) {
-                  <p class="detail-block__empty">No dedupe/merge/link actions in this compaction.</p>
-                } @else {
-                  <ul class="merge-list" role="list">
-                    @for (me of updatedMemoryEvents(event); track me.id) {
-                      <li class="merge-item">
-                        <div class="merge-item__head">
-                          <span class="merge-item__type merge-item__type--{{ me.merge_type }}">{{ mergeTypeLabel(me) }}</span>
-                          @if (me.merge_type === 'fold_live' && mergedSourceCount(me) >= 2) {
-                            <span class="merge-item__count">{{ mergedSourceCount(me) }}×</span>
-                          }
-                          @if (me.reverted_at) {
-                            <span class="merge-item__reverted">Undone</span>
-                          }
-                          <button type="button" class="merge-item__link" (click)="openMemory(me.survivor_memory_id)">View memory</button>
-                        </div>
-                        <p class="merge-item__content">{{ me.content }}</p>
-                      </li>
-                    }
-                  </ul>
-                }
-              </section>
+                </section>
+                <section class="detail-block">
+                  <h3 class="detail-block__title">Memory updates ({{ updatedMemoryEvents(event).length }})</h3>
+                  @if (updatedMemoryEvents(event).length === 0) {
+                    <p class="detail-block__empty">No dedupe/merge/link actions in this compaction.</p>
+                  } @else {
+                    <ul class="merge-list" role="list">
+                      @for (me of updatedMemoryEvents(event); track me.id) {
+                        <li class="merge-item">
+                          <div class="merge-item__head">
+                            <span class="merge-item__type merge-item__type--{{ me.merge_type }}">{{ mergeTypeLabel(me) }}</span>
+                            @if (me.merge_type === 'fold_live' && mergedSourceCount(me) >= 2) { <span class="merge-item__count">{{ mergedSourceCount(me) }}×</span> }
+                            @if (me.reverted_at) { <span class="merge-item__reverted">Undone</span> }
+                            <button type="button" class="merge-item__link" (click)="openMemory(me.survivor_memory_id)">View memory</button>
+                          </div>
+                          <p class="merge-item__content">{{ me.content }}</p>
+                        </li>
+                      }
+                    </ul>
+                  }
+                </section>
               }
-
             </div>
           }
         </li>
@@ -275,3 +176,41 @@
     }
   }
 </section>
+
+@if (changeDetail(); as detail) {
+  <div class="change-modal__backdrop" (click)="closeChangeDetail()">
+    <section class="change-modal" role="dialog" aria-modal="true" [attr.aria-label]="detail.title" (click)="$event.stopPropagation()">
+      <header class="change-modal__header">
+        <div>
+          <h2>{{ detail.title }}</h2>
+          <p>{{ detail.explanation }}</p>
+        </div>
+        <button type="button" class="change-modal__close" aria-label="Close change details" (click)="closeChangeDetail()">×</button>
+      </header>
+      <div class="diff-grid change-modal__diff">
+        <div class="diff-pane diff-pane--old">
+          <div class="diff-pane__head">
+            <span class="diff-pane__label">Before</span>
+            @if (detail.before) {
+              <button type="button" class="diff-pane__revert" [disabled]="revertingId() === detail.before.id || isSnapshotReverted(detail.before)" (click)="revert(detail.before)">
+                {{ isSnapshotReverted(detail.before) ? 'Restored' : (revertingId() === detail.before.id ? 'Reverting…' : 'Revert to this') }}
+              </button>
+            }
+          </div>
+          <pre class="diff-pane__content">{{ detail.before?.content || '(empty)' }}</pre>
+        </div>
+        <div class="diff-pane diff-pane--new">
+          <div class="diff-pane__head">
+            <span class="diff-pane__label">After</span>
+            @if (detail.after) {
+              <button type="button" class="diff-pane__revert" [disabled]="revertingId() === detail.after.id || isSnapshotReverted(detail.after)" (click)="revert(detail.after)">
+                {{ isSnapshotReverted(detail.after) ? 'Restored' : (revertingId() === detail.after.id ? 'Reverting…' : 'Revert to this') }}
+              </button>
+            }
+          </div>
+          <pre class="diff-pane__content">{{ detail.after?.content || '(empty)' }}</pre>
+        </div>
+      </div>
+    </section>
+  </div>
+}

--- a/web/app/src/app/features/memory/compaction-log-page.component.scss
+++ b/web/app/src/app/features/memory/compaction-log-page.component.scss
@@ -3,453 +3,84 @@
 }
 
 .compaction-log-header {
-  h1 {
-    margin: 0.5rem 0 0.25rem;
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-text-primary);
-  }
-
-  p {
-    margin: 0;
-    color: var(--color-text-secondary);
-    font-size: 0.8125rem;
-    line-height: 1.5;
-  }
-
-  &__back {
-    color: var(--color-text-secondary);
-    font-size: 0.8125rem;
-    text-decoration: none;
-
-    &:hover {
-      color: var(--color-text-primary);
-    }
-  }
+  h1 { margin: 0.5rem 0 0.25rem; font-size: 1.25rem; font-weight: 700; color: var(--color-text-primary); }
+  p { margin: 0; color: var(--color-text-secondary); font-size: 0.8125rem; line-height: 1.5; }
+  &__back { color: var(--color-text-secondary); font-size: 0.8125rem; text-decoration: none; &:hover { color: var(--color-text-primary); } }
 }
 
 .compaction-log-status,
 .compaction-log-error,
-.compaction-log-notice {
-  border-radius: 1rem;
-  border: 1px solid var(--color-border-base);
-  background: var(--color-surface-card);
-  padding: 1rem;
-  font-size: 0.875rem;
-}
-
-.compaction-log-error {
-  border-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
-  color: var(--color-danger);
-}
-
-.compaction-log-notice {
-  border-color: color-mix(in srgb, var(--color-success, #16a34a) 45%, transparent);
-  color: var(--color-success, #16a34a);
-}
+.compaction-log-notice { border-radius: 1rem; border: 1px solid var(--color-border-base); background: var(--color-surface-card); padding: 1rem; font-size: 0.875rem; }
+.compaction-log-error { border-color: color-mix(in srgb, var(--color-danger) 40%, transparent); color: var(--color-danger); }
+.compaction-log-notice { border-color: color-mix(in srgb, var(--color-success, #16a34a) 45%, transparent); color: var(--color-success, #16a34a); }
 
 .compaction-log-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-
-  label {
-    display: grid;
-    gap: 0.25rem;
-    color: var(--color-text-secondary);
-    font-size: 0.75rem;
-  }
-
-  select {
-    min-width: 12rem;
-    border: 1px solid var(--color-border-base);
-    border-radius: 0.5rem;
-    background: var(--color-surface-card);
-    color: var(--color-text-primary);
-    padding: 0.375rem 0.5rem;
-  }
+  display: flex; flex-wrap: wrap; gap: 0.75rem;
+  label { display: grid; gap: 0.25rem; color: var(--color-text-secondary); font-size: 0.75rem; }
+  select { min-width: 12rem; border: 1px solid var(--color-border-base); border-radius: 0.5rem; background: var(--color-surface-card); color: var(--color-text-primary); padding: 0.375rem 0.5rem; }
 }
 
-.compaction-log-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
+.compaction-log-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.75rem; }
 
 .compaction-card {
-  border-radius: 1rem;
+  border-radius: 1rem; border: 1px solid var(--color-border-base); background: var(--color-surface-card); padding: 1rem;
+  &--expanded { border-color: color-mix(in srgb, var(--color-text-secondary) 35%, transparent); }
+  &__head { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 0.5rem; }
+  &__badges { display: flex; flex-wrap: wrap; gap: 0.375rem; align-items: center; }
+  &__badge { display: inline-flex; align-items: center; gap: 0.25rem; border-radius: 999px; padding: 0.125rem 0.5rem; font-size: 0.6875rem; font-weight: 600; background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent); color: var(--color-text-primary); &--muted { background: transparent; border: 1px solid var(--color-border-base); color: var(--color-text-secondary); font-weight: 500; } &--chat { max-width: 18rem; } }
+  &__badge-label { color: var(--color-text-secondary); font-size: 0.625rem; font-weight: 700; letter-spacing: 0.03em; text-transform: uppercase; }
+  &__badge-value { color: var(--color-text-primary); }
+  &__badge--chat &__badge-value { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  &__meta { display: flex; align-items: center; gap: 0.5rem; font-size: 0.75rem; color: var(--color-text-secondary); }
+  &__thread { background: none; border: none; padding: 0; color: var(--color-text-secondary); font-size: 0.75rem; cursor: pointer; text-decoration: underline; &:hover { color: var(--color-text-primary); } }
+  &__toggle { display: flex; align-items: center; justify-content: space-between; width: 100%; margin-top: 0.5rem; border: 0; background: none; color: var(--color-text-primary); cursor: pointer; font-size: 0.875rem; font-weight: 600; padding: 0; text-align: left; }
+  &__body { display: flex; flex-direction: column; gap: 1rem; margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--color-border-base); }
+}
+
+.diff-block, .detail-block { &__title, &__title-row { margin: 0 0 0.5rem; } }
+.loaded-memories-toggle { display: flex; align-items: center; justify-content: space-between; width: 100%; margin: 0 0 0.5rem; border: 0; background: none; color: var(--color-text-primary); cursor: pointer; font-size: 0.8125rem; font-weight: 700; padding: 0; text-align: left; }
+.compaction-section-toggle { display: flex; align-items: center; justify-content: space-between; width: 100%; border: 0; border-bottom: 1px solid var(--color-border-base); background: none; color: var(--color-text-primary); cursor: pointer; font-size: 0.875rem; font-weight: 700; padding: 0.25rem 0 0.5rem; text-align: left; }
+.compaction-toggle__chevron { width: 0.5rem; height: 0.5rem; flex: 0 0 auto; border-right: 1.5px solid currentcolor; border-bottom: 1.5px solid currentcolor; color: var(--color-text-secondary); transform: rotate(45deg); transition: transform 150ms ease; }
+[aria-expanded='true'] > .compaction-toggle__chevron { transform: rotate(225deg); }
+.diff-block__title-row { display: flex; align-items: center; gap: 0.5rem; }
+.diff-block__title, .detail-block__title { font-size: 0.8125rem; font-weight: 700; color: var(--color-text-primary); }
+.diff-block__hint { font-weight: 400; color: var(--color-text-secondary); }
+.diff-block__unchanged { font-size: 0.6875rem; color: var(--color-text-secondary); border: 1px solid var(--color-border-base); border-radius: 999px; padding: 0.0625rem 0.4375rem; }
+
+.change-summary {
   border: 1px solid var(--color-border-base);
-  background: var(--color-surface-card);
-  padding: 1rem;
-
-  &--expanded {
-    border-color: color-mix(in srgb, var(--color-text-secondary) 35%, transparent);
-  }
-
-  &__head {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 0.5rem;
-  }
-
-  &__badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.375rem;
-    align-items: center;
-  }
-
-  &__badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    border-radius: 999px;
-    padding: 0.125rem 0.5rem;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent);
-    color: var(--color-text-primary);
-
-    &--muted {
-      background: transparent;
-      border: 1px solid var(--color-border-base);
-      color: var(--color-text-secondary);
-      font-weight: 500;
-    }
-
-    &--chat {
-      max-width: 18rem;
-    }
-  }
-
-  &__badge-label {
-    color: var(--color-text-secondary);
-    font-size: 0.625rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-  }
-
-  &__badge-value {
-    color: var(--color-text-primary);
-  }
-
-  &__badge--chat &__badge-value {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__meta {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.75rem;
-    color: var(--color-text-secondary);
-  }
-
-  &__thread {
-    background: none;
-    border: none;
-    padding: 0;
-    color: var(--color-text-secondary);
-    font-size: 0.75rem;
-    cursor: pointer;
-    text-decoration: underline;
-
-    &:hover {
-      color: var(--color-text-primary);
-    }
-  }
-
-  &__toggle {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    margin-top: 0.5rem;
-    border: 0;
-    background: none;
-    color: var(--color-text-primary);
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 600;
-    padding: 0;
-    text-align: left;
-  }
-
-  &__body {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    margin-top: 0.75rem;
-    padding-top: 0.75rem;
-    border-top: 1px solid var(--color-border-base);
-  }
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  &__explanation { margin: 0; color: var(--color-text-primary); font-size: 0.8125rem; line-height: 1.5; }
+  &__open { margin-top: 0.625rem; border: 1px solid var(--color-border-base); border-radius: 0.5rem; background: transparent; color: var(--color-text-secondary); cursor: pointer; font-size: 0.75rem; padding: 0.3rem 0.65rem; &:hover { border-color: var(--color-text-secondary); color: var(--color-text-primary); } }
 }
 
-.diff-block,
-.detail-block {
-  &__title,
-  &__title-row {
-    margin: 0 0 0.5rem;
-  }
-}
-
-.loaded-memories-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  margin: 0 0 0.5rem;
-  border: 0;
-  background: none;
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-size: 0.8125rem;
-  font-weight: 700;
-  padding: 0;
-  text-align: left;
-}
-
-.compaction-section-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  border: 0;
-  border-bottom: 1px solid var(--color-border-base);
-  background: none;
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-size: 0.875rem;
-  font-weight: 700;
-  padding: 0.25rem 0 0.5rem;
-  text-align: left;
-}
-
-.compaction-toggle__chevron {
-  width: 0.5rem;
-  height: 0.5rem;
-  flex: 0 0 auto;
-  border-right: 1.5px solid currentcolor;
-  border-bottom: 1.5px solid currentcolor;
-  color: var(--color-text-secondary);
-  transform: rotate(45deg);
-  transition: transform 150ms ease;
-}
-
-[aria-expanded='true'] > .compaction-toggle__chevron {
-  transform: rotate(225deg);
-}
-
-.diff-block__title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.diff-block__title,
-.detail-block__title {
-  font-size: 0.8125rem;
-  font-weight: 700;
-  color: var(--color-text-primary);
-}
-
-.diff-block__hint {
-  font-weight: 400;
-  color: var(--color-text-secondary);
-}
-
-.diff-block__unchanged {
-  font-size: 0.6875rem;
-  color: var(--color-text-secondary);
-  border: 1px solid var(--color-border-base);
-  border-radius: 999px;
-  padding: 0.0625rem 0.4375rem;
-}
-
-.diff-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.5rem;
-
-  @media (min-width: 768px) {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
+.diff-grid { display: grid; grid-template-columns: 1fr; gap: 0.5rem; @media (min-width: 768px) { grid-template-columns: 1fr 1fr; } }
 .diff-pane {
-  border-radius: 0.75rem;
-  border: 1px solid var(--color-border-base);
-  overflow: hidden;
-
-  &--old {
-    background: color-mix(in srgb, var(--color-danger) 6%, transparent);
-  }
-
-  &--new {
-    background: color-mix(in srgb, var(--color-success, #16a34a) 7%, transparent);
-  }
-
-  &__head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.375rem 0.625rem;
-    border-bottom: 1px solid var(--color-border-base);
-  }
-
-  &__label {
-    font-size: 0.6875rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    color: var(--color-text-secondary);
-  }
-
-  &__revert {
-    background: none;
-    border: 1px solid var(--color-border-base);
-    border-radius: 0.5rem;
-    padding: 0.125rem 0.5rem;
-    font-size: 0.6875rem;
-    color: var(--color-text-primary);
-    cursor: pointer;
-
-    &:hover:not(:disabled) {
-      border-color: var(--color-text-secondary);
-    }
-
-    &:disabled {
-      opacity: 0.6;
-      cursor: default;
-    }
-  }
-
-  &__content {
-    margin: 0;
-    padding: 0.625rem;
-    font-size: 0.75rem;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    word-break: break-word;
-    font-family: inherit;
-    color: var(--color-text-primary);
-    max-height: 20rem;
-    overflow-y: auto;
-  }
+  border-radius: 0.75rem; border: 1px solid var(--color-border-base); overflow: hidden;
+  &--old { background: color-mix(in srgb, var(--color-danger) 6%, transparent); }
+  &--new { background: color-mix(in srgb, var(--color-success, #16a34a) 7%, transparent); }
+  &__head { display: flex; align-items: center; justify-content: space-between; padding: 0.375rem 0.625rem; border-bottom: 1px solid var(--color-border-base); }
+  &__label { font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em; color: var(--color-text-secondary); }
+  &__revert { background: none; border: 1px solid var(--color-border-base); border-radius: 0.5rem; padding: 0.125rem 0.5rem; font-size: 0.6875rem; color: var(--color-text-primary); cursor: pointer; &:hover:not(:disabled) { border-color: var(--color-text-secondary); } &:disabled { opacity: 0.6; cursor: default; } }
+  &__content { margin: 0; padding: 0.625rem; font-size: 0.75rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word; font-family: inherit; color: var(--color-text-primary); max-height: 20rem; overflow-y: auto; }
 }
 
-.detail-block__empty {
-  margin: 0;
-  font-size: 0.8125rem;
-  color: var(--color-text-secondary);
+.change-modal__backdrop { position: fixed; inset: 0; z-index: 60; display: grid; place-items: center; padding: 1rem; background: color-mix(in srgb, black 55%, transparent); }
+.change-modal { width: min(60rem, 100%); max-height: min(48rem, calc(100vh - 2rem)); overflow: auto; border: 1px solid var(--color-border-base); border-radius: 1rem; background: var(--color-surface-card); box-shadow: 0 1rem 3rem color-mix(in srgb, black 30%, transparent); padding: 1rem; }
+.change-modal__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; h2 { margin: 0; color: var(--color-text-primary); font-size: 1rem; } p { margin: 0.35rem 0 0; color: var(--color-text-secondary); font-size: 0.8125rem; line-height: 1.5; } }
+.change-modal__close { border: 0; background: transparent; color: var(--color-text-secondary); cursor: pointer; font-size: 1.5rem; line-height: 1; padding: 0.1rem 0.3rem; }
+.change-modal__diff { align-items: start; }
+
+.detail-block__empty { margin: 0; font-size: 0.8125rem; color: var(--color-text-secondary); }
+.loaded-list, .merge-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.loaded-item, .merge-item {
+  border-radius: 0.75rem; border: 1px solid var(--color-border-base); padding: 0.5rem 0.625rem;
+  &__head { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem; }
+  &__content { margin: 0; font-size: 0.8125rem; line-height: 1.45; color: var(--color-text-primary); white-space: pre-wrap; word-break: break-word; }
+  &__scope, &__confidence, &__count { font-size: 0.6875rem; color: var(--color-text-secondary); border: 1px solid var(--color-border-base); border-radius: 999px; padding: 0.0625rem 0.4375rem; }
+  &__link { margin-left: auto; background: none; border: none; padding: 0; color: var(--color-text-secondary); font-size: 0.6875rem; text-decoration: underline; cursor: pointer; &:hover { color: var(--color-text-primary); } }
+  &__reverted { font-size: 0.6875rem; color: var(--color-danger); }
 }
-
-.loaded-list,
-.merge-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.loaded-item,
-.merge-item {
-  border-radius: 0.75rem;
-  border: 1px solid var(--color-border-base);
-  padding: 0.5rem 0.625rem;
-
-  &__head {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.25rem;
-  }
-
-  &__content {
-    margin: 0;
-    font-size: 0.8125rem;
-    line-height: 1.45;
-    color: var(--color-text-primary);
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-
-  &__scope,
-  &__confidence,
-  &__count {
-    font-size: 0.6875rem;
-    color: var(--color-text-secondary);
-    border: 1px solid var(--color-border-base);
-    border-radius: 999px;
-    padding: 0.0625rem 0.4375rem;
-  }
-
-  &__link {
-    margin-left: auto;
-    background: none;
-    border: none;
-    padding: 0;
-    color: var(--color-text-secondary);
-    font-size: 0.6875rem;
-    text-decoration: underline;
-    cursor: pointer;
-
-    &:hover {
-      color: var(--color-text-primary);
-    }
-  }
-
-  &__reverted {
-    font-size: 0.6875rem;
-    color: var(--color-danger);
-  }
-}
-
-.merge-item__type {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  border-radius: 999px;
-  padding: 0.0625rem 0.5rem;
-  background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent);
-  color: var(--color-text-primary);
-
-  &--link {
-    background: color-mix(in srgb, #6366f1 22%, transparent);
-  }
-
-  &--fold_live {
-    background: color-mix(in srgb, var(--color-success, #16a34a) 22%, transparent);
-  }
-}
-
-.compaction-log-pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  font-size: 0.8125rem;
-  color: var(--color-text-secondary);
-
-  button {
-    border: 1px solid var(--color-border-base);
-    border-radius: 0.5rem;
-    background: var(--color-surface-card);
-    padding: 0.375rem 0.75rem;
-    color: var(--color-text-primary);
-    cursor: pointer;
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: default;
-    }
-  }
-}
+.merge-item__type { font-size: 0.6875rem; font-weight: 700; border-radius: 999px; padding: 0.0625rem 0.5rem; background: color-mix(in srgb, var(--color-text-secondary) 15%, transparent); color: var(--color-text-primary); &--link { background: color-mix(in srgb, #6366f1 22%, transparent); } &--fold_live { background: color-mix(in srgb, var(--color-success, #16a34a) 22%, transparent); } }
+.compaction-log-pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; font-size: 0.8125rem; color: var(--color-text-secondary); button { border: 1px solid var(--color-border-base); border-radius: 0.5rem; background: var(--color-surface-card); padding: 0.375rem 0.75rem; color: var(--color-text-primary); cursor: pointer; &:disabled { opacity: 0.5; cursor: default; } } }

--- a/web/app/src/app/features/memory/compaction-log-page.component.ts
+++ b/web/app/src/app/features/memory/compaction-log-page.component.ts
@@ -15,6 +15,13 @@ import { ConfirmationService } from '../../core/services/confirmation.service';
 import { MemoryService } from '../../core/services/memory.service';
 import { PersonalityService } from '../../core/services/personality.service';
 
+type ChangeDetail = {
+  title: string;
+  explanation: string;
+  before?: CheckpointSnapshot | null;
+  after?: CheckpointSnapshot | null;
+};
+
 @Component({
   selector: 'app-compaction-log-page',
   standalone: true,
@@ -47,6 +54,7 @@ export class CompactionLogPageComponent implements OnInit {
   readonly page = signal(1);
   readonly totalCount = signal(0);
   readonly totalPages = signal(1);
+  readonly changeDetail = signal<ChangeDetail | null>(null);
 
   private static readonly PAGE_SIZE = 20;
 
@@ -91,17 +99,11 @@ export class CompactionLogPageComponent implements OnInit {
     return raw || 'Checkpoint created';
   }
 
-  isExpanded(event: CompactionEvent): boolean {
-    return this.expandedIds().has(event.id);
-  }
+  isExpanded(event: CompactionEvent): boolean { return this.expandedIds().has(event.id); }
 
   toggleExpanded(event: CompactionEvent): void {
     const next = new Set(this.expandedIds());
-    if (next.has(event.id)) {
-      next.delete(event.id);
-    } else {
-      next.add(event.id);
-    }
+    next.has(event.id) ? next.delete(event.id) : next.add(event.id);
     this.expandedIds.set(next);
   }
 
@@ -117,9 +119,7 @@ export class CompactionLogPageComponent implements OnInit {
     else this.collapsedMemoryIds.set(next);
   }
 
-  isLoadedMemoriesCollapsed(event: CompactionEvent): boolean {
-    return this.collapsedLoadedMemoryIds().has(event.id);
-  }
+  isLoadedMemoriesCollapsed(event: CompactionEvent): boolean { return this.collapsedLoadedMemoryIds().has(event.id); }
 
   toggleLoadedMemories(event: CompactionEvent): void {
     const next = new Set(this.collapsedLoadedMemoryIds());
@@ -135,16 +135,29 @@ export class CompactionLogPageComponent implements OnInit {
     return (event.old_scratchpad?.content ?? '') !== (event.new_scratchpad?.content ?? '');
   }
 
+  changeExplanation(event: CompactionEvent, kind: 'summary' | 'scratchpad'): string {
+    if (kind === 'summary') {
+      if (!this.summaryChanged(event)) return 'No change.';
+      return event.summary_explanation?.trim() || 'Conversation summary changed. Open the full change to inspect the before and after states.';
+    }
+    if (!this.scratchpadChanged(event)) return 'No change.';
+    return event.scratchpad_explanation?.trim() || 'Personality scratchpad changed. Open the full change to inspect the before and after states.';
+  }
+
+  openChangeDetail(event: CompactionEvent, kind: 'summary' | 'scratchpad'): void {
+    this.changeDetail.set(kind === 'summary'
+      ? { title: 'Conversation summary change', explanation: this.changeExplanation(event, kind), before: event.old_summary, after: event.new_summary }
+      : { title: 'Scratchpad change', explanation: this.changeExplanation(event, kind), before: event.old_scratchpad, after: event.new_scratchpad });
+  }
+
+  closeChangeDetail(): void { this.changeDetail.set(null); }
+
   mergeSummary(event: CompactionEvent): string {
     const created = event.created_memories?.length ?? 0;
     const updates = this.updatedMemoryEvents(event);
-    if (created === 0 && updates.length === 0) {
-      return 'No memory changes';
-    }
+    if (created === 0 && updates.length === 0) return 'No memory changes';
     const counts = { fold_live: 0, link: 0 } as Record<string, number>;
-    for (const me of updates) {
-      counts[me.merge_type] = (counts[me.merge_type] ?? 0) + 1;
-    }
+    for (const me of updates) counts[me.merge_type] = (counts[me.merge_type] ?? 0) + 1;
     const parts: string[] = [];
     if (created) parts.push(`${created} created`);
     if (counts['fold_live']) parts.push(`${counts['fold_live']} merged`);
@@ -154,95 +167,55 @@ export class CompactionLogPageComponent implements OnInit {
 
   mergeTypeLabel(event: MemoryMergeEvent): string {
     switch (event.merge_type) {
-      case 'link':
-        return 'Linked';
-      case 'fold_live':
-        return 'Memories Merged';
-      default:
-        return 'Updated';
+      case 'link': return 'Linked';
+      case 'fold_live': return 'Memories Merged';
+      default: return 'Updated';
     }
   }
 
-  /** Source memories that went into a fold (stored duplicates_folded is absorb-count = n-1). */
   mergedSourceCount(event: MemoryMergeEvent): number {
     const fromMembers = event.source_members?.length ?? 0;
-    if (fromMembers > 0) {
-      return fromMembers;
-    }
+    if (fromMembers > 0) return fromMembers;
     return Math.max(event.duplicates_folded + 1, 0);
   }
 
-  createdMemories(event: CompactionEvent): CompactionLoadedMemory[] {
-    return event.created_memories ?? [];
-  }
-
-  updatedMemoryEvents(event: CompactionEvent): MemoryMergeEvent[] {
-    // Legacy create-type merge rows may still exist; new creates live on created_memories.
-    return (event.merge_events ?? []).filter(item => item.merge_type !== 'create');
-  }
-
-  isSnapshotReverted(snapshot: CheckpointSnapshot | null | undefined): boolean {
-    return !!snapshot && this.revertedIds().has(snapshot.id);
-  }
+  createdMemories(event: CompactionEvent): CompactionLoadedMemory[] { return event.created_memories ?? []; }
+  updatedMemoryEvents(event: CompactionEvent): MemoryMergeEvent[] { return (event.merge_events ?? []).filter(item => item.merge_type !== 'create'); }
+  isSnapshotReverted(snapshot: CheckpointSnapshot | null | undefined): boolean { return !!snapshot && this.revertedIds().has(snapshot.id); }
 
   async revert(snapshot: CheckpointSnapshot | null | undefined): Promise<void> {
-    if (!snapshot || this.revertingId()) {
-      return;
-    }
-
+    if (!snapshot || this.revertingId()) return;
     const isScratchpad = snapshot.kind === 'scratchpad';
     const confirmed = await this.confirmation.confirm({
       title: isScratchpad ? 'Restore personality scratchpad?' : 'Restore conversation summary?',
       message: isScratchpad
         ? 'This restores the scratchpad for every chat using this personality. Continue?'
         : 'This restores this conversation to the selected checkpoint summary. Continue?',
-      type: 'warning',
-      confirmText: 'Restore',
-      cancelText: 'Cancel',
+      type: 'warning', confirmText: 'Restore', cancelText: 'Cancel',
     });
-    if (!confirmed) {
-      return;
-    }
-
+    if (!confirmed) return;
     const label = snapshot.kind === 'scratchpad' ? 'scratchpad' : 'summary';
-    this.revertingId.set(snapshot.id);
-    this.notice.set(null);
+    this.revertingId.set(snapshot.id); this.notice.set(null);
     this.memoryService.revertSnapshot(snapshot.id).subscribe({
       next: () => {
         this.revertingId.set(null);
-        const next = new Set(this.revertedIds());
-        next.add(snapshot.id);
-        this.revertedIds.set(next);
-        this.notice.set(
-          snapshot.kind === 'scratchpad'
-            ? 'Scratchpad restored for this personality (shared across its chats).'
-            : 'Conversation summary restored for this thread.',
-        );
+        const next = new Set(this.revertedIds()); next.add(snapshot.id); this.revertedIds.set(next);
+        this.notice.set(snapshot.kind === 'scratchpad'
+          ? 'Scratchpad restored for this personality (shared across its chats).'
+          : 'Conversation summary restored for this thread.');
       },
-      error: err => {
-        this.revertingId.set(null);
-        this.error.set(err instanceof Error ? err.message : `Failed to revert ${label}`);
-      },
+      error: err => { this.revertingId.set(null); this.error.set(err instanceof Error ? err.message : `Failed to revert ${label}`); },
     });
   }
 
-  openMemory(memoryId: string | null | undefined): void {
-    if (!memoryId) {
-      return;
-    }
-    void this.router.navigate(['/memories', memoryId]);
-  }
+  openMemory(memoryId: string | null | undefined): void { if (memoryId) void this.router.navigate(['/memories', memoryId]); }
 
   openThread(event: CompactionEvent): void {
-    void this.router.navigate(['/chat', event.chat_id], {
-      queryParams: event.assistant_message_id ? { checkpoint: event.assistant_message_id } : undefined,
-    });
+    void this.router.navigate(['/chat', event.chat_id], { queryParams: event.assistant_message_id ? { checkpoint: event.assistant_message_id } : undefined });
   }
 
   goToPage(page: number): void {
-    if (page < 1 || page > this.totalPages()) {
-      return;
-    }
+    if (page < 1 || page > this.totalPages()) return;
     this.load(page);
   }
 }


### PR DESCRIPTION
Fixes #41.

## Diagnosis

Checkpoint history already stores the authoritative before/after conversation summary and personality scratchpad on a `CompactionEvent`. Those snapshots are content-addressed and can be reused by adjacent checkpoints, so a human-readable explanation belongs to the transition/event, not to the snapshot itself.

The existing UI rendered the full old/new text inline, forcing users to infer the meaningful change from two large blocks.

## Test-first evidence

The first commit added a frontend regression with `summary_explanation` and `scratchpad_explanation`. On the unmodified implementation, Frontend PR Validation went red with exactly one failing test (1111 passed / 1 skipped): the explanation text was absent. Type-check/SDK checks and the local-LLM E2E run passed, so this was the intended product regression rather than a setup failure.

## Implementation

- Add summary and scratchpad explanation metadata to the existing compaction event schema/model.
- Persist scratchpad explanation when the event opens and summary explanation when the new summary is attached.
- Generate each explanation as best-effort audit metadata from the authoritative before/after states. Explanation failure does not fail the checkpoint.
- Surface explanation fields in the web model.
- Replace inline giant before/after blocks with short explanation snippets.
- Keep the complete before/after text and existing revert controls in a focused change-details modal.
- Preserve a fallback message for historical checkpoints that predate explanation metadata.
- Add datastore coverage for explanation persistence and frontend coverage that full text remains hidden until the user opens the detail view.

## Tradeoff

This isolated implementation uses an additional small archival inference for each changed summary/scratchpad transition rather than coupling #64 to other in-flight scratchpad-generation work. That keeps the PR independent, but adds archival-call cost/latency at checkpoint time. The explanation is descriptive audit metadata, not an authority on whether the underlying change was correct.

## Earlier BSD boundary

An earlier planning-stage BSD pass classified the implementation plan as BOUNDED. At that stage PPI/evidence mass were unavailable because the supplied source observations were not independently certified by BSD and provenance remained caller-supplied/unverified. That pass was used to constrain scope and expose the snapshot-vs-transition distinction, not as proof that the implementation was correct.

Passing CI establishes the encoded persistence/display behavior, not that every model-generated explanation is accurate or useful.

## BSD rerun — BSD-main (17), coding profile

Current-head evaluation: `eval-8d85e1b6-4b39-450d-87c2-b19f518decf5`.

- structural reasoning reliability: `0.833333` (`MEASURED`)
- evidence mass: `1.000000` (`MEASURED`; host-bound coverage/engagement, not truth probability)
- canonical PPI: `0.172414` (`MEASURED`, `ppi-trace-canonical-v0.2.0`)
- canonical comparison weight: implementation-correct `0.500` / partial-correctness `0.500` (`MEASURED` for both frames)
- unknown-unknown indicator: `BOUNDED [0.020833, 0.270833]` (`MISSING_VECTOR_DIMENSIONS_PRESERVED_AS_INTERVAL`)
- response policy: `DIRECT` with `MISSING_INFORMATION`, `SCOPE_LIMITED`

Current-head diff, GitHub Actions, mergeability, and maintainer-review observations were carried through the exchange receipt sidecar as host-bound `HOST_BOUND_FALLBACK` evidence. In BSD-main (17), distinct bound receipts count fully toward `E_mass` coverage; the host-mediated retrieval path remains separately recorded as `transport_quality=0.75` and is applied once downstream to canonical support. That establishes host-observed retrieval/binding, not that BSD independently proves the semantic interpretation or that the implementation is true/correct.

The transition-metadata mechanism is represented by the current diff and current PR Validation, Frontend PR Validation, local-LLM E2E, and mock E2E are green. The architecture remains genuinely contested because the maintainer said the original intent was to generate explanations inline with the updates themselves, while this head adds a separate archival inference. The PR is also currently non-mergeable, so the equal BSD comparison weight should not be read as an acceptance verdict.