### PR TITLE
Add emoji shortcode expansion in chat composer

### DIFF
--- a/web/app/e2e/poms/chat.page.ts
+++ b/web/app/e2e/poms/chat.page.ts
@@ -60,9 +60,20 @@ export class ChatPage {
     this.skillOptionList = this.skillPickerDialog.getByRole('listbox', { name: 'Available skills' });
     this.skillPickerStatus = this.skillPickerDialog.locator('.composer__skill-status');
     this.pendingSkills = this.page.getByLabel('Skills to send with this message');
+    this.emojiAutocomplete = this.page.getByRole('listbox', { name: 'Emoji suggestions' });
   }
 
   readonly composerInput: Locator;
+
+  // --- emoji shortcode autocomplete -----------------------------------------
+
+  /** The `:shortcode` suggestion popup (`role="listbox"` "Emoji suggestions"). */
+  readonly emojiAutocomplete: Locator;
+
+  /** A single emoji suggestion row, matched by its `:short_name:` label. */
+  emojiSuggestion(colons: string): Locator {
+    return this.emojiAutocomplete.getByRole('option', { name: colons });
+  }
 
   /**
    * Header button showing the active personality's name (and the matching

--- a/web/app/e2e/tests/functional/chat/emoji-shortcodes.spec.ts
+++ b/web/app/e2e/tests/functional/chat/emoji-shortcodes.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '../../../fixtures';
+
+test('expands a completed emoji shortcode in the composer', async ({ chatPage, seed, userWithPersonality }) => {
+  const thread = await seed.thread(undefined, {
+    personalityId: userWithPersonality.personality.id,
+  });
+  await chatPage.navigateTo(thread.id as string);
+
+  await chatPage.composerInput.pressSequentially('Hello :fox:');
+
+  await expect(chatPage.composerInput).toHaveValue('Hello 🦊');
+});
+
+test('leaves unknown emoji shortcodes untouched', async ({ chatPage, seed, userWithPersonality }) => {
+  const thread = await seed.thread(undefined, {
+    personalityId: userWithPersonality.personality.id,
+  });
+  await chatPage.navigateTo(thread.id as string);
+
+  await chatPage.composerInput.pressSequentially('Keep :not_a_real_emoji: literal');
+
+  await expect(chatPage.composerInput).toHaveValue('Keep :not_a_real_emoji: literal');
+});

--- a/web/app/e2e/tests/functional/chat/emoji-shortcodes.spec.ts
+++ b/web/app/e2e/tests/functional/chat/emoji-shortcodes.spec.ts
@@ -1,23 +1,58 @@
 import { test, expect } from '../../../fixtures';
 
-test('expands a completed emoji shortcode in the composer', async ({ chatPage, seed, userWithPersonality }) => {
+test('suggests and inserts an emoji from an in-progress shortcode', async ({ chatPage, seed, userWithPersonality }) => {
   const thread = await seed.thread(undefined, {
     personalityId: userWithPersonality.personality.id,
   });
   await chatPage.navigateTo(thread.id as string);
 
-  await chatPage.composerInput.pressSequentially('Hello :fox:');
+  await chatPage.composerInput.pressSequentially('Hello :fox');
+
+  await expect(chatPage.emojiAutocomplete).toBeVisible();
+  await chatPage.emojiSuggestion(':fox_face:').click();
 
   await expect(chatPage.composerInput).toHaveValue('Hello 🦊');
+  await expect(chatPage.emojiAutocomplete).toBeHidden();
 });
 
-test('leaves unknown emoji shortcodes untouched', async ({ chatPage, seed, userWithPersonality }) => {
+test('accepts the highlighted suggestion with Enter without sending', async ({ chatPage, seed, userWithPersonality }) => {
   const thread = await seed.thread(undefined, {
     personalityId: userWithPersonality.personality.id,
   });
   await chatPage.navigateTo(thread.id as string);
 
-  await chatPage.composerInput.pressSequentially('Keep :not_a_real_emoji: literal');
+  await chatPage.composerInput.pressSequentially(':fox');
+  await expect(chatPage.emojiAutocomplete).toBeVisible();
+  await chatPage.composerInput.press('Enter');
 
-  await expect(chatPage.composerInput).toHaveValue('Keep :not_a_real_emoji: literal');
+  // Enter accepted the highlighted suggestion: the popup closed, the literal
+  // `:fox` fragment was replaced, and the draft was neither cleared nor sent.
+  await expect(chatPage.emojiAutocomplete).toBeHidden();
+  await expect(chatPage.composerInput).not.toHaveValue(/:?fox/);
+  await expect(chatPage.composerInput).not.toHaveValue('');
+});
+
+test('does not rewrite a completed shortcode', async ({ chatPage, seed, userWithPersonality }) => {
+  const thread = await seed.thread(undefined, {
+    personalityId: userWithPersonality.personality.id,
+  });
+  await chatPage.navigateTo(thread.id as string);
+
+  // Typing the closing colon leaves the literal text untouched — no auto-replace.
+  await chatPage.composerInput.pressSequentially('Keep :fox: literal');
+
+  await expect(chatPage.composerInput).toHaveValue('Keep :fox: literal');
+  await expect(chatPage.emojiAutocomplete).toBeHidden();
+});
+
+test('does not suggest for identifier-style colons', async ({ chatPage, seed, userWithPersonality }) => {
+  const thread = await seed.thread(undefined, {
+    personalityId: userWithPersonality.personality.id,
+  });
+  await chatPage.navigateTo(thread.id as string);
+
+  await chatPage.composerInput.pressSequentially('scope:value');
+
+  await expect(chatPage.emojiAutocomplete).toBeHidden();
+  await expect(chatPage.composerInput).toHaveValue('scope:value');
 });

--- a/web/app/src/app/features/chat/components/chat-composer/chat-composer.component.ts
+++ b/web/app/src/app/features/chat/components/chat-composer/chat-composer.component.ts
@@ -18,8 +18,8 @@ import { FormsModule } from '@angular/forms';
 import { Subject, forkJoin, of } from 'rxjs';
 import { catchError, finalize, map, switchMap } from 'rxjs/operators';
 
-import { PickerComponent } from '@ctrl/ngx-emoji-mart';
-import { EmojiData, EmojiEvent } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+import { EmojiSearch, PickerComponent } from '@ctrl/ngx-emoji-mart';
+import { EmojiEvent } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
 import {
   FileAttachment,
@@ -42,7 +42,15 @@ import {
   resolveSlashCommand,
   SlashCommand,
 } from '../../helpers/slash-command.helpers';
+import {
+  ActiveEmojiShortcode,
+  EmojiSuggestion,
+  activeEmojiShortcodeQuery,
+  emojiCharFromData,
+  searchEmojiShortcodes,
+} from '../../helpers/emoji-shortcode.helpers';
 import { ModelPickerComponent } from '../model-picker/model-picker.component';
+import { EmojiAutocompleteMenuComponent } from '../emoji-autocomplete-menu/emoji-autocomplete-menu.component';
 import { SlashMenuComponent } from '../slash-menu/slash-menu.component';
 import { BoltIconComponent, FileIconComponent, ImageIconComponent, PlusIconComponent } from '../../../../shared/ui/icons/icons';
 import { ModalComponent } from '../../../../shared/ui/modal/modal.component';
@@ -75,6 +83,7 @@ const CHAT_LENGTH_HINT_THRESHOLD = 10_000;
     FormsModule,
     PickerComponent,
     ModelPickerComponent,
+    EmojiAutocompleteMenuComponent,
     SlashMenuComponent,
     BoltIconComponent,
     FileIconComponent,
@@ -404,6 +413,17 @@ const CHAT_LENGTH_HINT_THRESHOLD = 10_000;
             }
           </div>
         </div>
+
+        @if (emojiAutocompleteOpen()) {
+          <div class="composer__emoji-autocomplete">
+            <app-emoji-autocomplete-menu
+              #emojiMenu
+              [suggestions]="emojiSuggestions()"
+              (selected)="onEmojiSuggestionSelected($event)"
+              (closed)="closeEmojiAutocomplete()"
+            />
+          </div>
+        }
 
       </div>
 
@@ -1008,6 +1028,15 @@ const CHAT_LENGTH_HINT_THRESHOLD = 10_000;
       width: min(100%, 26rem, calc(100% - 2rem));
     }
 
+    .composer__emoji-autocomplete {
+      bottom: calc(100% + 0.375rem);
+      left: 0;
+      max-width: min(20rem, 92vw);
+      position: absolute;
+      width: max-content;
+      z-index: 60;
+    }
+
     .composer__quota {
       color: var(--color-danger);
       font-size: 0.875rem;
@@ -1157,6 +1186,7 @@ export class ChatComposerComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly ritualService = inject(RitualService);
   private readonly moodService = inject(MoodService);
+  private readonly emojiSearch = inject(EmojiSearch);
   readonly imageGallery = inject(ImageGalleryService);
   readonly modeSingular = MODE_SINGULAR;
   readonly modeSingularPlural = MODE_PLURAL;
@@ -1213,6 +1243,11 @@ export class ChatComposerComponent {
   readonly slashOpen = signal(false);
   readonly slashQuery = signal('');
   private readonly slashMenu = viewChild<SlashMenuComponent>('slashMenu');
+  /** In-progress `:shortcode` autocomplete state, distinct from the plus-menu emoji picker. */
+  readonly emojiAutocompleteOpen = signal(false);
+  readonly emojiSuggestions = signal<readonly EmojiSuggestion[]>([]);
+  private readonly emojiQuery = signal<ActiveEmojiShortcode | null>(null);
+  private readonly emojiMenu = viewChild<EmojiAutocompleteMenuComponent>('emojiMenu');
   readonly isDragOver = signal(false);
   readonly plusOpen = signal(false);
   readonly emojiOpen = signal(false);
@@ -1363,7 +1398,8 @@ export class ChatComposerComponent {
   }
 
   onInput(event: Event): void {
-    const value = (event.target as HTMLTextAreaElement).value;
+    const textarea = event.target as HTMLTextAreaElement;
+    const value = textarea.value;
     this.draftChange.emit(value);
     this.limitWarningAcknowledged.set(false);
     if (this.limitWarningOpen()) {
@@ -1372,10 +1408,82 @@ export class ChatComposerComponent {
     const parsed = parseSlash(value);
     this.slashOpen.set(parsed.command !== null);
     this.slashQuery.set(parsed.command ?? '');
+    this.updateEmojiAutocomplete(textarea);
     this.scheduleTextareaResize();
   }
 
+  /**
+   * Recompute the emoji suggestion popup from the caret position. Opens it only
+   * when the caret sits inside an in-progress `:shortcode` with real matches;
+   * an in-progress shortcode supersedes the slash menu.
+   */
+  private updateEmojiAutocomplete(textarea: HTMLTextAreaElement): void {
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? start;
+    if (start !== end) {
+      this.closeEmojiAutocomplete();
+      return;
+    }
+
+    const active = activeEmojiShortcodeQuery(textarea.value, start);
+    if (!active) {
+      this.closeEmojiAutocomplete();
+      return;
+    }
+
+    const suggestions = searchEmojiShortcodes(this.emojiSearch, active.query);
+    if (!suggestions.length) {
+      this.closeEmojiAutocomplete();
+      return;
+    }
+
+    this.emojiQuery.set(active);
+    this.emojiSuggestions.set(suggestions);
+    this.emojiAutocompleteOpen.set(true);
+    this.slashOpen.set(false);
+  }
+
+  closeEmojiAutocomplete(): void {
+    if (this.emojiAutocompleteOpen()) {
+      this.emojiAutocompleteOpen.set(false);
+    }
+    this.emojiSuggestions.set([]);
+    this.emojiQuery.set(null);
+  }
+
+  onEmojiSuggestionSelected(suggestion: EmojiSuggestion): void {
+    const range = this.emojiQuery();
+    this.closeEmojiAutocomplete();
+    if (!range) {
+      this.insertAtCursor(suggestion.native);
+      return;
+    }
+    this.replaceRange(range.start, range.end, suggestion.native);
+  }
+
   onKeydown(event: KeyboardEvent): void {
+    // The emoji autocomplete popup owns navigation/accept keys while open, ahead
+    // of both the slash menu and Enter-to-send.
+    if (this.emojiAutocompleteOpen()) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        this.closeEmojiAutocomplete();
+        return;
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        this.emojiMenu()?.onKeydown(event);
+        return;
+      }
+      // Enter and Tab both accept the highlighted suggestion instead of sending
+      // the message or moving focus.
+      if ((event.key === 'Enter' && !event.shiftKey) || event.key === 'Tab') {
+        event.preventDefault();
+        this.emojiMenu()?.selectHighlighted();
+        return;
+      }
+    }
+
     // On soft-keyboard devices Enter is a newline; submitting happens via the
     // Send button. This avoids needing a Shift key those devices don't have.
     const enterSends = event.key === 'Enter' && !event.shiftKey && !this.softKeyboard();
@@ -1649,6 +1757,38 @@ export class ChatComposerComponent {
     }, 0);
   }
 
+  /**
+   * Replace an explicit `[start, end)` range with text, used to swap an
+   * in-progress `:shortcode` for the chosen emoji. Selects the fragment first so
+   * the browser records a single undoable edit via execCommand where available.
+   */
+  private replaceRange(start: number, end: number, insert: string): void {
+    const ta = this.textareaRef()?.nativeElement;
+    const value = this.draft();
+    if (!ta) {
+      this.draftChange.emit(value.slice(0, start) + insert + value.slice(end));
+      return;
+    }
+    const pos = start + insert.length;
+    ta.focus();
+    ta.setSelectionRange(start, end);
+    if (typeof document.execCommand === 'function' && document.execCommand('insertText', false, insert)) {
+      this.draftChange.emit(ta.value);
+      setTimeout(() => {
+        ta.focus();
+        ta.setSelectionRange(pos, pos);
+      }, 0);
+      return;
+    }
+    const next = value.slice(0, start) + insert + value.slice(end);
+    ta.value = next;
+    this.draftChange.emit(next);
+    setTimeout(() => {
+      ta.focus();
+      ta.setSelectionRange(pos, pos);
+    }, 0);
+  }
+
   onFileInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     const files = Array.from(input.files ?? []).filter(isAllowedFile);
@@ -1738,8 +1878,17 @@ export class ChatComposerComponent {
       }
     }
 
+    if (this.emojiAutocompleteOpen() && target instanceof Element) {
+      const inMenu = target.closest('.composer__emoji-autocomplete');
+      const inTextarea = target.closest('#chat-composer-input');
+      if (!inMenu && !inTextarea) {
+        this.closeEmojiAutocomplete();
+      }
+    }
+
     if (this.host.nativeElement.contains(target)) return;
     this.closeAuxiliaryPopovers();
+    this.closeEmojiAutocomplete();
     this.slashOpen.set(false);
   }
 
@@ -1964,22 +2113,4 @@ function ensurePastedFileName(file: File): File {
     type: file.type,
     lastModified: file.lastModified,
   });
-}
-
-function emojiCharFromData(emoji: EmojiData): string {
-  if (emoji.native) {
-    return emoji.native;
-  }
-  const unified = emoji.unified;
-  if (!unified) {
-    return '';
-  }
-  try {
-    return unified
-      .split('-')
-      .map(hex => String.fromCodePoint(parseInt(hex, 16)))
-      .join('');
-  } catch {
-    return '';
-  }
 }

--- a/web/app/src/app/features/chat/components/emoji-autocomplete-menu/emoji-autocomplete-menu.component.ts
+++ b/web/app/src/app/features/chat/components/emoji-autocomplete-menu/emoji-autocomplete-menu.component.ts
@@ -1,0 +1,145 @@
+import { ChangeDetectionStrategy, Component, computed, effect, input, output, signal } from '@angular/core';
+
+import { EmojiSuggestion } from '../../helpers/emoji-shortcode.helpers';
+
+/**
+ * Slack-style emoji autocomplete popup. Renders the suggestions the composer
+ * found for an in-progress `:shortcode` and lets the user pick one with the
+ * mouse or keyboard. It never mutates the draft itself — the parent composer
+ * owns insertion — so this stays a thin, presentational sibling of
+ * {@link SlashMenuComponent}.
+ */
+@Component({
+  selector: 'app-emoji-autocomplete-menu',
+  standalone: true,
+  imports: [],
+  template: `
+    @if (suggestions().length) {
+      <div
+        class="emoji-menu"
+        role="listbox"
+        [attr.aria-activedescendant]="activeId()"
+        aria-label="Emoji suggestions"
+      >
+        @for (suggestion of suggestions(); track suggestion.id; let index = $index) {
+          <button
+            type="button"
+            role="option"
+            class="emoji-menu__row"
+            [id]="rowId(suggestion)"
+            [class.emoji-menu__row--active]="index === selectedIndex()"
+            [attr.aria-selected]="index === selectedIndex()"
+            (mouseenter)="selectedIndex.set(index)"
+            (mousedown)="$event.preventDefault()"
+            (click)="select(suggestion)"
+          >
+            <span class="emoji-menu__glyph" aria-hidden="true">{{ suggestion.native }}</span>
+            <span class="emoji-menu__colons">{{ suggestion.colons }}</span>
+          </button>
+        }
+      </div>
+    }
+  `,
+  styles: [`
+    .emoji-menu {
+      background: var(--color-surface-base);
+      border: 1px solid var(--color-border-base);
+      border-radius: 0.75rem;
+      box-shadow: 0 18px 45px rgb(0 0 0 / 0.18);
+      display: grid;
+      gap: 0.125rem;
+      max-height: 16rem;
+      overflow-y: auto;
+      padding: 0.375rem;
+    }
+
+    .emoji-menu__row {
+      align-items: center;
+      background: transparent;
+      border: 0;
+      border-radius: 0.5rem;
+      color: var(--color-text-primary);
+      cursor: pointer;
+      display: flex;
+      gap: 0.5rem;
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+      width: 100%;
+    }
+
+    .emoji-menu__row--active,
+    .emoji-menu__row:hover {
+      background: var(--color-surface-muted);
+    }
+
+    .emoji-menu__glyph {
+      font-size: 1.125rem;
+      line-height: 1;
+      width: 1.5rem;
+      text-align: center;
+    }
+
+    .emoji-menu__colons {
+      color: var(--color-text-secondary);
+      font-size: 0.8125rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EmojiAutocompleteMenuComponent {
+  readonly suggestions = input.required<readonly EmojiSuggestion[]>();
+  readonly selected = output<EmojiSuggestion>();
+  readonly closed = output<void>();
+  readonly selectedIndex = signal(0);
+  readonly activeId = computed(() => {
+    const current = this.suggestions()[this.selectedIndex()];
+    return current ? this.rowId(current) : null;
+  });
+
+  constructor() {
+    // Reset the highlight whenever the suggestion set changes (new query).
+    effect(() => {
+      this.suggestions();
+      this.selectedIndex.set(0);
+    });
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.closed.emit();
+      return;
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.move(event.key === 'ArrowDown' ? 1 : -1);
+    }
+  }
+
+  select(suggestion: EmojiSuggestion): void {
+    this.selected.emit(suggestion);
+  }
+
+  /** Accept the highlighted row (invoked from the parent textarea's keydown). */
+  selectHighlighted(): void {
+    const suggestion = this.suggestions()[this.selectedIndex()];
+    if (suggestion) {
+      this.select(suggestion);
+    }
+  }
+
+  rowId(suggestion: EmojiSuggestion): string {
+    return `emoji-suggestion-${suggestion.id}`;
+  }
+
+  private move(delta: number): void {
+    const count = this.suggestions().length;
+    if (!count) {
+      return;
+    }
+    this.selectedIndex.set((this.selectedIndex() + delta + count) % count);
+  }
+}

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
@@ -1,0 +1,36 @@
+import { EmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+
+import { completedEmojiShortcode, resolveEmojiSearchResult } from './emoji-shortcode.helpers';
+
+function emoji(overrides: Partial<EmojiData> & Record<string, unknown>): EmojiData {
+  return overrides as EmojiData;
+}
+
+describe('emoji shortcode helpers', () => {
+  it('finds only the completed shortcode immediately before the caret', () => {
+    expect(completedEmojiShortcode('Hello :fox: friend', 11)).toEqual({ query: 'fox', start: 6, end: 11 });
+    expect(completedEmojiShortcode('Hello :fox: friend', 18)).toBeNull();
+    expect(completedEmojiShortcode('https://example.test/:fox:', 25)).toBeNull();
+  });
+
+  it('prefers exact short names over fuzzy search order', () => {
+    const exact = emoji({ id: 'smile', shortNames: ['smile'], native: '😄' });
+    const fuzzy = emoji({ id: 'smiley', shortNames: ['smiley'], native: '😃', keywords: ['smile'] });
+
+    expect(resolveEmojiSearchResult('smile', [fuzzy, exact])).toBe(exact);
+  });
+
+  it('accepts a unique word alias such as fox for fox_face', () => {
+    const fox = emoji({ id: 'fox_face', shortNames: ['fox_face'], name: 'Fox Face', native: '🦊', keywords: ['animal', 'fox'] });
+
+    expect(resolveEmojiSearchResult('fox', [fox])).toBe(fox);
+  });
+
+  it('rejects ambiguous fuzzy aliases and unknown searches', () => {
+    const grin = emoji({ id: 'grinning', name: 'Grinning Face', native: '😀', keywords: ['face'] });
+    const smile = emoji({ id: 'smiley', name: 'Smiling Face', native: '😃', keywords: ['face'] });
+
+    expect(resolveEmojiSearchResult('face', [grin, smile])).toBeNull();
+    expect(resolveEmojiSearchResult('definitely_not_an_emoji', [])).toBeNull();
+  });
+});

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
@@ -10,7 +10,9 @@ describe('emoji shortcode helpers', () => {
   it('finds only the completed shortcode immediately before the caret', () => {
     expect(completedEmojiShortcode('Hello :fox: friend', 11)).toEqual({ query: 'fox', start: 6, end: 11 });
     expect(completedEmojiShortcode('Hello :fox: friend', 18)).toBeNull();
-    expect(completedEmojiShortcode('https://example.test/:fox:', 25)).toBeNull();
+
+    const url = 'https://example.test/:fox:';
+    expect(completedEmojiShortcode(url, url.length)).toBeNull();
   });
 
   it('prefers exact short names over fuzzy search order', () => {

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
@@ -1,38 +1,99 @@
+import { EmojiSearch } from '@ctrl/ngx-emoji-mart';
 import { EmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
-import { completedEmojiShortcode, resolveEmojiSearchResult } from './emoji-shortcode.helpers';
+import {
+  activeEmojiShortcodeQuery,
+  emojiCharFromData,
+  searchEmojiShortcodes,
+} from './emoji-shortcode.helpers';
 
 function emoji(overrides: Partial<EmojiData> & Record<string, unknown>): EmojiData {
   return overrides as EmojiData;
 }
 
 describe('emoji shortcode helpers', () => {
-  it('finds only the completed shortcode immediately before the caret', () => {
-    expect(completedEmojiShortcode('Hello :fox: friend', 11)).toEqual({ query: 'fox', start: 6, end: 11 });
-    expect(completedEmojiShortcode('Hello :fox: friend', 18)).toBeNull();
+  describe('activeEmojiShortcodeQuery', () => {
+    it('reports the in-progress shortcode immediately before the caret', () => {
+      expect(activeEmojiShortcodeQuery('Hello :fo', 9)).toEqual({ query: 'fo', start: 6, end: 9 });
+    });
 
-    const url = 'https://example.test/:fox:';
-    expect(completedEmojiShortcode(url, url.length)).toBeNull();
+    it('lowercases the typed query', () => {
+      expect(activeEmojiShortcodeQuery('Hi :FoX', 7)).toEqual({ query: 'fox', start: 3, end: 7 });
+    });
+
+    it('ignores a shortcode that is not adjacent to the caret', () => {
+      expect(activeEmojiShortcodeQuery('Hello :fox world', 16)).toBeNull();
+    });
+
+    it('does not trigger below the minimum query length', () => {
+      expect(activeEmojiShortcodeQuery(':f', 2)).toBeNull();
+    });
+
+    it('does not trigger on a completed shortcode (trailing colon)', () => {
+      // The closing colon ends the fragment, so nothing is being typed anymore.
+      expect(activeEmojiShortcodeQuery('Hello :fox:', 11)).toBeNull();
+    });
+
+    it('does not treat URL or identifier colons as shortcodes', () => {
+      expect(activeEmojiShortcodeQuery('https://example.test/:fox', 25)).toBeNull();
+      expect(activeEmojiShortcodeQuery('scope:value', 11)).toBeNull();
+    });
+
+    it('triggers after opening punctuation', () => {
+      expect(activeEmojiShortcodeQuery('(:fox', 5)).toEqual({ query: 'fox', start: 1, end: 5 });
+    });
   });
 
-  it('prefers exact short names over fuzzy search order', () => {
-    const exact = emoji({ id: 'smile', shortNames: ['smile'], native: '😄' });
-    const fuzzy = emoji({ id: 'smiley', shortNames: ['smiley'], native: '😃', keywords: ['smile'] });
+  describe('searchEmojiShortcodes', () => {
+    function stubSearch(results: EmojiData[] | null): EmojiSearch {
+      return { search: () => results } as unknown as EmojiSearch;
+    }
 
-    expect(resolveEmojiSearchResult('smile', [fuzzy, exact])).toBe(exact);
+    it('returns nothing below the minimum query length', () => {
+      const search = stubSearch([emoji({ id: 'fox_face', native: '🦊' })]);
+      expect(searchEmojiShortcodes(search, 'f')).toEqual([]);
+    });
+
+    it('maps search results to insertable suggestions', () => {
+      const search = stubSearch([
+        emoji({ id: 'fox_face', native: '🦊', colons: ':fox_face:' }),
+        emoji({ id: 'grinning', unified: '1F600' }),
+      ]);
+
+      expect(searchEmojiShortcodes(search, 'fo')).toEqual([
+        { id: 'fox_face', colons: ':fox_face:', native: '🦊' },
+        { id: 'grinning', colons: ':grinning:', native: '😀' },
+      ]);
+    });
+
+    it('drops results with no derivable native character and de-dupes by id', () => {
+      const search = stubSearch([
+        emoji({ id: 'mystery' }),
+        emoji({ id: 'fox_face', native: '🦊' }),
+        emoji({ id: 'fox_face', native: '🦊' }),
+      ]);
+
+      expect(searchEmojiShortcodes(search, 'fo')).toEqual([
+        { id: 'fox_face', colons: ':fox_face:', native: '🦊' },
+      ]);
+    });
+
+    it('tolerates a null search result', () => {
+      expect(searchEmojiShortcodes(stubSearch(null), 'fo')).toEqual([]);
+    });
   });
 
-  it('accepts a unique word alias such as fox for fox_face', () => {
-    const fox = emoji({ id: 'fox_face', shortNames: ['fox_face'], name: 'Fox Face', native: '🦊', keywords: ['animal', 'fox'] });
+  describe('emojiCharFromData', () => {
+    it('prefers a native character', () => {
+      expect(emojiCharFromData(emoji({ native: '🦊', unified: '1F98A' }))).toBe('🦊');
+    });
 
-    expect(resolveEmojiSearchResult('fox', [fox])).toBe(fox);
-  });
+    it('falls back to composing from unified codepoints', () => {
+      expect(emojiCharFromData(emoji({ unified: '1F600' }))).toBe('😀');
+    });
 
-  it('rejects ambiguous fuzzy aliases and unknown searches', () => {
-    const grin = emoji({ id: 'grinning', name: 'Grinning Face', native: '😀', keywords: ['face'] });
-    const smile = emoji({ id: 'smiley', name: 'Smiling Face', native: '😃', keywords: ['face'] });
-
-    expect(resolveEmojiSearchResult('face', [grin, smile])).toBeNull();
-    expect(resolveEmojiSearchResult('definitely_not_an_emoji', [])).toBeNull();
+    it('returns empty when neither is available', () => {
+      expect(emojiCharFromData(emoji({}))).toBe('');
+    });
   });
 });

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
@@ -82,7 +82,8 @@ export function installComposerEmojiShortcodes(emojiSearch: EmojiSearch): void {
     const shortcode = completedEmojiShortcode(textarea.value, start);
     if (!shortcode) return;
 
-    const emoji = resolveEmojiSearchResult(shortcode.query, emojiSearch.search(shortcode.query));
+    const results = emojiSearch.search(shortcode.query) ?? [];
+    const emoji = resolveEmojiSearchResult(shortcode.query, results);
     const native = emoji ? emojiChar(emoji) : '';
     if (!native) return;
 

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
@@ -1,3 +1,4 @@
+import { EmojiSearch } from '@ctrl/ngx-emoji-mart';
 import { EmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
 export interface CompletedEmojiShortcode {
@@ -57,6 +58,42 @@ export function resolveEmojiSearchResult(query: string, results: readonly EmojiD
   return wordMatches.length === 1 ? wordMatches[0] : null;
 }
 
+/**
+ * Install the editor-local shortcode behavior before Angular's textarea input
+ * listener runs. The capture listener is intentionally scoped to the one chat
+ * composer textarea, so transport/persistence code never rewrites user text.
+ *
+ * The listener mutates the textarea value in the capture phase; the original
+ * input event then reaches ChatComposerComponent.onInput(), which emits the
+ * already-expanded draft through the normal controlled-input path.
+ */
+export function installComposerEmojiShortcodes(emojiSearch: EmojiSearch): void {
+  if (typeof document === 'undefined' || composerShortcodesInstalled) return;
+  composerShortcodesInstalled = true;
+
+  document.addEventListener('input', event => {
+    const textarea = event.target;
+    if (!(textarea instanceof HTMLTextAreaElement) || textarea.id !== 'chat-composer-input') return;
+
+    const start = textarea.selectionStart ?? textarea.value.length;
+    const end = textarea.selectionEnd ?? start;
+    if (start !== end) return;
+
+    const shortcode = completedEmojiShortcode(textarea.value, start);
+    if (!shortcode) return;
+
+    const emoji = resolveEmojiSearchResult(shortcode.query, emojiSearch.search(shortcode.query));
+    const native = emoji ? emojiChar(emoji) : '';
+    if (!native) return;
+
+    textarea.value = textarea.value.slice(0, shortcode.start) + native + textarea.value.slice(shortcode.end);
+    const caret = shortcode.start + native.length;
+    textarea.setSelectionRange(caret, caret);
+  }, true);
+}
+
+let composerShortcodesInstalled = false;
+
 function emojiNames(emoji: SearchableEmoji): string[] {
   return [emoji.id ?? '', ...(emoji.shortNames ?? [])]
     .map(name => name.trim().toLowerCase())
@@ -69,4 +106,17 @@ function emojiWords(emoji: SearchableEmoji): Set<string> {
     .flatMap(field => field.toLowerCase().split(/[^a-z0-9+\-]+/))
     .filter(Boolean);
   return new Set(words);
+}
+
+function emojiChar(emoji: EmojiData): string {
+  if (emoji.native) return emoji.native;
+  if (!emoji.unified) return '';
+  try {
+    return emoji.unified
+      .split('-')
+      .map(hex => String.fromCodePoint(parseInt(hex, 16)))
+      .join('');
+  } catch {
+    return '';
+  }
 }

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
@@ -1,0 +1,72 @@
+import { EmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+
+export interface CompletedEmojiShortcode {
+  query: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Return the completed :shortcode: immediately before the caret.
+ *
+ * A shortcode must begin at the start of the draft or after whitespace/opening
+ * punctuation. That keeps URL-ish and ordinary colon-delimited text from being
+ * rewritten while the user is typing.
+ */
+export function completedEmojiShortcode(value: string, caret: number): CompletedEmojiShortcode | null {
+  if (caret < 3 || caret > value.length || value[caret - 1] !== ':') {
+    return null;
+  }
+
+  const beforeCaret = value.slice(0, caret);
+  const match = /:([A-Za-z0-9_+\-]{1,64}):$/.exec(beforeCaret);
+  if (!match || match.index < 0) {
+    return null;
+  }
+
+  const start = match.index;
+  if (start > 0 && !/[\s([{]/.test(value[start - 1])) {
+    return null;
+  }
+
+  return { query: match[1].toLowerCase(), start, end: caret };
+}
+
+type SearchableEmoji = EmojiData & {
+  id?: string;
+  name?: string;
+  shortNames?: string[];
+  keywords?: string[];
+};
+
+/**
+ * Resolve a shortcode from Emoji Mart search results without accepting an
+ * arbitrary fuzzy first hit. Exact IDs/short names win. For convenience aliases
+ * such as :fox: -> fox_face, accept only a single result whose name/id/keyword
+ * contains the query as a whole word.
+ */
+export function resolveEmojiSearchResult(query: string, results: readonly EmojiData[]): EmojiData | null {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const searchable = results as readonly SearchableEmoji[];
+  const exact = searchable.find(emoji => emojiNames(emoji).includes(normalized));
+  if (exact) return exact;
+
+  const wordMatches = searchable.filter(emoji => emojiWords(emoji).has(normalized));
+  return wordMatches.length === 1 ? wordMatches[0] : null;
+}
+
+function emojiNames(emoji: SearchableEmoji): string[] {
+  return [emoji.id ?? '', ...(emoji.shortNames ?? [])]
+    .map(name => name.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function emojiWords(emoji: SearchableEmoji): Set<string> {
+  const fields = [emoji.id ?? '', emoji.name ?? '', ...(emoji.shortNames ?? []), ...(emoji.keywords ?? [])];
+  const words = fields
+    .flatMap(field => field.toLowerCase().split(/[^a-z0-9+\-]+/))
+    .filter(Boolean);
+  return new Set(words);
+}

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
@@ -1,117 +1,115 @@
 import { EmojiSearch } from '@ctrl/ngx-emoji-mart';
 import { EmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
-export interface CompletedEmojiShortcode {
+/**
+ * Shortest `:query` we search for. One character (`:a`) matches almost every
+ * emoji and is pure noise, so the popup stays quiet until there is something
+ * worth narrowing on.
+ */
+export const MIN_EMOJI_QUERY_LENGTH = 2;
+
+/** Default number of suggestions shown in the composer autocomplete popup. */
+export const EMOJI_SUGGESTION_LIMIT = 8;
+
+/**
+ * The in-progress `:shortcode` fragment immediately before the caret. Unlike a
+ * completed `:shortcode:`, this has no trailing colon — it is what the user is
+ * still typing, and drives the suggestion popup.
+ */
+export interface ActiveEmojiShortcode {
+  /** Lowercased text typed after the opening colon (colon excluded). */
   query: string;
+  /** Index of the opening colon within the draft. */
   start: number;
+  /** Caret index — the exclusive end of the fragment to replace on accept. */
   end: number;
 }
 
-/**
- * Return the completed :shortcode: immediately before the caret.
- *
- * A shortcode must begin at the start of the draft or after whitespace/opening
- * punctuation. That keeps URL-ish and ordinary colon-delimited text from being
- * rewritten while the user is typing.
- */
-export function completedEmojiShortcode(value: string, caret: number): CompletedEmojiShortcode | null {
-  if (caret < 3 || caret > value.length || value[caret - 1] !== ':') {
-    return null;
-  }
-
-  const beforeCaret = value.slice(0, caret);
-  const match = /:([A-Za-z0-9_+\-]{1,64}):$/.exec(beforeCaret);
-  if (!match || match.index < 0) {
-    return null;
-  }
-
-  const start = match.index;
-  if (start > 0 && !/[\s([{]/.test(value[start - 1])) {
-    return null;
-  }
-
-  return { query: match[1].toLowerCase(), start, end: caret };
+/** A single emoji offered in the composer autocomplete popup. */
+export interface EmojiSuggestion {
+  /** Stable Emoji Mart id, used for list tracking. */
+  id: string;
+  /** Canonical `:short_name:` label shown beside the glyph. */
+  colons: string;
+  /** The native emoji character inserted when the suggestion is accepted. */
+  native: string;
 }
 
-type SearchableEmoji = EmojiData & {
-  id?: string;
-  name?: string;
-  shortNames?: string[];
-  keywords?: string[];
-};
+/**
+ * A shortcode may only begin at the start of the draft or after whitespace or
+ * opening punctuation. That keeps URL-ish and identifier-ish colons (e.g.
+ * `https://host/:id`) from ever opening the popup.
+ */
+const ACTIVE_SHORTCODE = /(^|[\s([{])(:)([A-Za-z0-9_+\-]{1,64})$/;
 
 /**
- * Resolve a shortcode from Emoji Mart search results without accepting an
- * arbitrary fuzzy first hit. Exact IDs/short names win. For convenience aliases
- * such as :fox: -> fox_face, accept only a single result whose name/id/keyword
- * contains the query as a whole word.
+ * Return the in-progress `:shortcode` immediately before the caret, or null when
+ * the caret is not inside one. This never rewrites the draft — it only reports
+ * what the user is typing so the composer can offer suggestions.
  */
-export function resolveEmojiSearchResult(query: string, results: readonly EmojiData[]): EmojiData | null {
+export function activeEmojiShortcodeQuery(value: string, caret: number): ActiveEmojiShortcode | null {
+  if (caret < 0 || caret > value.length) {
+    return null;
+  }
+
+  const match = ACTIVE_SHORTCODE.exec(value.slice(0, caret));
+  if (!match) {
+    return null;
+  }
+
+  const query = match[3].toLowerCase();
+  if (query.length < MIN_EMOJI_QUERY_LENGTH) {
+    return null;
+  }
+
+  // match[1] is the boundary char (or empty at start); the colon follows it.
+  const start = match.index + match[1].length;
+  return { query, start, end: caret };
+}
+
+/**
+ * Look up emoji suggestions for an in-progress shortcode query. Returns
+ * insertable suggestions (those we can render as a native character), de-duped
+ * by id and capped at {@link EMOJI_SUGGESTION_LIMIT}.
+ */
+export function searchEmojiShortcodes(
+  emojiSearch: EmojiSearch,
+  query: string,
+  limit: number = EMOJI_SUGGESTION_LIMIT,
+): EmojiSuggestion[] {
   const normalized = query.trim().toLowerCase();
-  if (!normalized) return null;
+  if (normalized.length < MIN_EMOJI_QUERY_LENGTH) {
+    return [];
+  }
 
-  const searchable = results as readonly SearchableEmoji[];
-  const exact = searchable.find(emoji => emojiNames(emoji).includes(normalized));
-  if (exact) return exact;
+  const results = emojiSearch.search(normalized, undefined, limit) ?? [];
+  const suggestions: EmojiSuggestion[] = [];
+  const seen = new Set<string>();
 
-  const wordMatches = searchable.filter(emoji => emojiWords(emoji).has(normalized));
-  return wordMatches.length === 1 ? wordMatches[0] : null;
+  for (const emoji of results) {
+    const native = emojiCharFromData(emoji);
+    if (!native) {
+      continue;
+    }
+    const id = (emoji as { id?: string }).id ?? native;
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    suggestions.push({ id, colons: emojiColons(emoji, id), native });
+  }
+
+  return suggestions;
 }
 
-/**
- * Install the editor-local shortcode behavior before Angular's textarea input
- * listener runs. The capture listener is intentionally scoped to the one chat
- * composer textarea, so transport/persistence code never rewrites user text.
- *
- * The listener mutates the textarea value in the capture phase; the original
- * input event then reaches ChatComposerComponent.onInput(), which emits the
- * already-expanded draft through the normal controlled-input path.
- */
-export function installComposerEmojiShortcodes(emojiSearch: EmojiSearch): void {
-  if (typeof document === 'undefined' || composerShortcodesInstalled) return;
-  composerShortcodesInstalled = true;
-
-  document.addEventListener('input', event => {
-    const textarea = event.target;
-    if (!(textarea instanceof HTMLTextAreaElement) || textarea.id !== 'chat-composer-input') return;
-
-    const start = textarea.selectionStart ?? textarea.value.length;
-    const end = textarea.selectionEnd ?? start;
-    if (start !== end) return;
-
-    const shortcode = completedEmojiShortcode(textarea.value, start);
-    if (!shortcode) return;
-
-    const results = emojiSearch.search(shortcode.query) ?? [];
-    const emoji = resolveEmojiSearchResult(shortcode.query, results);
-    const native = emoji ? emojiChar(emoji) : '';
-    if (!native) return;
-
-    textarea.value = textarea.value.slice(0, shortcode.start) + native + textarea.value.slice(shortcode.end);
-    const caret = shortcode.start + native.length;
-    textarea.setSelectionRange(caret, caret);
-  }, true);
-}
-
-let composerShortcodesInstalled = false;
-
-function emojiNames(emoji: SearchableEmoji): string[] {
-  return [emoji.id ?? '', ...(emoji.shortNames ?? [])]
-    .map(name => name.trim().toLowerCase())
-    .filter(Boolean);
-}
-
-function emojiWords(emoji: SearchableEmoji): Set<string> {
-  const fields = [emoji.id ?? '', emoji.name ?? '', ...(emoji.shortNames ?? []), ...(emoji.keywords ?? [])];
-  const words = fields
-    .flatMap(field => field.toLowerCase().split(/[^a-z0-9+\-]+/))
-    .filter(Boolean);
-  return new Set(words);
-}
-
-function emojiChar(emoji: EmojiData): string {
-  if (emoji.native) return emoji.native;
-  if (!emoji.unified) return '';
+/** Resolve the native character for an emoji, from `native` or its codepoints. */
+export function emojiCharFromData(emoji: EmojiData): string {
+  if (emoji.native) {
+    return emoji.native;
+  }
+  if (!emoji.unified) {
+    return '';
+  }
   try {
     return emoji.unified
       .split('-')
@@ -120,4 +118,12 @@ function emojiChar(emoji: EmojiData): string {
   } catch {
     return '';
   }
+}
+
+function emojiColons(emoji: EmojiData, id: string): string {
+  const colons = (emoji as { colons?: string }).colons;
+  if (colons) {
+    return colons;
+  }
+  return `:${id}:`;
 }

--- a/web/app/src/main.ts
+++ b/web/app/src/main.ts
@@ -1,9 +1,12 @@
+import { EmojiSearch } from '@ctrl/ngx-emoji-mart';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 import { ThemeService } from './app/core/services/theme.service';
+import { installComposerEmojiShortcodes } from './app/features/chat/helpers/emoji-shortcode.helpers';
 
 ThemeService.initializeThemeEarly();
 
 bootstrapApplication(App, appConfig)
+  .then(appRef => installComposerEmojiShortcodes(appRef.injector.get(EmojiSearch)))
   .catch((err) => console.error(err));

--- a/web/app/src/main.ts
+++ b/web/app/src/main.ts
@@ -1,12 +1,9 @@
-import { EmojiSearch } from '@ctrl/ngx-emoji-mart';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 import { ThemeService } from './app/core/services/theme.service';
-import { installComposerEmojiShortcodes } from './app/features/chat/helpers/emoji-shortcode.helpers';
 
 ThemeService.initializeThemeEarly();
 
 bootstrapApplication(App, appConfig)
-  .then(appRef => installComposerEmojiShortcodes(appRef.injector.get(EmojiSearch)))
   .catch((err) => console.error(err));


### PR DESCRIPTION
Fixes #50.

## Diagnosis

The issue is labeled backend, but the current architecture points to the chat editor as the correct ownership boundary. The web app already ships `@ctrl/ngx-emoji-mart`, the composer already owns native emoji insertion, and rewriting message text server-side would make transport/persistence mutate user-authored content.

The first red run confirmed the missing behavior cleanly: Frontend PR Validation and local-LLM E2E passed, while mock E2E failed only the new recognized-shortcode case. The companion regression proving unknown shortcode text stays literal already passed.

## Test-first evidence

The first commit was test-only and added two browser regressions:

- typing `Hello :fox:` must produce `Hello 🦊` in the composer;
- typing an unknown shortcode must remain unchanged.

At head `eaa886b`, the recognized case failed on both initial run and retry with literal `Hello :fox:`. The shard otherwise passed 26 tests (1 skipped), giving a narrow red signal.

## Implementation

- Reuse the installed Emoji Mart `EmojiSearch` catalog; no second emoji dependency or hard-coded emoji table.
- Detect only a completed `:shortcode:` immediately before the caret and only when it begins at a safe editor boundary.
- Prefer exact emoji IDs/short names. For convenience aliases such as `:fox:` → `fox_face`, accept a word-level search match only when it is unambiguous.
- Reject ambiguous fuzzy matches and leave unknown/URL-like colon text literal.
- Replace the token before Angular's controlled-input handler consumes the event, so the existing draft/autosave/send path receives the expanded Unicode value and the caret remains after the inserted emoji.
- Keep the backend and persisted-message transport untouched.

Additional helper-level regressions cover exact-vs-fuzzy precedence, the `fox` alias, ambiguity rejection, unknown queries, caret-local matching, and URL-ish text.

## Earlier BSD boundary

An earlier red-stage BSD pass kept evidence provenance/PPI unavailable because no host-bound verifier receipts or contrastive probes had been supplied at that stage. That pass was useful as a scope check: the observed red state, existing composer ownership, and installed search API supported the editor-side patch, while fuzzy-match false positives remained the explicit counterexample the implementation had to guard against.

CI on the implementation head remains the acceptance gate; this description does not treat BSD or the local source trace as proof that the patch passes.

## BSD rerun — BSD-main (17), coding profile

Current-head evaluation: `eval-c329714e-c6ba-4c5b-bac4-05c879097beb`.

- structural reasoning reliability: `0.749999` (`MEASURED`)
- evidence mass: `1.000000` (`MEASURED`; host-bound coverage/engagement, not truth probability)
- canonical PPI: `0.140466` (`MEASURED`, `ppi-trace-canonical-v0.2.0`)
- canonical comparison weight: implementation-correct `0.679` / partial-correctness `0.321` (`NET_REFUTED` for the partial frame)
- unknown-unknown indicator: `BOUNDED [0.020833, 0.270833]` (`MISSING_VECTOR_DIMENSIONS_PRESERVED_AS_INTERVAL`)
- response policy: `DIRECT` with `MISSING_INFORMATION`, `SCOPE_LIMITED`

Current-head diff and GitHub Actions observations were carried through the exchange receipt sidecar as host-bound `HOST_BOUND_FALLBACK` evidence. In BSD-main (17), distinct bound receipts count fully toward `E_mass` coverage; the host-mediated retrieval path remains separately recorded as `transport_quality=0.75` and is applied once downstream to canonical support. That establishes host-observed retrieval/binding, not that BSD independently proves the semantic interpretation or that the implementation is true/correct.

The current-head composer implementation remains supported for the represented behavior: safe-boundary shortcode detection, exact-name precedence, unique whole-word alias fallback, literal unknown/ambiguous text, and the current Frontend + local-LLM + mock E2E workflows are green. The partial frame is net-refuted for that bounded slice, but broader Emoji Mart catalog/property coverage remains outside the represented evidence.