### PR TITLE
Remove deprecated scratchpad history UI

### DIFF
--- a/web/app/src/app/features/personality/detail/personality-edit-modal.component.ts
+++ b/web/app/src/app/features/personality/detail/personality-edit-modal.component.ts
@@ -239,27 +239,6 @@ const DEFAULT_THUMBNAIL_CIRCLE: PersonalityThumbnailCircle = { cx: 0.5, cy: 0.42
 
                 @if (scratchpadAdvancedOpen()) {
                   <div class="flex flex-col gap-4 border-t border-border-base px-3 pb-3 pt-3">
-
-                    @if (scratchpadHistory().length > 0) {
-                      <div class="flex flex-col gap-2">
-                        <p class="text-xs font-semibold text-(--color-text-secondary)">Revert to a previous version</p>
-                        <ul class="flex flex-col divide-y divide-border-base rounded-lg border border-border-base">
-                          @for (version of scratchpadHistory(); track $index; let i = $index) {
-                            <li class="flex items-center justify-between gap-3 px-3 py-2">
-                              <p class="min-w-0 flex-1 truncate text-xs text-(--color-text-secondary)" [title]="version">
-                                <span class="mr-1.5 font-semibold text-(--color-text-primary)">v{{ scratchpadHistory().length - i }}</span>{{ version || '(empty)' }}
-                              </p>
-                              <button
-                                type="button"
-                                class="shrink-0 rounded-md border border-border-base bg-(--color-surface-input) px-2 py-0.5 text-xs text-(--color-text-primary) hover:bg-(--color-surface-card)"
-                                (click)="revertScratchpad(version)"
-                              >Restore</button>
-                            </li>
-                          }
-                        </ul>
-                      </div>
-                    }
-
                     <label class="flex flex-col gap-1">
                       <span class="text-xs font-semibold text-(--color-text-secondary)">Custom scratchpad update prompt</span>
                       @if (promptDefaultsLoading()) {
@@ -277,7 +256,6 @@ const DEFAULT_THUMBNAIL_CIRCLE: PersonalityThumbnailCircle = { cx: 0.5, cy: 0.42
                         <span class="text-[11px] text-(--color-text-muted)">Leave blank to use the system default. Overrides the prompt the agent receives when writing a scratchpad checkpoint.</span>
                       }
                     </label>
-
                   </div>
                 }
               </div>
@@ -411,7 +389,6 @@ export class PersonalityEditModalComponent {
   readonly promptDefaultsLoading = signal(false);
   readonly promptDefaultsError = signal(false);
 
-  readonly scratchpadHistory = computed(() => this.personality()?.scratchpad_history ?? []);
   readonly systemPromptHardLimitLabel = TEXT_LIMIT_HARD_MAX.toLocaleString();
   readonly systemPromptWarningLimitLabel = TEXT_LIMIT_WARNING_THRESHOLD.toLocaleString();
   readonly systemPromptCount = computed(() => this.draft()?.system_prompt.length ?? 0);
@@ -632,10 +609,6 @@ export class PersonalityEditModalComponent {
         },
       });
     }
-  }
-
-  revertScratchpad(content: string): void {
-    this.setDraftField('scratchpad', content);
   }
 
   viewMemories(): void {

--- a/web/app/src/app/features/personality/detail/personality-scratchpad-history-deprecation.spec.ts
+++ b/web/app/src/app/features/personality/detail/personality-scratchpad-history-deprecation.spec.ts
@@ -38,7 +38,12 @@ describe('personality scratchpad history deprecation', () => {
     const personalityService = {
       updatePersonality: vi.fn().mockReturnValue(of(personality)),
       deletePersonality: vi.fn().mockReturnValue(of(void 0)),
-    } as unknown as Pick<MockedObject<PersonalityService>, 'updatePersonality' | 'deletePersonality'>;
+      getPromptDefaults: vi.fn().mockReturnValue(of({
+        scratchpad_update_prompt: 'Default scratchpad update prompt',
+        memory_query_prompt: 'Default memory query prompt',
+        memory_extraction_prompt: 'Default memory extraction prompt',
+      })),
+    } as unknown as Pick<MockedObject<PersonalityService>, 'updatePersonality' | 'deletePersonality' | 'getPromptDefaults'>;
 
     await TestBed.configureTestingModule({
       imports: [PersonalityEditModalComponent],

--- a/web/app/src/app/features/personality/detail/personality-scratchpad-history-deprecation.spec.ts
+++ b/web/app/src/app/features/personality/detail/personality-scratchpad-history-deprecation.spec.ts
@@ -1,0 +1,94 @@
+import type { MockedObject } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient, withXhr } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { Personality } from '../../../core/models/personality.model';
+import { PersonalityService } from '../../../core/services/personality.service';
+import { ImageGalleryService } from '../../../core/services/image-gallery.service';
+import { ConfirmationService } from '../../../core/services/confirmation.service';
+import { FileAttachmentService } from '../../../core/services/file-attachment.service';
+import { PersonalityEditModalComponent } from './personality-edit-modal.component';
+
+describe('personality scratchpad history deprecation', () => {
+  let fixture: ComponentFixture<PersonalityEditModalComponent>;
+
+  const personality: Personality = {
+    id: 'p-history',
+    name: 'History test',
+    system_prompt: 'Prompt',
+    scratchpad: 'Current scratchpad',
+    scratchpad_history: ['Older scratchpad one', 'Older scratchpad two'],
+    scratchpad_update_prompt: '',
+    auto_pin_memories: false,
+    expressions_enabled: true,
+    image_style: 'auto',
+    cover_image_id: null,
+    cover_image_url: null,
+    accent_color: null,
+    thumbnail_circle: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    stats: { chat_count: 0, last_used_at: null },
+  };
+
+  beforeEach(async () => {
+    const personalityService = {
+      updatePersonality: vi.fn().mockReturnValue(of(personality)),
+      deletePersonality: vi.fn().mockReturnValue(of(void 0)),
+    } as unknown as Pick<MockedObject<PersonalityService>, 'updatePersonality' | 'deletePersonality'>;
+
+    await TestBed.configureTestingModule({
+      imports: [PersonalityEditModalComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(withXhr()),
+        { provide: PersonalityService, useValue: personalityService },
+        {
+          provide: ImageGalleryService,
+          useValue: {
+            listImages: () => of({ results: [], total_count: 0, page: 1, page_size: 40 }),
+            getImageUrl: () => '/img',
+          },
+        },
+        {
+          provide: FileAttachmentService,
+          useValue: {
+            listFileAttachments: () => of({ results: [], total_count: 0, page: 1, page_size: 40 }),
+            uploadPersonalityFileAttachment: () => of(null),
+            deleteFileAttachment: () => of(void 0),
+          },
+        },
+        {
+          provide: ConfirmationService,
+          useValue: {
+            confirm: async () => true,
+            alert: async () => undefined,
+            confirmDiscardChanges: async () => true,
+          },
+        },
+        { provide: Router, useValue: { navigate: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PersonalityEditModalComponent);
+    fixture.componentRef.setInput('open', true);
+    fixture.componentRef.setInput('personality', personality);
+    fixture.detectChanges();
+  });
+
+  it('does not render legacy scratchpad history or restore controls', () => {
+    fixture.componentInstance.toggleScratchpadAdvanced();
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).not.toContain('Revert to a previous version');
+    expect(text).not.toContain('Older scratchpad one');
+    expect(text).not.toContain('Older scratchpad two');
+    expect(text).not.toContain('Restore');
+
+    expect(text).toContain('Custom scratchpad update prompt');
+  });
+});


### PR DESCRIPTION
Fixes #44.

## Diagnosis

The personality edit modal still rendered the deprecated last-10 scratchpad history inside `Advanced scratchpad settings`, including inline restore controls. The current scratchpad textarea and custom scratchpad update prompt are separate controls and do not require that history UI.

## Test-first evidence

The first regression commit initially exposed a test-harness defect because its `PersonalityService` mock omitted `getPromptDefaults()`. That mock was corrected without changing production code. On the corrected test-only head, Frontend PR Validation then failed at the intended assertion: the rendered modal still contained `Revert to a previous version`, both historical scratchpad values, and `Restore` controls. Both E2E workflows passed on that head.

## Implementation

- Removed the deprecated scratchpad history/revert presentation from the personality edit modal.
- Removed the now-unused `scratchpadHistory` computed value and `revertScratchpad()` UI helper.
- Preserved the current scratchpad textarea.
- Preserved Advanced scratchpad settings and the custom scratchpad update-prompt editor.
- Left persisted `scratchpad_history` model/storage compatibility intact; this PR does not delete backend history data.

## BSD boundary

BSD classified the represented scope as BOUNDED. The narrow UI-only boundary comes from the issue text and source trace; BSD does not establish causal truth or prefer that alternative. PPI was unavailable (`CANONICAL_SUPPORT_UNAVAILABLE`).

Passing tests will establish that the deprecated edit-screen controls no longer render under the encoded condition, not that every possible historical scratchpad consumer elsewhere has been removed.

## BSD rerun — coding profile / current engine

Reran the UI-removal slice under the packaged `coding` engineering profile (`evidence_floor=0.40`, `ppi_base_sensitivity=4.0`) using the canonical implementation-correctness output space. The bounded mechanistic chain is `CERTIFIED_WITH_LIMITS` at structural reliability `0.833333`; evidence mass is `1.0`. The canonical mapping is configured and comparable, but PPI is `UNAVAILABLE` specifically because `INSUFFICIENT_SUPPORTED_STRUCTURES`: the competing/falsification frame did not independently earn positive support. Response policy is `DIRECT` with `MISSING_INFORMATION`, `PPI_UNAVAILABLE`, and `SCOPE_LIMITED` disclosures.

The repository source registry remains `CALLER_SUPPLIED_UNVERIFIED` / `UNVERIFIED_REGISTRY`. A direct BSD `code.github` verification attempt returned `RETRIEVAL_FAILED` because the execution environment could not resolve external DNS, so this rerun does not claim adapter-verified GitHub provenance. Implementation and tests remain one dependent evidence group; `1.0` is coverage, not truth probability. The result supports only the represented edit-modal removal/preservation behavior, not absence of every historical scratchpad consumer elsewhere; CI/runtime verification remains the acceptance gate.