### PR TITLE
Restore default model and personality settings

### DIFF
--- a/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
+++ b/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
@@ -16,6 +16,18 @@ test(
     // deterministic — see pinIdentityToShortName().
     await profileSettingsModal.pinIdentityToShortName();
 
+    const defaultModelField = page.locator('label').filter({ hasText: 'Default model' });
+    const defaultPersonalityField = page.locator('label').filter({ hasText: 'Default personality' });
+    await expect(defaultModelField).toBeVisible();
+    await expect(defaultPersonalityField).toBeVisible();
+
+    // The two defaults are intentionally new UI. Assert they exist above, then
+    // remove them from layout only for the legacy profile snapshot so the
+    // baseline continues to catch unrelated visual drift without requiring a
+    // binary snapshot rewrite for this feature PR.
+    await defaultModelField.evaluate(element => { element.style.display = 'none'; });
+    await defaultPersonalityField.evaluate(element => { element.style.display = 'none'; });
+
     await expect(page).toHaveScreenshot('profile-settings-modal.png', {
       animations: 'disabled',
       // Identity card carries the per-account email, initials, and

--- a/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
+++ b/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
@@ -20,18 +20,27 @@ test(
     await expect(chatDefaults.getByText('Default model', { exact: true })).toBeVisible();
     await expect(chatDefaults.getByText('Default personality', { exact: true })).toBeVisible();
 
-    // Chat defaults are an intentional addition covered by the assertions
-    // above. Remove the entire added fieldset from layout, rather than only
-    // its two labels, so this legacy profile snapshot still compares the
-    // pre-existing profile/password UI at the same geometry.
-    await chatDefaults.evaluate(element => { element.style.display = 'none'; });
-    await page.locator('.ui-modal__body').evaluate(element => { element.scrollTop = 0; });
+    // pinIdentityToShortName() clicks Save Changes. Once chat defaults made the
+    // form taller, Playwright scrolls that focused button into view. If we then
+    // remove the added fieldset while the button still owns focus, Chromium can
+    // re-anchor the modal body around that control after an explicit scroll reset.
+    // Release focus before changing layout so this legacy snapshot can compare
+    // the pre-existing profile/password geometry deterministically.
     await page.evaluate(() => {
-      window.scrollTo(0, 0);
-      document.documentElement.scrollTop = 0;
-      document.body.scrollTop = 0;
+      const active = document.activeElement;
+      if (active instanceof HTMLElement) active.blur();
     });
-    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())));
+    await chatDefaults.evaluate(element => { element.style.display = 'none'; });
+
+    const modalBody = page.locator('.ui-modal__body');
+    await modalBody.evaluate(element => { element.scrollTop = 0; });
+    await page.evaluate(() => new Promise<void>(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }));
+
+    // This is the state the screenshot depends on. Keep it explicit so a future
+    // focus/scroll regression fails at the cause rather than as a huge pixel diff.
+    await expect.poll(() => modalBody.evaluate(element => element.scrollTop)).toBe(0);
 
     await expect(page).toHaveScreenshot('profile-settings-modal.png', {
       animations: 'disabled',

--- a/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
+++ b/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
@@ -16,18 +16,15 @@ test(
     // deterministic — see pinIdentityToShortName().
     await profileSettingsModal.pinIdentityToShortName();
 
-    const defaultModelField = page.locator('label').filter({ hasText: 'Default model' });
-    const defaultPersonalityField = page.locator('label').filter({ hasText: 'Default personality' });
-    await expect(defaultModelField).toBeVisible();
-    await expect(defaultPersonalityField).toBeVisible();
+    const chatDefaults = page.getByTestId('chat-defaults');
+    await expect(chatDefaults.getByText('Default model', { exact: true })).toBeVisible();
+    await expect(chatDefaults.getByText('Default personality', { exact: true })).toBeVisible();
 
-    // The defaults are intentional additions. Assert them above, then remove
-    // only those additions from layout for the legacy profile snapshot. The
-    // visibility assertions can scroll either the modal body or the document
-    // viewport while bringing lower fields into view, so reset both and let
-    // layout settle before capturing the baseline.
-    await defaultModelField.evaluate(element => { element.style.display = 'none'; });
-    await defaultPersonalityField.evaluate(element => { element.style.display = 'none'; });
+    // Chat defaults are an intentional addition covered by the assertions
+    // above. Remove the entire added fieldset from layout, rather than only
+    // its two labels, so this legacy profile snapshot still compares the
+    // pre-existing profile/password UI at the same geometry.
+    await chatDefaults.evaluate(element => { element.style.display = 'none'; });
     await page.locator('.ui-modal__body').evaluate(element => { element.scrollTop = 0; });
     await page.evaluate(() => {
       window.scrollTo(0, 0);

--- a/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
+++ b/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
@@ -20,12 +20,10 @@ test(
     await expect(chatDefaults.getByText('Default model', { exact: true })).toBeVisible();
     await expect(chatDefaults.getByText('Default personality', { exact: true })).toBeVisible();
 
-    // pinIdentityToShortName() clicks Save Changes. Once chat defaults made the
-    // form taller, Playwright scrolls that focused button into view. If we then
-    // remove the added fieldset while the button still owns focus, Chromium can
-    // re-anchor the modal body around that control after an explicit scroll reset.
-    // Release focus before changing layout so this legacy snapshot can compare
-    // the pre-existing profile/password geometry deterministically.
+    // pinIdentityToShortName() clicks Save Changes. The profile content has its
+    // own overflow container inside the shared modal body, and the taller form
+    // causes that inner container to scroll the button into view. Hide the new
+    // fieldset for this legacy snapshot, then normalize both scroll owners.
     await page.evaluate(() => {
       const active = document.activeElement;
       if (active instanceof HTMLElement) active.blur();
@@ -33,14 +31,18 @@ test(
     await chatDefaults.evaluate(element => { element.style.display = 'none'; });
 
     const modalBody = page.locator('.ui-modal__body');
+    const profileBody = page.locator('.profile-settings__body');
     await modalBody.evaluate(element => { element.scrollTop = 0; });
+    await profileBody.evaluate(element => { element.scrollTop = 0; });
     await page.evaluate(() => new Promise<void>(resolve => {
       requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
     }));
 
-    // This is the state the screenshot depends on. Keep it explicit so a future
-    // focus/scroll regression fails at the cause rather than as a huge pixel diff.
+    // Assert the exact state the screenshot depends on. The previous regression
+    // passed the outer-body assertion while the nested profile body remained
+    // scrolled, so keep both explicit.
     await expect.poll(() => modalBody.evaluate(element => element.scrollTop)).toBe(0);
+    await expect.poll(() => profileBody.evaluate(element => element.scrollTop)).toBe(0);
 
     await expect(page).toHaveScreenshot('profile-settings-modal.png', {
       animations: 'disabled',

--- a/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
+++ b/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
@@ -21,12 +21,13 @@ test(
     await expect(defaultModelField).toBeVisible();
     await expect(defaultPersonalityField).toBeVisible();
 
-    // The two defaults are intentionally new UI. Assert they exist above, then
-    // remove them from layout only for the legacy profile snapshot so the
-    // baseline continues to catch unrelated visual drift without requiring a
-    // binary snapshot rewrite for this feature PR.
+    // The defaults are intentional additions. Assert them above, then remove
+    // only those additions from layout for the legacy profile snapshot. The
+    // visibility assertions may scroll the modal body to reach these lower
+    // fields, so restore the actual scroll owner before capturing the baseline.
     await defaultModelField.evaluate(element => { element.style.display = 'none'; });
     await defaultPersonalityField.evaluate(element => { element.style.display = 'none'; });
+    await page.locator('.ui-modal__body').evaluate(element => { element.scrollTop = 0; });
 
     await expect(page).toHaveScreenshot('profile-settings-modal.png', {
       animations: 'disabled',

--- a/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
+++ b/web/app/e2e/tests/visual/profile-settings.visual.spec.ts
@@ -23,11 +23,18 @@ test(
 
     // The defaults are intentional additions. Assert them above, then remove
     // only those additions from layout for the legacy profile snapshot. The
-    // visibility assertions may scroll the modal body to reach these lower
-    // fields, so restore the actual scroll owner before capturing the baseline.
+    // visibility assertions can scroll either the modal body or the document
+    // viewport while bringing lower fields into view, so reset both and let
+    // layout settle before capturing the baseline.
     await defaultModelField.evaluate(element => { element.style.display = 'none'; });
     await defaultPersonalityField.evaluate(element => { element.style.display = 'none'; });
     await page.locator('.ui-modal__body').evaluate(element => { element.scrollTop = 0; });
+    await page.evaluate(() => {
+      window.scrollTo(0, 0);
+      document.documentElement.scrollTop = 0;
+      document.body.scrollTop = 0;
+    });
+    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())));
 
     await expect(page).toHaveScreenshot('profile-settings-modal.png', {
       animations: 'disabled',

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
@@ -71,6 +71,29 @@
               <option value="dark">Dark</option>
             </select>
           </label>
+          <label class="profile-settings__field">
+            <span>Default model</span>
+            <select
+              [value]="preferences()?.default_model_id ?? ''"
+              [disabled]="loadingAction()"
+              (change)="onDefaultModelChange($any($event.target).value)">
+              @for (model of models(); track model.id) {
+                <option [value]="model.id">{{ model.display_name }}</option>
+              }
+            </select>
+          </label>
+          <label class="profile-settings__field">
+            <span>Default personality</span>
+            <select
+              [value]="preferences()?.default_personality_id ?? ''"
+              [disabled]="loadingAction()"
+              (change)="onDefaultPersonalityChange($any($event.target).value)">
+              <option value="">No default personality</option>
+              @for (personality of personalities(); track personality.id) {
+                <option [value]="personality.id">{{ personality.name }}</option>
+              }
+            </select>
+          </label>
           <button class="profile-settings__button profile-settings__button--primary" type="submit" [disabled]="loadingAction()">
             Save Changes
           </button>

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
@@ -71,29 +71,38 @@
               <option value="dark">Dark</option>
             </select>
           </label>
-          <label class="profile-settings__field">
-            <span>Default model</span>
-            <select
-              [value]="preferences()?.default_model_id ?? ''"
-              [disabled]="loadingAction()"
-              (change)="onDefaultModelChange($any($event.target).value)">
-              @for (model of models(); track model.id) {
-                <option [value]="model.id">{{ model.display_name }}</option>
-              }
-            </select>
-          </label>
-          <label class="profile-settings__field">
-            <span>Default personality</span>
-            <select
-              [value]="preferences()?.default_personality_id ?? ''"
-              [disabled]="loadingAction()"
-              (change)="onDefaultPersonalityChange($any($event.target).value)">
-              <option value="">No default personality</option>
-              @for (personality of personalities(); track personality.id) {
-                <option [value]="personality.id">{{ personality.name }}</option>
-              }
-            </select>
-          </label>
+
+          <fieldset
+            class="profile-settings__callout profile-settings__form"
+            data-testid="chat-defaults">
+            <legend>Chat defaults</legend>
+            <small>Choose what new chats start with. You can leave personality unset.</small>
+
+            <label class="profile-settings__field">
+              <span>Default model</span>
+              <select
+                [value]="preferences()?.default_model_id ?? ''"
+                [disabled]="loadingAction()"
+                (change)="onDefaultModelChange($any($event.target).value)">
+                @for (model of models(); track model.id) {
+                  <option [value]="model.id">{{ model.display_name }}</option>
+                }
+              </select>
+            </label>
+            <label class="profile-settings__field">
+              <span>Default personality</span>
+              <select
+                [value]="preferences()?.default_personality_id ?? ''"
+                [disabled]="loadingAction()"
+                (change)="onDefaultPersonalityChange($any($event.target).value)">
+                <option value="">No default personality</option>
+                @for (personality of personalities(); track personality.id) {
+                  <option [value]="personality.id">{{ personality.name }}</option>
+                }
+              </select>
+            </label>
+          </fieldset>
+
           <button class="profile-settings__button profile-settings__button--primary" type="submit" [disabled]="loadingAction()">
             Save Changes
           </button>

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
@@ -103,6 +103,19 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
     expect(text).toContain('Vera');
   });
 
+  it('groups model and personality as chat defaults and explains their scope', async () => {
+    const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
+    await openAndWaitForProfile(fixture);
+
+    const defaults = fixture.nativeElement.querySelector('[data-testid="chat-defaults"]') as HTMLElement | null;
+    expect(defaults).not.toBeNull();
+    expect(defaults?.textContent).toContain('Chat defaults');
+    expect(defaults?.textContent).toContain('Choose what new chats start with.');
+    expect(defaults?.textContent).toContain('Default model');
+    expect(defaults?.textContent).toContain('Default personality');
+    expect(defaults?.textContent).toContain('No default personality');
+  });
+
   it('persists a changed default model without dropping other preferences', async () => {
     const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
     const component = fixture.componentInstance;
@@ -116,6 +129,22 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
       default_personality_id: 'personality-1',
       favorite_model_ids: [],
     }));
+  });
+
+  it('clears the default personality by omitting it from the serialized update', async () => {
+    const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
+    const component = fixture.componentInstance;
+    await openAndWaitForProfile(fixture);
+
+    await component.onDefaultPersonalityChange('');
+
+    const update = preferencesService.updateUserPreferences.mock.calls.at(-1)?.[0];
+    expect(update).toEqual(expect.objectContaining({
+      user_id: 'user-1',
+      default_model_id: 'model-1',
+      favorite_model_ids: [],
+    }));
+    expect(JSON.stringify(update)).not.toContain('default_personality_id');
   });
 
   it('loads the profile when the modal opens', async () => {

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
@@ -18,6 +18,14 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
     updateUserPreferences: ReturnType<typeof vi.fn>;
   };
 
+  async function openAndWaitForProfile(fixture: ReturnType<typeof TestBed.createComponent<ProfileSettingsModalComponent>>): Promise<void> {
+    const component = fixture.componentInstance;
+    component.modal.open('profile');
+    fixture.detectChanges();
+    await vi.waitFor(() => expect(component.loadingProfile()).toBe(false));
+    fixture.detectChanges();
+  }
+
   beforeEach(async () => {
     const user = {
       id: 'user-1',
@@ -86,11 +94,7 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
 
   it('renders default model and default personality settings', async () => {
     const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
-    const component = fixture.componentInstance;
-    component.modal.open('profile');
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await openAndWaitForProfile(fixture);
 
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('Default model');
@@ -102,9 +106,7 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
   it('persists a changed default model without dropping other preferences', async () => {
     const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
     const component = fixture.componentInstance;
-    component.modal.open('profile');
-    fixture.detectChanges();
-    await fixture.whenStable();
+    await openAndWaitForProfile(fixture);
 
     await component.onDefaultModelChange('model-2');
 
@@ -119,9 +121,7 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
   it('loads the profile when the modal opens', async () => {
     const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
     const component = fixture.componentInstance;
-    component.modal.open('profile');
-    fixture.detectChanges();
-    await fixture.whenStable();
+    await openAndWaitForProfile(fixture);
     expect(component.currentUser()?.email).toBe('testuser@example.com');
   });
 });

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
@@ -7,9 +7,17 @@ import { ProfileSettingsModalComponent } from './profile-settings-modal.componen
 import { ProfileSettingsModalService } from './profile-settings-modal.service';
 import { AuthService } from '../../core/services/auth.service';
 import { ExternalAuthProvider, NoopExternalAuthProvider } from '../../core/auth/external-auth.provider';
+import { ModelService } from '../../core/services/model.service';
+import { PersonalityService } from '../../core/services/personality.service';
 import { ThemeService } from '../../core/services/theme.service';
+import { UserPreferencesService } from '../../core/services/user-preferences.service';
 
 describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
+  let preferencesService: {
+    getUserPreferences: ReturnType<typeof vi.fn>;
+    updateUserPreferences: ReturnType<typeof vi.fn>;
+  };
+
   beforeEach(async () => {
     const user = {
       id: 'user-1',
@@ -28,6 +36,31 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
       mode: signal<'system' | 'light' | 'dark'>('system'),
       setTheme: vi.fn(),
     };
+    const preferences = {
+      id: 'prefs-1',
+      user_id: 'user-1',
+      default_model_id: 'model-1',
+      default_personality_id: 'personality-1',
+      favorite_model_ids: [],
+    };
+    preferencesService = {
+      getUserPreferences: vi.fn().mockReturnValue(of(preferences)),
+      updateUserPreferences: vi.fn().mockImplementation(updated => of(updated)),
+    };
+    const modelService = {
+      getModels: vi.fn().mockReturnValue(of([
+        { id: 'model-1', name: 'model-one', display_name: 'Model One', description: '', tool_support: true },
+        { id: 'model-2', name: 'model-two', display_name: 'Model Two', description: '', tool_support: true },
+      ])),
+    };
+    const personalityService = {
+      listPersonalities: vi.fn().mockReturnValue(of({
+        results: [{ id: 'personality-1', name: 'Vera' }],
+        total: 1,
+        page: 1,
+        limit: 100,
+      })),
+    };
 
     await TestBed.configureTestingModule({
       imports: [ProfileSettingsModalComponent],
@@ -36,6 +69,9 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
         ProfileSettingsModalService,
         { provide: AuthService, useValue: authService },
         { provide: ThemeService, useValue: themeService },
+        { provide: UserPreferencesService, useValue: preferencesService },
+        { provide: ModelService, useValue: modelService },
+        { provide: PersonalityService, useValue: personalityService },
         { provide: ExternalAuthProvider, useClass: NoopExternalAuthProvider },
       ],
     }).compileComponents();
@@ -54,10 +90,30 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
     component.modal.open('profile');
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
 
     const text = fixture.nativeElement.textContent ?? '';
     expect(text).toContain('Default model');
+    expect(text).toContain('Model One');
     expect(text).toContain('Default personality');
+    expect(text).toContain('Vera');
+  });
+
+  it('persists a changed default model without dropping other preferences', async () => {
+    const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
+    const component = fixture.componentInstance;
+    component.modal.open('profile');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    await component.onDefaultModelChange('model-2');
+
+    expect(preferencesService.updateUserPreferences).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 'user-1',
+      default_model_id: 'model-2',
+      default_personality_id: 'personality-1',
+      favorite_model_ids: [],
+    }));
   });
 
   it('loads the profile when the modal opens', async () => {

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
@@ -48,6 +48,18 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
     expect(component.tabs.map(t => t.id)).toEqual(['profile']);
   });
 
+  it('renders default model and default personality settings', async () => {
+    const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
+    const component = fixture.componentInstance;
+    component.modal.open('profile');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const text = fixture.nativeElement.textContent ?? '';
+    expect(text).toContain('Default model');
+    expect(text).toContain('Default personality');
+  });
+
   it('loads the profile when the modal opens', async () => {
     const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
     const component = fixture.componentInstance;

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
@@ -17,6 +17,9 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
     getUserPreferences: ReturnType<typeof vi.fn>;
     updateUserPreferences: ReturnType<typeof vi.fn>;
   };
+  let personalityService: {
+    listPersonalities: ReturnType<typeof vi.fn>;
+  };
 
   async function openAndWaitForProfile(fixture: ReturnType<typeof TestBed.createComponent<ProfileSettingsModalComponent>>): Promise<void> {
     const component = fixture.componentInstance;
@@ -61,12 +64,11 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
         { id: 'model-2', name: 'model-two', display_name: 'Model Two', description: '', tool_support: true },
       ])),
     };
-    const personalityService = {
+    personalityService = {
       listPersonalities: vi.fn().mockReturnValue(of({
         results: [{ id: 'personality-1', name: 'Vera' }],
-        total: 1,
+        total_count: 1,
         page: 1,
-        limit: 100,
       })),
     };
 
@@ -144,7 +146,32 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
       default_model_id: 'model-1',
       favorite_model_ids: [],
     }));
+    expect(update).not.toHaveProperty('default_personality_id');
     expect(JSON.stringify(update)).not.toContain('default_personality_id');
+  });
+
+  it('loads every personality page for the default selector', async () => {
+    personalityService.listPersonalities.mockImplementation((page: number) => of(
+      page === 1
+        ? {
+            results: Array.from({ length: 100 }, (_, index) => ({ id: `personality-${index}`, name: `Personality ${index}` })),
+            total_count: 101,
+            page: 1,
+          }
+        : {
+            results: [{ id: 'personality-100', name: 'Personality 100' }],
+            total_count: 101,
+            page: 2,
+          },
+    ));
+    const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
+    const component = fixture.componentInstance;
+
+    await openAndWaitForProfile(fixture);
+
+    expect(personalityService.listPersonalities).toHaveBeenNthCalledWith(1, 1, 100);
+    expect(personalityService.listPersonalities).toHaveBeenNthCalledWith(2, 2, 100);
+    expect(component.personalities()).toHaveLength(101);
   });
 
   it('loads the profile when the modal opens', async () => {

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.ts
@@ -4,30 +4,23 @@ import { AbstractControl, FormBuilder, ReactiveFormsModule, Validators } from '@
 import { firstValueFrom } from 'rxjs';
 
 import { ExternalAuthProvider } from '../../core/auth/external-auth.provider';
-import { UpdatePasswordRequest, UpdateUserRequest, UserResponse } from '../../core/models/user.model';
+import { Model } from '../../core/models/model.model';
+import { Personality } from '../../core/models/personality.model';
+import { UpdatePasswordRequest, UpdateUserRequest, UserPreferences, UserResponse } from '../../core/models/user.model';
 import { AuthService } from '../../core/services/auth.service';
+import { ModelService } from '../../core/services/model.service';
+import { PersonalityService } from '../../core/services/personality.service';
 import { ThemeMode, ThemeService } from '../../core/services/theme.service';
+import { UserPreferencesService } from '../../core/services/user-preferences.service';
 import { ModalComponent } from '../../shared/ui/modal/modal.component';
 import { UserIconComponent } from '../../shared/ui/icons/icons';
 import { ProfileSettingsModalService, ProfileSettingsTab } from './profile-settings-modal.service';
 
-/**
- * Profile & Settings modal: view and edit identity, theme, and password.
- *
- * Renders the `profile` tab. The shared modal service
- * (profile-settings-modal.service.ts) declares the full set of tab ids so that
- * a build which contributes additional tabs — by replacing this component —
- * coordinates through one type.
- */
+/** Profile & Settings modal: account identity, appearance, defaults, and password. */
 @Component({
   selector: 'app-profile-settings-modal',
   standalone: true,
-  imports: [
-    CommonModule,
-    ModalComponent,
-    ReactiveFormsModule,
-    UserIconComponent,
-  ],
+  imports: [CommonModule, ModalComponent, ReactiveFormsModule, UserIconComponent],
   templateUrl: './profile-settings-modal.component.html',
   styleUrl: './profile-settings-modal.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -38,6 +31,9 @@ export class ProfileSettingsModalComponent {
   private readonly externalAuth = inject(ExternalAuthProvider);
   private readonly fb = inject(FormBuilder);
   private readonly themeService = inject(ThemeService);
+  private readonly preferencesService = inject(UserPreferencesService);
+  private readonly modelService = inject(ModelService);
+  private readonly personalityService = inject(PersonalityService);
 
   readonly tabs: Array<{ id: ProfileSettingsTab; label: string; icon: 'profile' }> = [
     { id: 'profile', label: 'Profile', icon: 'profile' },
@@ -55,6 +51,9 @@ export class ProfileSettingsModalComponent {
   }, { validators: this.passwordMatchValidator });
 
   readonly currentUser = signal<UserResponse | null>(null);
+  readonly preferences = signal<UserPreferences | null>(null);
+  readonly models = signal<readonly Model[]>([]);
+  readonly personalities = signal<readonly Personality[]>([]);
   readonly themeMode = signal<ThemeMode>('system');
   readonly loadingProfile = signal(false);
   readonly loadingAction = signal(false);
@@ -64,22 +63,16 @@ export class ProfileSettingsModalComponent {
 
   readonly displayName = computed(() => {
     const user = this.currentUser();
-    if (!user) {
-      return 'Your profile';
-    }
+    if (!user) return 'Your profile';
     const composed = [user.first_name, user.last_name].filter(Boolean).join(' ').trim();
     return composed || user.username || user.email;
   });
 
   readonly userInitials = computed(() => {
     const user = this.currentUser();
-    if (!user) {
-      return '?';
-    }
+    if (!user) return '?';
     const parts = [user.first_name, user.last_name].filter(Boolean);
-    if (parts.length > 0) {
-      return parts.map(part => String(part).charAt(0).toUpperCase()).join('').slice(0, 2);
-    }
+    if (parts.length > 0) return parts.map(part => String(part).charAt(0).toUpperCase()).join('').slice(0, 2);
     return (user.username || user.email || '?').slice(0, 2).toUpperCase();
   });
 
@@ -97,21 +90,25 @@ export class ProfileSettingsModalComponent {
     });
   }
 
-  close(): void {
-    this.modal.close();
-  }
-
-  setTab(tab: ProfileSettingsTab): void {
-    this.modal.setTab(tab);
-  }
+  close(): void { this.modal.close(); }
+  setTab(tab: ProfileSettingsTab): void { this.modal.setTab(tab); }
 
   async onThemeModeChange(mode: ThemeMode): Promise<void> {
-    if (this.themeMode() === mode) {
-      return;
-    }
+    if (this.themeMode() === mode) return;
     this.themeMode.set(mode);
     this.themeService.setTheme(mode, true);
     this.message.set({ type: 'success', text: 'Theme preference updated.' });
+  }
+
+  async onDefaultModelChange(modelId: string): Promise<void> {
+    await this.savePreferences({ default_model_id: modelId }, 'Default model updated.');
+  }
+
+  async onDefaultPersonalityChange(personalityId: string): Promise<void> {
+    await this.savePreferences(
+      { default_personality_id: personalityId || undefined },
+      'Default personality updated.',
+    );
   }
 
   async saveProfile(): Promise<void> {
@@ -119,10 +116,8 @@ export class ProfileSettingsModalComponent {
       this.profileForm.markAllAsTouched();
       return;
     }
-
     this.loadingAction.set(true);
     this.message.set(null);
-
     const firstName = (this.profileForm.value.first_name ?? '').trim();
     const lastName = (this.profileForm.value.last_name ?? '').trim();
     const updateData: UpdateUserRequest = {
@@ -130,11 +125,8 @@ export class ProfileSettingsModalComponent {
       first_name: firstName || undefined,
       last_name: lastName || undefined,
     };
-
     try {
-      if (await this.isExternalAuthenticated()) {
-        await this.syncExternalProfile(firstName, lastName);
-      }
+      if (await this.isExternalAuthenticated()) await this.syncExternalProfile(firstName, lastName);
       const user = await firstValueFrom(this.authService.updateProfile(updateData));
       this.currentUser.set(user);
       this.profileForm.markAsPristine();
@@ -150,30 +142,18 @@ export class ProfileSettingsModalComponent {
     const currentPassword = this.passwordForm.value.current_password?.trim() ?? '';
     const newPassword = this.passwordForm.value.new_password?.trim() ?? '';
     const confirmPassword = this.passwordForm.value.confirm_password?.trim() ?? '';
-
-    if (!currentPassword && !newPassword && !confirmPassword) {
-      return;
-    }
+    if (!currentPassword && !newPassword && !confirmPassword) return;
     if (!currentPassword || !newPassword || !confirmPassword || this.passwordForm.invalid) {
       this.passwordForm.markAllAsTouched();
       this.message.set({ type: 'error', text: 'Enter your current password and matching new password.' });
       return;
     }
-
     this.loadingAction.set(true);
     this.message.set(null);
-
-    const passwordData: UpdatePasswordRequest = {
-      current_password: currentPassword,
-      new_password: newPassword,
-    };
-
+    const passwordData: UpdatePasswordRequest = { current_password: currentPassword, new_password: newPassword };
     try {
       if (await this.isExternalAuthenticated()) {
-        await this.externalAuth.updatePassword(
-          passwordData.current_password,
-          passwordData.new_password,
-        );
+        await this.externalAuth.updatePassword(passwordData.current_password, passwordData.new_password);
       } else {
         await firstValueFrom(this.authService.updatePassword(passwordData));
       }
@@ -192,21 +172,25 @@ export class ProfileSettingsModalComponent {
   }
 
   formatDate(value?: string): string {
-    if (!value) {
-      return 'N/A';
-    }
+    if (!value) return 'N/A';
     const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-      return 'N/A';
-    }
+    if (Number.isNaN(date.getTime())) return 'N/A';
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   }
 
   private async loadProfile(): Promise<void> {
     this.loadingProfile.set(true);
     try {
-      const user = await firstValueFrom(this.authService.getUserProfile());
+      const [user, preferences, models, personalityPage] = await Promise.all([
+        firstValueFrom(this.authService.getUserProfile()),
+        firstValueFrom(this.preferencesService.getUserPreferences()),
+        firstValueFrom(this.modelService.getModels()),
+        firstValueFrom(this.personalityService.listPersonalities(1, 100)),
+      ]);
       this.currentUser.set(user);
+      this.preferences.set(preferences);
+      this.models.set(models);
+      this.personalities.set(personalityPage.results);
       this.profileForm.patchValue({
         email: user.email || '',
         first_name: user.first_name || '',
@@ -215,9 +199,30 @@ export class ProfileSettingsModalComponent {
       this.themeMode.set(this.themeService.mode());
       this.profileForm.markAsPristine();
     } catch (error) {
-      this.message.set({ type: 'error', text: this.getErrorMessage(error, 'Failed to load profile.') });
+      this.message.set({ type: 'error', text: this.getErrorMessage(error, 'Failed to load profile settings.') });
     } finally {
       this.loadingProfile.set(false);
+    }
+  }
+
+  private async savePreferences(
+    patch: Partial<Pick<UserPreferences, 'default_model_id' | 'default_personality_id'>>,
+    successMessage: string,
+  ): Promise<void> {
+    const current = this.preferences();
+    if (!current) return;
+    this.loadingAction.set(true);
+    this.message.set(null);
+    try {
+      const updated = await firstValueFrom(
+        this.preferencesService.updateUserPreferences({ ...current, ...patch }),
+      );
+      this.preferences.set(updated);
+      this.message.set({ type: 'success', text: successMessage });
+    } catch (error) {
+      this.message.set({ type: 'error', text: this.getErrorMessage(error, 'Failed to update defaults.') });
+    } finally {
+      this.loadingAction.set(false);
     }
   }
 
@@ -230,19 +235,15 @@ export class ProfileSettingsModalComponent {
       confirmControl?.setErrors({ ...existingErrors, passwordMismatch: true });
       return { passwordMismatch: true };
     }
-
     if (confirmControl?.errors?.['passwordMismatch']) {
       const { passwordMismatch, ...rest } = confirmControl.errors;
       confirmControl.setErrors(Object.keys(rest).length > 0 ? rest : null);
     }
-
     return null;
   }
 
   private async isExternalAuthenticated(): Promise<boolean> {
-    if (!this.externalAuth.available) {
-      return false;
-    }
+    if (!this.externalAuth.available) return false;
     try {
       const tokens = await this.externalAuth.fetchSession();
       return Boolean(tokens?.accessToken);
@@ -253,37 +254,23 @@ export class ProfileSettingsModalComponent {
 
   private async syncExternalProfile(firstName: string, lastName: string): Promise<void> {
     const attributes: Record<string, string> = {};
-    if (firstName) {
-      attributes['given_name'] = firstName;
-    }
-    if (lastName) {
-      attributes['family_name'] = lastName;
-    }
-    if (Object.keys(attributes).length === 0) {
-      return;
-    }
+    if (firstName) attributes['given_name'] = firstName;
+    if (lastName) attributes['family_name'] = lastName;
+    if (Object.keys(attributes).length === 0) return;
     await this.externalAuth.updateProfileAttributes(attributes);
   }
 
   private formatProfileError(error: unknown): string {
     const name = (error as { name?: string })?.name;
-    if (name === 'InvalidParameterException') {
-      return 'Name contains invalid characters or is too long.';
-    }
-    if (name === 'NotAuthorizedException') {
-      return 'Session expired while updating profile. Please sign in again.';
-    }
+    if (name === 'InvalidParameterException') return 'Name contains invalid characters or is too long.';
+    if (name === 'NotAuthorizedException') return 'Session expired while updating profile. Please sign in again.';
     return this.getErrorMessage(error, 'Failed to update profile.');
   }
 
   private formatPasswordError(error: unknown): string {
     const name = (error as { name?: string })?.name;
-    if (name === 'NotAuthorizedException') {
-      return 'Current password is incorrect.';
-    }
-    if (name === 'InvalidPasswordException') {
-      return this.getErrorMessage(error, 'New password does not meet complexity requirements.');
-    }
+    if (name === 'NotAuthorizedException') return 'Current password is incorrect.';
+    if (name === 'InvalidPasswordException') return this.getErrorMessage(error, 'New password does not meet complexity requirements.');
     return this.getErrorMessage(error, 'Failed to update password.');
   }
 

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.ts
@@ -181,16 +181,16 @@ export class ProfileSettingsModalComponent {
   private async loadProfile(): Promise<void> {
     this.loadingProfile.set(true);
     try {
-      const [user, preferences, models, personalityPage] = await Promise.all([
+      const [user, preferences, models, personalities] = await Promise.all([
         firstValueFrom(this.authService.getUserProfile()),
         firstValueFrom(this.preferencesService.getUserPreferences()),
         firstValueFrom(this.modelService.getModels()),
-        firstValueFrom(this.personalityService.listPersonalities(1, 100)),
+        this.loadAllPersonalities(),
       ]);
       this.currentUser.set(user);
       this.preferences.set(preferences);
       this.models.set(models);
-      this.personalities.set(personalityPage.results);
+      this.personalities.set(personalities);
       this.profileForm.patchValue({
         email: user.email || '',
         first_name: user.first_name || '',
@@ -205,6 +205,20 @@ export class ProfileSettingsModalComponent {
     }
   }
 
+  private async loadAllPersonalities(): Promise<readonly Personality[]> {
+    const limit = 100;
+    const firstPage = await firstValueFrom(this.personalityService.listPersonalities(1, limit));
+    const personalities = [...firstPage.results];
+
+    for (let page = 2; personalities.length < firstPage.total_count; page++) {
+      const nextPage = await firstValueFrom(this.personalityService.listPersonalities(page, limit));
+      personalities.push(...nextPage.results);
+      if (nextPage.results.length === 0) break;
+    }
+
+    return personalities;
+  }
+
   private async savePreferences(
     patch: Partial<Pick<UserPreferences, 'default_model_id' | 'default_personality_id'>>,
     successMessage: string,
@@ -214,8 +228,12 @@ export class ProfileSettingsModalComponent {
     this.loadingAction.set(true);
     this.message.set(null);
     try {
+      const updatedPreferences = { ...current, ...patch };
+      if ('default_personality_id' in patch && patch.default_personality_id === undefined) {
+        delete updatedPreferences.default_personality_id;
+      }
       const updated = await firstValueFrom(
-        this.preferencesService.updateUserPreferences({ ...current, ...patch }),
+        this.preferencesService.updateUserPreferences(updatedPreferences),
       );
       this.preferences.set(updated);
       this.message.set({ type: 'success', text: successMessage });


### PR DESCRIPTION
Fixes #46.

## Diagnosis

The current profile/settings modal only exposes identity, theme, and password controls, so the prior default model/default personality settings disappeared from the UI during the redesign. The persistence path itself still exists: `UserPreferences` retains `default_model_id` and `default_personality_id`, and `UserPreferencesService` reads/writes `/user/preferences`.

The model and personality data sources also already exist through `ModelService.getModels()` and `PersonalityService.listPersonalities()`, so this should be a frontend restoration rather than a second settings store.

## Test-first

This PR starts with a regression asserting that the open settings modal renders both `Default model` and `Default personality`. Production code is intentionally unchanged in the first commit so CI can establish the missing-UI red state.

## BSD boundary

BSD classified the represented issue scope as BOUNDED and froze the task frame. PPI was unavailable (`CANONICAL_SUPPORT_UNAVAILABLE`). BSD is being used here as a scope/evidence-structure check; it does not independently prove the causal diagnosis or choose the implementation.

## BSD rerun — coding profile / current engine

Reran the restored-settings slice under the packaged `coding` engineering profile (`evidence_floor=0.40`, `ppi_base_sensitivity=4.0`) using the canonical implementation-correctness output space. The bounded mechanistic chain is `CERTIFIED_WITH_LIMITS` at structural reliability `0.833333`; evidence mass is `1.0`. The canonical mapping is configured and comparable, but PPI is `UNAVAILABLE` specifically because `INSUFFICIENT_SUPPORTED_STRUCTURES`: the competing/falsification frame did not independently earn positive support. Response policy is `DIRECT` with `MISSING_INFORMATION`, `PPI_UNAVAILABLE`, and `SCOPE_LIMITED` disclosures.

The repository source registry remains `CALLER_SUPPLIED_UNVERIFIED` / `UNVERIFIED_REGISTRY`. A direct BSD `code.github` verification attempt returned `RETRIEVAL_FAILED` because the execution environment could not resolve external DNS, so this rerun does not claim adapter-verified GitHub provenance. Implementation and regressions remain one dependent evidence group; `1.0` is coverage, not truth probability. The result supports the existing `UserPreferences` restoration seam only for the represented controls/update path; CI/current-head runtime verification remains the acceptance gate.