### PR TITLE
Feat/Add tooling seams and file attachment download support

### DIFF
--- a/internal/agent/agentloop.go
+++ b/internal/agent/agentloop.go
@@ -33,6 +33,7 @@ func (a *Agent) handleAgentLoop(
 
 		if len(toolUses) == 0 {
 			// Model produced a final answer — no tool calls requested.
+			allGeneratedAttachments = a.appendPostToolLoopGeneratedAttachments(ctx, chatCtx, allGeneratedAttachments)
 			return result, allToolCalls, allGeneratedAttachments, nil
 		}
 
@@ -47,11 +48,27 @@ func (a *Agent) handleAgentLoop(
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to force final response: %w", err)
 			}
+			allGeneratedAttachments = a.appendPostToolLoopGeneratedAttachments(ctx, chatCtx, allGeneratedAttachments)
 			return final, allToolCalls, allGeneratedAttachments, nil
 		}
 	}
 
 	return nil, nil, nil, fmt.Errorf("agent loop ended without a final response after %d rounds", maxToolCallRounds)
+}
+
+func (a *Agent) appendPostToolLoopGeneratedAttachments(ctx context.Context, chatCtx *chatContext, existing []*models.FileAttachment) []*models.FileAttachment {
+	if chatCtx == nil || chatCtx.chat == nil || additionalGeneratedAttachmentsForChat == nil {
+		return existing
+	}
+	load := additionalGeneratedAttachmentsForChat(a, chatCtx.chat)
+	if load == nil {
+		return existing
+	}
+	extra := load(ctx)
+	if len(extra) == 0 {
+		return existing
+	}
+	return append(existing, extra...)
 }
 
 // executeToolUses executes all tool uses and returns provider-agnostic results
@@ -61,6 +78,7 @@ func (a *Agent) executeToolUses(ctx context.Context, chatCtx *chatContext, uses 
 	generatedAttachments := make([][]*models.FileAttachment, len(uses))
 	for i, use := range uses {
 		results[i], generatedAttachments[i] = a.executeToolUseWithRecovery(ctx, chatCtx, use)
+		a.notifyToolUseGeneratedAttachments(chatCtx, use, generatedAttachments[i])
 		results[i].Images = toolResultImagesFromAttachments(generatedAttachments[i])
 	}
 
@@ -90,6 +108,13 @@ func (a *Agent) executeToolUses(ctx context.Context, chatCtx *chatContext, uses 
 		flatAttachments = append(flatAttachments, perTool...)
 	}
 	return results, modelToolCalls, flatAttachments
+}
+
+func (a *Agent) notifyToolUseGeneratedAttachments(chatCtx *chatContext, use provider.ToolUse, attachments []*models.FileAttachment) {
+	if chatCtx == nil || chatCtx.chat == nil || onToolUseGeneratedAttachmentsForChat == nil || len(attachments) == 0 {
+		return
+	}
+	onToolUseGeneratedAttachmentsForChat(a, chatCtx.chat, use, attachments)
 }
 
 // executeToolUseWithRecovery executes a single tool use with panic recovery.

--- a/internal/agent/agentloop_test.go
+++ b/internal/agent/agentloop_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
 	"go.uber.org/zap"
 )
 
@@ -210,4 +212,60 @@ func TestExecuteToolUseWithRecovery_RecoversPanics(t *testing.T) {
 	assert.Contains(t, result.Output, `tool "create_agent_job" encountered an internal error`)
 	assert.Contains(t, result.Output, "panic-tool-id")
 	assert.Empty(t, attachments)
+}
+
+func TestHandleAgentLoop_AppendsPostToolLoopAttachments(t *testing.T) {
+	prev := additionalGeneratedAttachmentsForChat
+	t.Cleanup(func() { additionalGeneratedAttachmentsForChat = prev })
+
+	additionalGeneratedAttachmentsForChat = func(_ *Agent, _ *models.Chat) func(context.Context) []*models.FileAttachment {
+		return func(context.Context) []*models.FileAttachment {
+			return []*models.FileAttachment{{Name: "final.txt", FileType: "text/plain", FileContent: "aGk="}}
+		}
+	}
+
+	adapter := &scriptedAdapter{
+		callFn: func(step int) (*provider.GenerateResponse, []provider.ToolUse, error) {
+			return &provider.GenerateResponse{ID: "r-final", Text: "final-answer"}, nil, nil
+		},
+	}
+	chat := &models.Chat{ID: uuid.New(), UserID: uuid.New(), PersonalityID: uuid.New()}
+	a := &Agent{logger: zap.NewNop()}
+
+	result, _, generatedAttachments, err := a.handleAgentLoop(context.Background(), &chatContext{chat: chat}, adapter)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, generatedAttachments, 1)
+	assert.Equal(t, "final.txt", generatedAttachments[0].Name)
+}
+
+func TestExecuteToolUses_NotifiesPerToolGeneratedAttachments(t *testing.T) {
+	prev := onToolUseGeneratedAttachmentsForChat
+	prevExtra := extraToolHandlersForChat
+	t.Cleanup(func() { onToolUseGeneratedAttachmentsForChat = prev })
+	t.Cleanup(func() { extraToolHandlersForChat = prevExtra })
+
+	seen := make([]string, 0, 2)
+	onToolUseGeneratedAttachmentsForChat = func(_ *Agent, _ *models.Chat, use provider.ToolUse, atts []*models.FileAttachment) {
+		seen = append(seen, use.Name)
+		assert.NotEmpty(t, atts)
+	}
+	extraToolHandlersForChat = func(_ *Agent, _ *models.Chat) map[string]ExtraToolHandler {
+		return map[string]ExtraToolHandler{
+			"fake_tool": func(context.Context, []byte) (string, []*models.FileAttachment, error) {
+				return `{"ok":true}`, []*models.FileAttachment{{Name: "out.txt", FileType: "text/plain", FileContent: "aGk="}}, nil
+			},
+		}
+	}
+
+	a := &Agent{logger: zap.NewNop()}
+	chat := &models.Chat{ID: uuid.New(), UserID: uuid.New(), PersonalityID: uuid.New()}
+	uses := []provider.ToolUse{
+		{ID: "u1", Name: "fake_tool", Input: []byte(`{}`)},
+	}
+	ctx := &chatContext{chat: chat}
+
+	_, _, attachments := a.executeToolUses(context.Background(), ctx, uses)
+	assert.NotEmpty(t, attachments)
+	assert.Equal(t, []string{"fake_tool"}, seen)
 }

--- a/internal/agent/external_tools_seam.go
+++ b/internal/agent/external_tools_seam.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/theimaginaryfoundation/what-iff/internal/agent/provider"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+)
+
+// ExtraToolHandler matches the core tool handler contract.
+type ExtraToolHandler func(context.Context, []byte) (string, []*models.FileAttachment, error)
+
+// extraToolHandlersForChat, when non-nil, returns additional handlers keyed by
+// tool name for the active chat.
+var extraToolHandlersForChat func(a *Agent, chat *models.Chat) map[string]ExtraToolHandler
+
+// additionalDisabledToolsForChat, when non-nil, returns tool names that should
+// be hidden for this chat at runtime (for example: integration disabled by
+// missing env config). It is merged into disabled_tools policy.
+var additionalDisabledToolsForChat func(a *Agent, chat *models.Chat) map[string]bool
+
+// additionalGeneratedAttachmentsForChat, when non-nil, returns a callback that
+// may contribute extra tool-generated attachments once per assistant message
+// after the tool loop completes (for example: a final container manifest sweep).
+var additionalGeneratedAttachmentsForChat func(a *Agent, chat *models.Chat) func(context.Context) []*models.FileAttachment
+
+// additionalDeveloperContextForChat, when non-nil, returns extra developer
+// instructions appended for this chat turn.
+var additionalDeveloperContextForChat func(a *Agent, chat *models.Chat) string
+
+// onToolUseGeneratedAttachmentsForChat, when non-nil, is notified after each
+// tool use with any tool-generated attachments for this chat turn.
+var onToolUseGeneratedAttachmentsForChat func(a *Agent, chat *models.Chat, use provider.ToolUse, attachments []*models.FileAttachment)

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -407,6 +407,12 @@ func (a *Agent) ChunkPipeline() *filechunker.FileChunkPipeline { return a.chunkP
 // FileStore returns the file store for S3 archival.
 func (a *Agent) FileStore() storage.FileStore { return a.fileStore }
 
+// DataStore returns the agent datastore for extension seams.
+func (a *Agent) DataStore() *datastore.Datastore { return a.ds }
+
+// Logger returns the agent logger for extension seams.
+func (a *Agent) Logger() *zap.Logger { return a.logger }
+
 // RecordFileUpload emits a counter for a file-attachment upload attempt.
 // status should be "success" or "failure".
 func (a *Agent) RecordFileUpload(ctx context.Context, fileType, status string) {
@@ -438,22 +444,27 @@ func (a *Agent) buildModelContextForChatMessage(ctx context.Context, userID uuid
 	}
 	// Attachment labels are only injected when tools are enabled, matching the
 	// previous behavior for OpenAI chat turns.
+	additionalDevContext := ""
+	if additionalDeveloperContextForChat != nil {
+		additionalDevContext = additionalDeveloperContextForChat(a, chatCtx.chat)
+	}
 	return b.build(ctx, messageContextBuildRequest{
-		UserID:                   userID,
-		Chat:                     chatCtx.chat,
-		UserPrompt:               userPrompt,
-		CurrentMessage:           chatMessage,
-		Memories:                 chatCtx.memories,
-		LiveMemories:             chatCtx.liveMemories,
-		ActiveMood:               chatCtx.activeMood,
-		ActiveMoodRituals:        chatCtx.activeMoodRituals,
-		IsAutoMood:               chatCtx.chat.IsAutoMood,
-		MoodToolsAvailable:       a.shouldExposeMoodTools(ctx, userID, chatCtx.chat),
-		Attachments:              chatMessage.Attachments,
-		ImageBytes:               imageBytes,
-		ExpressionsEnabled:       chatCtx.expressionsEnabled,
-		IncludeAttachmentContext: chatCtx.chat.ToolsEnabled,
-		LoadHistoryImageBytes:    models.UsesAnthropicMessagesAPI(chatCtx.modelProvider, chatCtx.model),
+		UserID:                     userID,
+		Chat:                       chatCtx.chat,
+		UserPrompt:                 userPrompt,
+		CurrentMessage:             chatMessage,
+		Memories:                   chatCtx.memories,
+		LiveMemories:               chatCtx.liveMemories,
+		ActiveMood:                 chatCtx.activeMood,
+		ActiveMoodRituals:          chatCtx.activeMoodRituals,
+		IsAutoMood:                 chatCtx.chat.IsAutoMood,
+		MoodToolsAvailable:         a.shouldExposeMoodTools(ctx, userID, chatCtx.chat),
+		Attachments:                chatMessage.Attachments,
+		ImageBytes:                 imageBytes,
+		ExpressionsEnabled:         chatCtx.expressionsEnabled,
+		IncludeAttachmentContext:   chatCtx.chat.ToolsEnabled,
+		AdditionalDeveloperContext: additionalDevContext,
+		LoadHistoryImageBytes:      models.UsesAnthropicMessagesAPI(chatCtx.modelProvider, chatCtx.model),
 	})
 }
 
@@ -1947,21 +1958,42 @@ func (a *Agent) saveAgentResponse(ctx context.Context, userID, chatID uuid.UUID,
 		}
 		persistSuccesses++
 
-		// Best-effort: upload to S3/local images/ path so the gallery and Claude can
-		// access the image.
-		if created != nil && strings.HasPrefix(fileType, models.ImageMIMEPrefix) {
-			rawBytes, decodeErr := base64.StdEncoding.DecodeString(content)
-			if decodeErr == nil && len(rawBytes) > 0 {
-				imageutil.UploadBytesToGalleryPath(ctx, a.fileStore, a.logger, userID, created.ID, name, fileType, rawBytes)
-				// Persist the S3 key so delete/rename can resolve it without re-deriving.
-				imgKey := storage.FileKeyForImage(userID, created.ID, name)
-				if err := a.ds.SetFileAttachmentS3Key(ctx, userID, created.ID, imgKey); err != nil {
-					a.logger.Warn("failed to persist attachment s3_key after tool-generated image save",
-						zap.String("attachment_id", created.ID.String()),
-						zap.String("s3_key", imgKey),
-						zap.Error(err))
-				}
+		rawBytes, decodeErr := base64.StdEncoding.DecodeString(content)
+		if decodeErr != nil || len(rawBytes) == 0 {
+			a.logger.Warn("failed to decode tool-generated attachment content",
+				zap.String("chat_message_id", agentMessage.ID.String()),
+				zap.String("attachment_id", created.ID.String()),
+				zap.String("name", name),
+				zap.Error(decodeErr),
+			)
+			continue
+		}
+
+		var s3Key string
+		if strings.HasPrefix(fileType, models.ImageMIMEPrefix) {
+			// Keep generated images on the canonical gallery path (full-size + thumb).
+			imageutil.UploadBytesToGalleryPath(ctx, a.fileStore, a.logger, userID, created.ID, name, fileType, rawBytes)
+			s3Key = storage.FileKeyForImage(userID, created.ID, name)
+		} else {
+			chatIDRef := agentMessage.ChatID
+			s3Key = storage.FileKeyForAttachment(userID, created.ID, name, fileType, &chatIDRef, nil)
+			if uploadErr := a.fileStore.UploadFile(ctx, s3Key, rawBytes, fileType); uploadErr != nil {
+				a.logger.Error("failed to upload tool-generated attachment",
+					zap.String("chat_message_id", agentMessage.ID.String()),
+					zap.String("attachment_id", created.ID.String()),
+					zap.String("name", name),
+					zap.String("s3_key", s3Key),
+					zap.Error(uploadErr),
+				)
+				continue
 			}
+		}
+
+		if err := a.ds.SetFileAttachmentS3Key(ctx, userID, created.ID, s3Key); err != nil {
+			a.logger.Warn("failed to persist attachment s3_key after tool-generated attachment save",
+				zap.String("attachment_id", created.ID.String()),
+				zap.String("s3_key", s3Key),
+				zap.Error(err))
 		}
 	}
 

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -413,6 +413,14 @@ func (a *Agent) DataStore() *datastore.Datastore { return a.ds }
 // Logger returns the agent logger for extension seams.
 func (a *Agent) Logger() *zap.Logger { return a.logger }
 
+// DeleteProviderFileAttachment deletes a provider-managed file by provider file ID.
+func (a *Agent) DeleteProviderFileAttachment(ctx context.Context, fileID string) error {
+	if a == nil || a.OpenAIProvider == nil {
+		return fmt.Errorf("openai provider is not configured")
+	}
+	return a.OpenAIProvider.DeleteFileAttachment(ctx, fileID)
+}
+
 // RecordFileUpload emits a counter for a file-attachment upload attempt.
 // status should be "success" or "failure".
 func (a *Agent) RecordFileUpload(ctx context.Context, fileType, status string) {

--- a/internal/agent/message_context_builder.go
+++ b/internal/agent/message_context_builder.go
@@ -64,8 +64,9 @@ type messageContextBuildRequest struct {
 	// OpenAI path; the OpenAI renderer uses FileID and ignores RawBytes entirely.
 	ImageBytes map[uuid.UUID][]byte
 
-	ExpressionsEnabled       bool
-	IncludeAttachmentContext bool
+	ExpressionsEnabled         bool
+	IncludeAttachmentContext   bool
+	AdditionalDeveloperContext string
 	// LoadHistoryImageBytes controls whether prior-turn image attachments are loaded
 	// as raw bytes for Claude vision. OpenAI uses FileID from attachment records.
 	LoadHistoryImageBytes bool
@@ -92,6 +93,9 @@ func (b *messageContextBuilder) build(ctx context.Context, req messageContextBui
 	})
 	if req.ExpressionsEnabled {
 		b.appendPriorTurnExpressionContinuity(ctx, req.UserID, modelCtx, carryOver, history)
+	}
+	if extra := strings.TrimSpace(req.AdditionalDeveloperContext); extra != "" {
+		modelCtx.Append(provider.SegmentKindDeveloperContext, provider.RoleDeveloper, extra, false)
 	}
 	modelCtx.AppendUserMessage(provider.RoleUser, req.UserPrompt, userMessageImagesFromAttachments(req.Attachments, req.ImageBytes), false)
 	return modelCtx, nil

--- a/internal/agent/message_context_builder_test.go
+++ b/internal/agent/message_context_builder_test.go
@@ -224,6 +224,40 @@ func TestMessageContextBuilder_Build_InjectsPersistedToolResults(t *testing.T) {
 	require.Contains(t, joined, tools.RecallToolSpec.Name)
 }
 
+func TestMessageContextBuilder_Build_AppendsAdditionalDeveloperContextBeforeUser(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	userID := uuid.New()
+	chat := &models.Chat{ID: uuid.New(), SystemPrompt: "be helpful"}
+	tel := &telemetry.Telemetry{Logger: zap.NewNop()}
+	b, err := newMessageContextBuilder(nil, tel, nil, func(_ context.Context, _, _ uuid.UUID, _ uuid.UUID, _ int, _ *time.Time, _ string) []*models.ChatMessage {
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	mc, err := b.build(ctx, messageContextBuildRequest{
+		UserID:                     userID,
+		Chat:                       chat,
+		UserPrompt:                 "final user text",
+		AdditionalDeveloperContext: "extra shell guidance",
+	})
+	require.NoError(t, err)
+
+	var devIdx, userIdx int
+	devIdx, userIdx = -1, -1
+	for i, s := range mc.Segments {
+		if s.Kind == provider.SegmentKindDeveloperContext && s.Content == "extra shell guidance" {
+			devIdx = i
+		}
+		if s.Kind == provider.SegmentKindUserMessage {
+			userIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, devIdx, 0, "expected injected developer context segment")
+	require.GreaterOrEqual(t, userIdx, 0, "expected user message segment")
+	require.Less(t, devIdx, userIdx, "developer guidance must be placed before user message")
+}
+
 func TestMessageContextBuilder_SelectCarryOverTurns_InvalidMax(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/agent/message_coverage_test.go
+++ b/internal/agent/message_coverage_test.go
@@ -116,6 +116,25 @@ func TestChunkPipelineAndFileStore_ReturnConfiguredFields(t *testing.T) {
 	require.Nil(t, a.FileStore())
 }
 
+func TestDataStoreAndLogger_ReturnConfiguredFields(t *testing.T) {
+	t.Parallel()
+	ds, _, cleanup := newTestDatastore(t)
+	defer cleanup()
+
+	logger := zap.NewNop()
+	a := &Agent{ds: ds, logger: logger}
+
+	require.Same(t, ds, a.DataStore())
+	require.Same(t, logger, a.Logger())
+}
+
+func TestDeleteProviderFileAttachment_NoProviderConfigured(t *testing.T) {
+	t.Parallel()
+	a := &Agent{logger: zap.NewNop()}
+	err := a.DeleteProviderFileAttachment(context.Background(), "file_123")
+	require.ErrorContains(t, err, "openai provider is not configured")
+}
+
 // --- RecordFileUpload / recordCounter / recordTime / recordCountHistogram no-telemetry guards ---
 
 func TestRecordFileUpload_NoopWithNilTelemetry(t *testing.T) {
@@ -253,11 +272,11 @@ func TestMaxTurnsBeforeCheckpoint(t *testing.T) {
 func TestNewJobDraftDeltaBuffer_NilInputsReturnEmptyBuffer(t *testing.T) {
 	t.Parallel()
 
-	b := newJobDraftDeltaBuffer(nil, nil, zap.NewNop(), nil, 96, time.Second)
+	b := newJobDraftDeltaBuffer(context.TODO(), nil, zap.NewNop(), nil, 96, time.Second)
 	require.Nil(t, b.ds)
 
 	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
-	b2 := newJobDraftDeltaBuffer(nil, nil, zap.NewNop(), job, 96, time.Second)
+	b2 := newJobDraftDeltaBuffer(context.TODO(), nil, zap.NewNop(), job, 96, time.Second)
 	require.Nil(t, b2.ds, "nil datastore keeps buffer inert even with a valid job")
 }
 
@@ -268,7 +287,7 @@ func TestNewJobDraftDeltaBuffer_DefaultsInvalidConfig(t *testing.T) {
 	defer cleanup()
 
 	job := &models.Job{ID: uuid.New(), UserID: uuid.New()}
-	b := newJobDraftDeltaBuffer(nil, ds, zap.NewNop(), job, 0, 0)
+	b := newJobDraftDeltaBuffer(context.TODO(), ds, zap.NewNop(), job, 0, 0)
 	require.NotNil(t, b.ds)
 	require.Equal(t, 1, b.minChunkChars)
 	require.Equal(t, 250*time.Millisecond, b.maxWait)

--- a/internal/agent/processtoolcall.go
+++ b/internal/agent/processtoolcall.go
@@ -38,7 +38,7 @@ func (a *Agent) dispatchToolUse(ctx context.Context, chatCtx *chatContext, use p
 type toolHandler func(context.Context, []byte) (string, []*models.FileAttachment, error)
 
 func (a *Agent) toolHandlers(chatCtx *chatContext) map[string]toolHandler {
-	return map[string]toolHandler{
+	handlers := map[string]toolHandler{
 		tools.UpdateScratchpadToolSpec.Name: func(ctx context.Context, input []byte) (string, []*models.FileAttachment, error) {
 			out, err := a.scratchpadTool.UpdateScratchpadTool(ctx, chatCtx.chat, input)
 			return out, nil, err
@@ -78,4 +78,13 @@ func (a *Agent) toolHandlers(chatCtx *chatContext) map[string]toolHandler {
 			return out, attachments, err
 		},
 	}
+	if extraToolHandlersForChat != nil {
+		for name, h := range extraToolHandlersForChat(a, chatCtx.chat) {
+			if h == nil {
+				continue
+			}
+			handlers[name] = toolHandler(h)
+		}
+	}
+	return handlers
 }

--- a/internal/agent/processtoolcall_test.go
+++ b/internal/agent/processtoolcall_test.go
@@ -25,6 +25,15 @@ func TestGetAgentToolsList_IncludesCreateJobByDefault(t *testing.T) {
 	require.True(t, hasCreateJob)
 }
 
+func TestGetAgentToolsList_RespectsDisabledTools(t *testing.T) {
+	list := getAgentToolsList(map[string]bool{"create_agent_job": true}, false)
+	for _, tool := range list {
+		if tool.OfFunction != nil && tool.OfFunction.Name == "create_agent_job" {
+			t.Fatalf("create_agent_job should have been filtered out")
+		}
+	}
+}
+
 func TestGetAgentToolsList_IncludesGenerateImageTool(t *testing.T) {
 	list := getAgentToolsList(nil, true)
 	hasGenerateImage := false
@@ -87,6 +96,28 @@ func TestExecutableCatalogToolsHaveHandlers(t *testing.T) {
 	for _, spec := range tools.ExecutableFunctionToolSpecs() {
 		require.Contains(t, handlers, spec.Name)
 	}
+}
+
+func TestToolHandlers_ExtraHandlersOverrideDefaults(t *testing.T) {
+	prev := extraToolHandlersForChat
+	t.Cleanup(func() { extraToolHandlersForChat = prev })
+
+	extraToolHandlersForChat = func(_ *Agent, _ *models.Chat) map[string]ExtraToolHandler {
+		return map[string]ExtraToolHandler{
+			"list": func(context.Context, []byte) (string, []*models.FileAttachment, error) {
+				return `{"source":"extra"}`, nil, nil
+			},
+		}
+	}
+
+	a := &Agent{logger: zap.NewNop()}
+	out, _, err := a.dispatchToolUse(context.Background(), &chatContext{chat: &models.Chat{}}, provider.ToolUse{
+		ID:    "override-list",
+		Name:  "list",
+		Input: []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.Contains(t, out, `"source":"extra"`)
 }
 
 func TestDispatchToolUse_CreateAgentJobValidation_NoAttachments(t *testing.T) {

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -69,6 +69,13 @@ func (a *Agent) buildTurnToolPolicy(ctx context.Context, chatCtx *chatContext, u
 	if !policy.toolsEnabled {
 		return policy
 	}
+	if additionalDisabledToolsForChat != nil {
+		for name, disabled := range additionalDisabledToolsForChat(a, chatCtx.chat) {
+			if disabled {
+				policy.disabledTools[name] = true
+			}
+		}
+	}
 
 	return policy
 }

--- a/internal/agent/tools/catalog.go
+++ b/internal/agent/tools/catalog.go
@@ -24,14 +24,16 @@ var functionToolCatalog = []FunctionToolDefinition{
 }
 
 func FunctionToolCatalog() []FunctionToolDefinition {
-	out := make([]FunctionToolDefinition, len(functionToolCatalog))
-	copy(out, functionToolCatalog)
+	catalog := mergedFunctionToolCatalog()
+	out := make([]FunctionToolDefinition, len(catalog))
+	copy(out, catalog)
 	return out
 }
 
 func AgentFunctionToolSpecs(includeMoodTools bool) []FunctionToolSpec {
-	specs := make([]FunctionToolSpec, 0, len(functionToolCatalog))
-	for _, def := range functionToolCatalog {
+	catalog := mergedFunctionToolCatalog()
+	specs := make([]FunctionToolSpec, 0, len(catalog))
+	for _, def := range catalog {
 		if !def.AgentDefault {
 			continue
 		}
@@ -44,8 +46,9 @@ func AgentFunctionToolSpecs(includeMoodTools bool) []FunctionToolSpec {
 }
 
 func UserToggleableFunctionToolSpecs() []FunctionToolSpec {
-	specs := make([]FunctionToolSpec, 0, len(functionToolCatalog))
-	for _, def := range functionToolCatalog {
+	catalog := mergedFunctionToolCatalog()
+	specs := make([]FunctionToolSpec, 0, len(catalog))
+	for _, def := range catalog {
 		if def.UserToggleable {
 			specs = append(specs, def.Spec)
 		}
@@ -54,8 +57,9 @@ func UserToggleableFunctionToolSpecs() []FunctionToolSpec {
 }
 
 func ExecutableFunctionToolSpecs() []FunctionToolSpec {
-	specs := make([]FunctionToolSpec, 0, len(functionToolCatalog))
-	for _, def := range functionToolCatalog {
+	catalog := mergedFunctionToolCatalog()
+	specs := make([]FunctionToolSpec, 0, len(catalog))
+	for _, def := range catalog {
 		specs = append(specs, def.Spec)
 	}
 	return specs

--- a/internal/agent/tools/external_catalog_seam.go
+++ b/internal/agent/tools/external_catalog_seam.go
@@ -1,0 +1,17 @@
+package tools
+
+// AdditionalFunctionToolCatalog, when non-nil, can contribute extra function
+// tool definitions at runtime.
+var AdditionalFunctionToolCatalog func() []FunctionToolDefinition
+
+func mergedFunctionToolCatalog() []FunctionToolDefinition {
+	out := make([]FunctionToolDefinition, 0, len(functionToolCatalog)+2)
+	out = append(out, functionToolCatalog...)
+	if AdditionalFunctionToolCatalog != nil {
+		extras := AdditionalFunctionToolCatalog()
+		if len(extras) > 0 {
+			out = append(out, extras...)
+		}
+	}
+	return out
+}

--- a/internal/agent/tools/external_catalog_seam_test.go
+++ b/internal/agent/tools/external_catalog_seam_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergedFunctionToolCatalog_DefaultOnly(t *testing.T) {
+	t.Parallel()
+	prev := AdditionalFunctionToolCatalog
+	t.Cleanup(func() { AdditionalFunctionToolCatalog = prev })
+	AdditionalFunctionToolCatalog = nil
+
+	got := mergedFunctionToolCatalog()
+	require.Equal(t, len(functionToolCatalog), len(got))
+	require.Equal(t, functionToolCatalog[0].Spec.Name, got[0].Spec.Name)
+}
+
+func TestMergedFunctionToolCatalog_AppendsExtras(t *testing.T) {
+	t.Parallel()
+	prev := AdditionalFunctionToolCatalog
+	t.Cleanup(func() { AdditionalFunctionToolCatalog = prev })
+
+	extra := FunctionToolDefinition{
+		Spec:         FunctionToolSpec{Name: "extra_tool", Description: "extra tool", Properties: map[string]any{}},
+		AgentDefault: true,
+	}
+	AdditionalFunctionToolCatalog = func() []FunctionToolDefinition { return []FunctionToolDefinition{extra} }
+
+	got := mergedFunctionToolCatalog()
+	require.Equal(t, len(functionToolCatalog)+1, len(got))
+	require.Equal(t, extra.Spec.Name, got[len(got)-1].Spec.Name)
+}

--- a/internal/agent/tools/recall.go
+++ b/internal/agent/tools/recall.go
@@ -229,8 +229,10 @@ func (a recallArgs) wantsCurrentConversation() bool {
 type recallChunk struct {
 	SourceType string `json:"source_type"` // "file" | "conversation" | "summary"
 	Name       string `json:"name"`        // file name, conversation name, or chat name (summary)
-	Index      int    `json:"index"`       // chunk sequence / message ordinal
-	Text       string `json:"text"`
+	// AttachmentID is set for file chunks sourced from a file attachment.
+	AttachmentID string `json:"attachment_id,omitempty"`
+	Index        int    `json:"index"` // chunk sequence / message ordinal
+	Text         string `json:"text"`
 	// ConversationID is set on "summary" chunks: the conversation the summary was checkpointed
 	// from, so the model can hop straight into conversation/fetch mode for the full source.
 	ConversationID string `json:"conversation_id,omitempty"`

--- a/internal/agent/tools/recall_modes.go
+++ b/internal/agent/tools/recall_modes.go
@@ -102,7 +102,16 @@ func (t *RecallTool) gather(ctx context.Context, chat *models.Chat, query, src s
 			if !withinWindow(c.CreatedAt, window) {
 				continue
 			}
-			r.chunks = append(r.chunks, recallChunk{SourceType: "file", Name: c.FileName, Index: c.Sequence, Text: c.Content})
+			chunk := recallChunk{
+				SourceType: "file",
+				Name:       c.FileName,
+				Index:      c.Sequence,
+				Text:       c.Content,
+			}
+			if c.FileAttachmentID != uuid.Nil {
+				chunk.AttachmentID = c.FileAttachmentID.String()
+			}
+			r.chunks = append(r.chunks, chunk)
 			if added++; added >= maxChunks {
 				break
 			}
@@ -437,7 +446,16 @@ func (t *RecallTool) fetchFileChunks(ctx context.Context, faID uuid.UUID, name, 
 	chunks := make([]recallChunk, 0, end-start)
 	for i := start; i < end; i++ {
 		c := rows[i]
-		chunks = append(chunks, recallChunk{SourceType: "file", Name: c.FileName, Index: c.Sequence, Text: c.Content})
+		chunk := recallChunk{
+			SourceType: "file",
+			Name:       c.FileName,
+			Index:      c.Sequence,
+			Text:       c.Content,
+		}
+		if c.FileAttachmentID != uuid.Nil {
+			chunk.AttachmentID = c.FileAttachmentID.String()
+		}
+		chunks = append(chunks, chunk)
 	}
 
 	res := recallResult{Mode: recallModeFetch, Chunks: chunks}

--- a/internal/agent/tools/recall_test.go
+++ b/internal/agent/tools/recall_test.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
 	"github.com/theimaginaryfoundation/what-iff/internal/storage"
@@ -1372,4 +1373,31 @@ func TestTimeScopeReceiptLastN(t *testing.T) {
 	if r.NormalizedEnd != now.Format(time.RFC3339) {
 		t.Fatalf("unexpected end: %+v", r)
 	}
+}
+
+func TestParseBookmarkFetchTargetAndBuilder(t *testing.T) {
+	chatID := uuid.New()
+	messageID := uuid.New()
+	target := bookmarkFetchTarget(chatID, messageID)
+
+	gotChatID, gotMessageID, err := parseBookmarkFetchTarget(target)
+	require.NoError(t, err)
+	require.Equal(t, chatID, gotChatID)
+	require.Equal(t, messageID, gotMessageID)
+
+	_, _, err = parseBookmarkFetchTarget("bookmark:not-a-uuid")
+	require.Error(t, err)
+}
+
+func TestConversationWindow_UsesCursorBounds(t *testing.T) {
+	now := time.Now().UTC()
+	min := now.Add(-2 * time.Hour).Format(time.RFC3339Nano)
+	max := now.Add(-1 * time.Hour).Format(time.RFC3339Nano)
+
+	window, err := conversationWindow("last 7 days", recallCursor{MinSentAt: min, MaxSentAt: max}, now)
+	require.NoError(t, err)
+	require.NotNil(t, window.Min)
+	require.NotNil(t, window.Max)
+	require.Equal(t, min, window.Min.UTC().Format(time.RFC3339Nano))
+	require.Equal(t, max, window.Max.UTC().Format(time.RFC3339Nano))
 }

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -1,10 +1,15 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	agenttools "github.com/theimaginaryfoundation/what-iff/internal/agent/tools"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"go.uber.org/zap"
 )
 
 func TestGetChatToolsAddsWebSearch(t *testing.T) {
@@ -20,4 +25,36 @@ func TestGetChatToolsRespectsWebSearchToggle(t *testing.T) {
 	})
 
 	require.Empty(t, tools)
+}
+
+func TestDisabledToolsSetReturnsEmptyMapForEmptyInput(t *testing.T) {
+	t.Parallel()
+	set := disabledToolsSet(nil)
+	require.NotNil(t, set)
+	require.Empty(t, set)
+}
+
+func TestBuildTurnToolPolicy_StripsMoodToolsAndMergesAdditionalDisabled(t *testing.T) {
+	t.Parallel()
+	prev := additionalDisabledToolsForChat
+	t.Cleanup(func() { additionalDisabledToolsForChat = prev })
+
+	additionalDisabledToolsForChat = func(_ *Agent, _ *models.Chat) map[string]bool {
+		return map[string]bool{"run_subagent": true}
+	}
+
+	a := &Agent{logger: zap.NewNop()}
+	chat := &models.Chat{
+		ID:            uuid.New(),
+		UserID:        uuid.New(),
+		ToolsEnabled:  true,
+		DisabledTools: []string{agenttools.ListMoodsToolSpec.Name, agenttools.ChangeMoodToolSpec.Name},
+	}
+	chatCtx := &chatContext{chat: chat}
+
+	policy := a.buildTurnToolPolicy(context.Background(), chatCtx, chat.UserID, &models.ChatMessage{})
+	require.True(t, policy.toolsEnabled)
+	assert.False(t, policy.disabledTools[agenttools.ListMoodsToolSpec.Name], "system mood tools should never be user-disabled")
+	assert.False(t, policy.disabledTools[agenttools.ChangeMoodToolSpec.Name], "system mood tools should never be user-disabled")
+	assert.True(t, policy.disabledTools["run_subagent"], "runtime disabled tools should be merged")
 }

--- a/internal/datastore/filechunk.go
+++ b/internal/datastore/filechunk.go
@@ -31,10 +31,11 @@ type FileChunkInput struct {
 
 // FileChunkResult represents a file chunk returned from a similarity search
 type FileChunkResult struct {
-	Content  string
-	FileName string
-	Sequence int
-	Score    float64
+	Content          string
+	FileName         string
+	FileAttachmentID uuid.UUID
+	Sequence         int
+	Score            float64
 	// CreatedAt is the parent file attachment's upload time. Populated so callers can
 	// time-filter file results (e.g. recall's time_scope). Zero when the attachment edge
 	// was not loaded.
@@ -164,7 +165,7 @@ func (d *Datastore) GetRelatedFileChunks(ctx context.Context, userID uuid.UUID, 
 	// Vector is passed as $1 (parameterized) to avoid SQL injection from string interpolation.
 
 	baseQuery := `
-		SELECT fc.content, fa.name, fc.sequence, fc.embedding <-> $1::vector AS score, fa.created_at
+		SELECT fc.content, fa.name, fa.id, fc.sequence, fc.embedding <-> $1::vector AS score, fa.created_at
 		FROM file_chunks fc
 		JOIN file_attachments fa ON fc.file_chunk_file_attachment = fa.id
 		WHERE fa.user_file_attachments = $2`
@@ -221,7 +222,7 @@ func (d *Datastore) GetRelatedFileChunks(ctx context.Context, userID uuid.UUID, 
 	var results []FileChunkResult
 	for rows.Next() {
 		var r FileChunkResult
-		if err := rows.Scan(&r.Content, &r.FileName, &r.Sequence, &r.Score, &r.CreatedAt); err != nil {
+		if err := rows.Scan(&r.Content, &r.FileName, &r.FileAttachmentID, &r.Sequence, &r.Score, &r.CreatedAt); err != nil {
 			d.logger.Error(i18n.T("filechunk.scan_failed"), zap.Error(err))
 			return nil, err
 		}
@@ -270,10 +271,11 @@ func (d *Datastore) ListFileChunksForAttachment(ctx context.Context, fileAttachm
 			createdAt = row.Edges.FileAttachment.CreatedAt
 		}
 		results = append(results, FileChunkResult{
-			Content:   row.Content,
-			FileName:  name,
-			Sequence:  row.Sequence,
-			CreatedAt: createdAt,
+			Content:          row.Content,
+			FileName:         name,
+			FileAttachmentID: fileAttachmentID,
+			Sequence:         row.Sequence,
+			CreatedAt:        createdAt,
 		})
 	}
 	return results, nil

--- a/internal/datastore/filechunk_test.go
+++ b/internal/datastore/filechunk_test.go
@@ -121,9 +121,9 @@ func TestGetRelatedFileChunks_WithResults(t *testing.T) {
 
 	// Expect the SELECT query with JOINs (no transaction for read-only query)
 	chunkCreatedAt := time.Now().UTC().Truncate(time.Second)
-	rows := sqlmock.NewRows([]string{"content", "name", "sequence", "score", "created_at"}).
-		AddRow("relevant chunk content", "document.pdf", 0, 0.85, chunkCreatedAt).
-		AddRow("another relevant chunk", "notes.txt", 1, 0.92, chunkCreatedAt)
+	rows := sqlmock.NewRows([]string{"content", "name", "id", "sequence", "score", "created_at"}).
+		AddRow("relevant chunk content", "document.pdf", uuid.New(), 0, 0.85, chunkCreatedAt).
+		AddRow("another relevant chunk", "notes.txt", uuid.New(), 1, 0.92, chunkCreatedAt)
 
 	mock.ExpectQuery("SELECT.*file_chunks.*").
 		WithArgs(sqlmock.AnyArg(), userID, personalityID, chatID, FileChunkRelevanceThreshold, 10).
@@ -157,7 +157,7 @@ func TestGetRelatedFileChunks_NoResults(t *testing.T) {
 	queryEmbedding := []float32{0.1, 0.2, 0.3}
 
 	// Expect the SELECT query returning no rows (no transaction for read-only query)
-	rows := sqlmock.NewRows([]string{"content", "name", "sequence", "score", "created_at"})
+	rows := sqlmock.NewRows([]string{"content", "name", "id", "sequence", "score", "created_at"})
 
 	mock.ExpectQuery("SELECT.*file_chunks.*").
 		WithArgs(sqlmock.AnyArg(), userID, personalityID, chatID, FileChunkRelevanceThreshold, 10).
@@ -179,8 +179,8 @@ func TestGetRelatedFileChunks_PersonalityOnly(t *testing.T) {
 	queryEmbedding := []float32{0.1, 0.2, 0.3}
 
 	// Expect the SELECT query with only personality filter (no chat subquery, no transaction)
-	rows := sqlmock.NewRows([]string{"content", "name", "sequence", "score", "created_at"}).
-		AddRow("personality chunk", "persona-doc.pdf", 0, 0.75, time.Now())
+	rows := sqlmock.NewRows([]string{"content", "name", "id", "sequence", "score", "created_at"}).
+		AddRow("personality chunk", "persona-doc.pdf", uuid.New(), 0, 0.75, time.Now())
 
 	mock.ExpectQuery("SELECT.*file_chunks.*").
 		WithArgs(sqlmock.AnyArg(), userID, personalityID, FileChunkRelevanceThreshold, 5).
@@ -207,8 +207,8 @@ func TestGetRelatedFileChunks_ChatOnly(t *testing.T) {
 	queryEmbedding := []float32{0.1, 0.2, 0.3}
 
 	// Expect the SELECT query with only chat filter (no personality filter, no transaction)
-	rows := sqlmock.NewRows([]string{"content", "name", "sequence", "score", "created_at"}).
-		AddRow("chat chunk", "uploaded-file.txt", 2, 0.60, time.Now())
+	rows := sqlmock.NewRows([]string{"content", "name", "id", "sequence", "score", "created_at"}).
+		AddRow("chat chunk", "uploaded-file.txt", uuid.New(), 2, 0.60, time.Now())
 
 	mock.ExpectQuery("SELECT.*file_chunks.*").
 		WithArgs(sqlmock.AnyArg(), userID, chatID, FileChunkRelevanceThreshold, 5).

--- a/internal/datastore/filechunk_test.go
+++ b/internal/datastore/filechunk_test.go
@@ -274,3 +274,21 @@ func TestGetRelatedFileChunks_NoContext(t *testing.T) {
 func TestFileChunkRelevanceThreshold(t *testing.T) {
 	assert.Equal(t, 1.2, FileChunkRelevanceThreshold)
 }
+
+func TestSetFileChunkStatus_Success(t *testing.T) {
+	ds, mock, cleanup := newMockDatastore(t)
+	defer cleanup()
+
+	fileAttachmentID := uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE .*file_attachments.*").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT.*file_attachments.*").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "file_id", "name", "file_type", "file_content", "chunk_status", "created_at"}).
+			AddRow(fileAttachmentID, "file-123", "test.pdf", "application/pdf", nil, "chunked", time.Now()))
+	mock.ExpectCommit()
+
+	err := ds.SetFileChunkStatus(context.Background(), fileAttachmentID, "chunked")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/handlers/fileattachment/fileattachment.go
+++ b/internal/handlers/fileattachment/fileattachment.go
@@ -1,15 +1,20 @@
 package fileattachment
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
 	"github.com/theimaginaryfoundation/what-iff/internal/handlers/handlerutils"
 	"github.com/theimaginaryfoundation/what-iff/internal/middleware"
 	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"github.com/theimaginaryfoundation/what-iff/internal/storage"
 	"go.uber.org/zap"
 )
 
@@ -131,4 +136,89 @@ func (h *Handler) DeleteFileAttachment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handlerutils.RespondWithJSON(w, h.logger, http.StatusOK, nil)
+}
+
+// GetFileAttachmentContent returns attachment bytes for the authenticated user.
+func (h *Handler) GetFileAttachmentContent(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserIDFromContext(r.Context())
+	if !ok {
+		handlerutils.RespondWithError(w, h.logger, http.StatusUnauthorized, handlerutils.CodeNotSet, "Unauthorized", nil)
+		return
+	}
+
+	idStr := mux.Vars(r)["id"]
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		handlerutils.RespondWithError(w, h.logger, http.StatusBadRequest, handlerutils.CodeNotSet, "Invalid attachment ID", err)
+		return
+	}
+
+	attachment, err := h.ds.GetFileAttachment(r.Context(), userID, id)
+	if err != nil {
+		if errors.Is(err, datastore.ErrFileAttachmentNotFound) {
+			handlerutils.RespondWithError(w, h.logger, http.StatusNotFound, handlerutils.CodeNotSet, "File attachment not found", nil)
+		} else {
+			handlerutils.RespondWithError(w, h.logger, http.StatusInternalServerError, handlerutils.CodeNotSet, "Failed to fetch file attachment", err)
+		}
+		return
+	}
+
+	fileStore := h.agent.FileStore()
+	if fileStore == nil {
+		handlerutils.RespondWithError(w, h.logger, http.StatusNotFound, handlerutils.CodeNotSet, "File storage not configured", nil)
+		return
+	}
+
+	keys := make([]string, 0, 2)
+	if k := strings.TrimSpace(attachment.S3Key); k != "" {
+		keys = append(keys, k)
+	}
+	keys = append(keys, storage.FileKeyForAttachment(
+		userID,
+		attachment.ID,
+		attachment.Name,
+		attachment.FileType,
+		attachment.ChatMessageID,
+		attachment.PersonalityID,
+	))
+
+	var data []byte
+	for _, key := range keys {
+		blob, downloadErr := fileStore.DownloadFile(r.Context(), key)
+		if downloadErr != nil {
+			handlerutils.RespondWithError(
+				w,
+				h.logger,
+				http.StatusInternalServerError,
+				handlerutils.CodeNotSet,
+				fmt.Sprintf("Failed to download file attachment %q", attachment.Name),
+				downloadErr,
+			)
+			return
+		}
+		if len(blob) != 0 {
+			data = blob
+			break
+		}
+	}
+	if len(data) == 0 {
+		handlerutils.RespondWithError(w, h.logger, http.StatusNotFound, handlerutils.CodeNotSet, "File content not available", nil)
+		return
+	}
+
+	contentType := strings.TrimSpace(attachment.FileType)
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	filename := strings.TrimSpace(attachment.Name)
+	if filename == "" {
+		filename = attachment.ID.String()
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	w.Header().Set("Cache-Control", "private, max-age=3600")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
 }

--- a/internal/handlers/fileattachment/fileattachment.go
+++ b/internal/handlers/fileattachment/fileattachment.go
@@ -122,7 +122,7 @@ func (h *Handler) DeleteFileAttachment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if fileAttachment.FileID != nil {
-		err = h.agent.OpenAIProvider.DeleteFileAttachment(r.Context(), *fileAttachment.FileID)
+		err = h.agent.DeleteProviderFileAttachment(r.Context(), *fileAttachment.FileID)
 		if err != nil {
 			handlerutils.RespondWithError(w, h.logger, http.StatusInternalServerError, handlerutils.CodeNotSet, "Error deleting file attachment", err)
 			return

--- a/internal/handlers/fileattachment/fileattachment_test.go
+++ b/internal/handlers/fileattachment/fileattachment_test.go
@@ -1,0 +1,396 @@
+package fileattachment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
+	"github.com/theimaginaryfoundation/what-iff/internal/middleware"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"github.com/theimaginaryfoundation/what-iff/internal/storage"
+	"go.uber.org/zap"
+)
+
+type stubStore struct {
+	listFn   func(context.Context, uuid.UUID, int, int, models.FileAttachmentFilters) (*models.PaginatedResponse, error)
+	getFn    func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error)
+	deleteFn func(context.Context, uuid.UUID, uuid.UUID) error
+}
+
+func (s stubStore) ListFileAttachments(ctx context.Context, userID uuid.UUID, pageNum, pageSize int, filters models.FileAttachmentFilters) (*models.PaginatedResponse, error) {
+	return s.listFn(ctx, userID, pageNum, pageSize, filters)
+}
+
+func (s stubStore) GetFileAttachment(ctx context.Context, userID, id uuid.UUID) (*models.FileAttachment, error) {
+	return s.getFn(ctx, userID, id)
+}
+
+func (s stubStore) DeleteFileAttachment(ctx context.Context, userID, id uuid.UUID) error {
+	return s.deleteFn(ctx, userID, id)
+}
+
+type stubAgent struct {
+	store         storage.FileStore
+	deleteErr     error
+	deletedFileID string
+}
+
+func (a *stubAgent) FileStore() storage.FileStore { return a.store }
+
+func (a *stubAgent) DeleteProviderFileAttachment(_ context.Context, fileID string) error {
+	a.deletedFileID = fileID
+	return a.deleteErr
+}
+
+type stubFileStore struct {
+	contentByKey map[string][]byte
+	errByKey     map[string]error
+	seenKeys     []string
+}
+
+func (s *stubFileStore) UploadFile(context.Context, string, []byte, string) error { return nil }
+func (s *stubFileStore) DeleteFile(context.Context, string) error                 { return nil }
+func (s *stubFileStore) DownloadFile(_ context.Context, key string) ([]byte, error) {
+	s.seenKeys = append(s.seenKeys, key)
+	if err := s.errByKey[key]; err != nil {
+		return nil, err
+	}
+	return s.contentByKey[key], nil
+}
+
+func requestWithUser(t *testing.T, method, url string) (*http.Request, uuid.UUID) {
+	t.Helper()
+	userID := uuid.New()
+	req := httptest.NewRequest(method, url, nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	return req, userID
+}
+
+func TestListFileAttachments_Unauthorized(t *testing.T) {
+	h := &Handler{logger: zap.NewNop()}
+	req := httptest.NewRequest(http.MethodGet, "/file-attachment", nil)
+	rec := httptest.NewRecorder()
+
+	h.ListFileAttachments(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestListFileAttachments_ParsesFiltersAndReturnsPage(t *testing.T) {
+	var gotPage, gotLimit int
+	var gotFilters models.FileAttachmentFilters
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			listFn: func(_ context.Context, _ uuid.UUID, page, limit int, filters models.FileAttachmentFilters) (*models.PaginatedResponse, error) {
+				gotPage, gotLimit = page, limit
+				gotFilters = filters
+				return &models.PaginatedResponse{Results: []any{}, TotalCount: 0, Page: page}, nil
+			},
+		},
+	}
+	msgID := uuid.New()
+	persID := uuid.New()
+	minDate := time.Now().UTC().Add(-48 * time.Hour).Format(time.RFC3339)
+	maxDate := time.Now().UTC().Format(time.RFC3339)
+	req, _ := requestWithUser(t, http.MethodGet,
+		"/file-attachment?page=2&limit=7&name=notes&file_type=text&chat_message_id="+msgID.String()+"&personality_id="+persID.String()+"&docs_only=true&min_date="+minDate+"&max_date="+maxDate)
+	rec := httptest.NewRecorder()
+
+	h.ListFileAttachments(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 2, gotPage)
+	require.Equal(t, 7, gotLimit)
+	require.NotNil(t, gotFilters.Name)
+	require.Equal(t, "notes", *gotFilters.Name)
+	require.NotNil(t, gotFilters.FileType)
+	require.Equal(t, "text", *gotFilters.FileType)
+	require.NotNil(t, gotFilters.ChatMessageID)
+	require.Equal(t, msgID, *gotFilters.ChatMessageID)
+	require.NotNil(t, gotFilters.PersonalityID)
+	require.Equal(t, persID, *gotFilters.PersonalityID)
+	require.NotNil(t, gotFilters.DocsOnly)
+	require.True(t, *gotFilters.DocsOnly)
+	require.NotNil(t, gotFilters.MinDate)
+	require.NotNil(t, gotFilters.MaxDate)
+}
+
+func TestDeleteFileAttachment_InvalidID(t *testing.T) {
+	h := &Handler{logger: zap.NewNop(), ds: stubStore{}, agent: &stubAgent{}}
+	req, _ := requestWithUser(t, http.MethodDelete, "/file-attachment/not-a-uuid")
+	req = mux.SetURLVars(req, map[string]string{"id": "not-a-uuid"})
+	rec := httptest.NewRecorder()
+
+	h.DeleteFileAttachment(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDeleteFileAttachment_ProviderDeleteError(t *testing.T) {
+	fileID := "provider-file-id"
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return &models.FileAttachment{ID: uuid.New(), FileID: &fileID}, nil
+			},
+			deleteFn: func(context.Context, uuid.UUID, uuid.UUID) error { return nil },
+		},
+		agent: &stubAgent{deleteErr: errors.New("delete failed")},
+	}
+	id := uuid.New()
+	req, _ := requestWithUser(t, http.MethodDelete, "/file-attachment/"+id.String())
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	rec := httptest.NewRecorder()
+
+	h.DeleteFileAttachment(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestDeleteFileAttachment_SuccessWithoutProviderFileID(t *testing.T) {
+	deleted := false
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return &models.FileAttachment{ID: uuid.New()}, nil
+			},
+			deleteFn: func(context.Context, uuid.UUID, uuid.UUID) error {
+				deleted = true
+				return nil
+			},
+		},
+		agent: &stubAgent{},
+	}
+	id := uuid.New()
+	req, _ := requestWithUser(t, http.MethodDelete, "/file-attachment/"+id.String())
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	rec := httptest.NewRecorder()
+
+	h.DeleteFileAttachment(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, deleted)
+}
+
+func TestGetFileAttachmentContent_NotFound(t *testing.T) {
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return nil, datastore.ErrFileAttachmentNotFound
+			},
+		},
+		agent: &stubAgent{},
+	}
+	id := uuid.New()
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment/"+id.String())
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetFileAttachmentContent_FileStoreNotConfigured(t *testing.T) {
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return &models.FileAttachment{ID: uuid.New(), Name: "report.pdf", FileType: "application/pdf"}, nil
+			},
+		},
+		agent: &stubAgent{},
+	}
+	id := uuid.New()
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment/"+id.String())
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetFileAttachmentContent_DownloadsFallbackKey(t *testing.T) {
+	attachmentID := uuid.New()
+	userID := uuid.New()
+	chatID := uuid.New()
+	attachment := &models.FileAttachment{
+		ID:            attachmentID,
+		Name:          "notes.txt",
+		FileType:      "text/plain",
+		ChatMessageID: &chatID,
+		S3Key:         "legacy/key",
+	}
+	expectedFallback := storage.FileKeyForAttachment(userID, attachmentID, attachment.Name, attachment.FileType, attachment.ChatMessageID, attachment.PersonalityID)
+
+	fs := &stubFileStore{
+		contentByKey: map[string][]byte{
+			"legacy/key":     nil,
+			expectedFallback: []byte("hello world"),
+		},
+		errByKey: map[string]error{},
+	}
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return attachment, nil
+			},
+		},
+		agent: &stubAgent{store: fs},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/file-attachment/"+attachmentID.String(), nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	req = mux.SetURLVars(req, map[string]string{"id": attachmentID.String()})
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "text/plain", rec.Header().Get("Content-Type"))
+	require.Equal(t, `attachment; filename="notes.txt"`, rec.Header().Get("Content-Disposition"))
+	require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, []string{"legacy/key", expectedFallback}, fs.seenKeys)
+	require.Equal(t, "hello world", rec.Body.String())
+}
+
+func TestGetFileAttachmentContent_DownloadError(t *testing.T) {
+	id := uuid.New()
+	fs := &stubFileStore{
+		contentByKey: map[string][]byte{},
+		errByKey:     map[string]error{"primary": errors.New("download failed")},
+	}
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return &models.FileAttachment{ID: id, Name: "x.txt", FileType: "text/plain", S3Key: "primary"}, nil
+			},
+		},
+		agent: &stubAgent{store: fs},
+	}
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment/"+id.String())
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestGetFileAttachmentContent_ContentNotAvailable(t *testing.T) {
+	id := uuid.New()
+	fs := &stubFileStore{contentByKey: map[string][]byte{}, errByKey: map[string]error{}}
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			getFn: func(context.Context, uuid.UUID, uuid.UUID) (*models.FileAttachment, error) {
+				return &models.FileAttachment{ID: id, Name: "x.txt", FileType: ""}, nil
+			},
+		},
+		agent: &stubAgent{store: fs},
+	}
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment/"+id.String())
+	req = mux.SetURLVars(req, map[string]string{"id": id.String()})
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestRegisterRoutes_WiresEndpoints(t *testing.T) {
+	h := &Handler{logger: zap.NewNop(), ds: stubStore{}, agent: &stubAgent{}}
+	router := mux.NewRouter()
+	h.RegisterRoutes(router)
+
+	req := httptest.NewRequest(http.MethodGet, "/file-attachment", nil)
+	match := &mux.RouteMatch{}
+	require.True(t, router.Match(req, match))
+}
+
+func TestListFileAttachments_DatastoreErrorReturns500(t *testing.T) {
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			listFn: func(context.Context, uuid.UUID, int, int, models.FileAttachmentFilters) (*models.PaginatedResponse, error) {
+				return nil, errors.New("db down")
+			},
+		},
+		agent: &stubAgent{},
+	}
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment")
+	rec := httptest.NewRecorder()
+
+	h.ListFileAttachments(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestGetFileAttachmentContent_Unauthorized(t *testing.T) {
+	h := &Handler{logger: zap.NewNop(), ds: stubStore{}, agent: &stubAgent{}}
+	req := httptest.NewRequest(http.MethodGet, "/file-attachment/"+uuid.NewString(), nil)
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestGetFileAttachmentContent_InvalidID(t *testing.T) {
+	h := &Handler{logger: zap.NewNop(), ds: stubStore{}, agent: &stubAgent{}}
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment/not-a-uuid")
+	req = mux.SetURLVars(req, map[string]string{"id": "not-a-uuid"})
+	rec := httptest.NewRecorder()
+
+	h.GetFileAttachmentContent(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDeleteFileAttachment_Unauthorized(t *testing.T) {
+	h := &Handler{logger: zap.NewNop(), ds: stubStore{}, agent: &stubAgent{}}
+	req := httptest.NewRequest(http.MethodDelete, "/file-attachment/"+uuid.NewString(), nil)
+	rec := httptest.NewRecorder()
+
+	h.DeleteFileAttachment(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestListFileAttachments_IgnoresInvalidDocsOnly(t *testing.T) {
+	var captured models.FileAttachmentFilters
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			listFn: func(_ context.Context, _ uuid.UUID, _ int, _ int, filters models.FileAttachmentFilters) (*models.PaginatedResponse, error) {
+				captured = filters
+				return &models.PaginatedResponse{Results: []any{}}, nil
+			},
+		},
+		agent: &stubAgent{},
+	}
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment?docs_only=nope")
+	rec := httptest.NewRecorder()
+	h.ListFileAttachments(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Nil(t, captured.DocsOnly)
+}
+
+func TestListFileAttachments_ResponseIsJSON(t *testing.T) {
+	h := &Handler{
+		logger: zap.NewNop(),
+		ds: stubStore{
+			listFn: func(_ context.Context, _ uuid.UUID, _ int, _ int, _ models.FileAttachmentFilters) (*models.PaginatedResponse, error) {
+				return &models.PaginatedResponse{Results: []any{}, TotalCount: 0, Page: 1}, nil
+			},
+		},
+		agent: &stubAgent{},
+	}
+	req, _ := requestWithUser(t, http.MethodGet, "/file-attachment")
+	rec := httptest.NewRecorder()
+	h.ListFileAttachments(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+}

--- a/internal/handlers/fileattachment/handler.go
+++ b/internal/handlers/fileattachment/handler.go
@@ -25,5 +25,6 @@ func (h *Handler) RegisterRoutes(router *mux.Router) {
 	fileAttachmentRouter := router.PathPrefix("/file-attachment").Subrouter()
 
 	fileAttachmentRouter.HandleFunc("", h.ListFileAttachments).Methods("GET")
+	fileAttachmentRouter.HandleFunc("/{id}", h.GetFileAttachmentContent).Methods("GET")
 	fileAttachmentRouter.HandleFunc("/{id}", h.DeleteFileAttachment).Methods("DELETE")
 }

--- a/internal/handlers/fileattachment/handler.go
+++ b/internal/handlers/fileattachment/handler.go
@@ -1,18 +1,34 @@
 package fileattachment
 
 import (
+	"context"
+
+	"github.com/google/uuid"
 	"github.com/theimaginaryfoundation/what-iff/internal/agent"
 	"github.com/theimaginaryfoundation/what-iff/internal/datastore"
+	"github.com/theimaginaryfoundation/what-iff/internal/models"
+	"github.com/theimaginaryfoundation/what-iff/internal/storage"
 
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
 
+type attachmentStore interface {
+	ListFileAttachments(ctx context.Context, userID uuid.UUID, pageNum, pageSize int, filters models.FileAttachmentFilters) (*models.PaginatedResponse, error)
+	GetFileAttachment(ctx context.Context, userID, id uuid.UUID) (*models.FileAttachment, error)
+	DeleteFileAttachment(ctx context.Context, userID, id uuid.UUID) error
+}
+
+type attachmentAgent interface {
+	FileStore() storage.FileStore
+	DeleteProviderFileAttachment(ctx context.Context, fileID string) error
+}
+
 // Handler handles file attachment-related API requests
 type Handler struct {
-	ds     *datastore.Datastore
+	ds     attachmentStore
 	logger *zap.Logger
-	agent  *agent.Agent
+	agent  attachmentAgent
 }
 
 // NewHandler creates a new Handler instance

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4938,6 +4938,50 @@ paths:
                 $ref: '#/components/schemas/Error'
 
   /file-attachment/{id}:
+    get:
+      summary: Download file attachment
+      description: Downloads the binary content for a single file attachment owned by the authenticated user.
+      tags: [File Attachments]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: File attachment ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: File attachment content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid attachment ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: File attachment not found or content unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error while downloading the file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     delete:
       summary: Delete file attachment
       description: Permanently deletes a file attachment and removes it from storage

--- a/web/app/e2e/sdk/schema.d.ts
+++ b/web/app/e2e/sdk/schema.d.ts
@@ -7087,7 +7087,69 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Download file attachment
+         * @description Downloads the binary content for a single file attachment owned by the authenticated user.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description File attachment ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description File attachment content */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/octet-stream": string;
+                    };
+                };
+                /** @description Invalid attachment ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description File attachment not found or content unavailable */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description Internal server error while downloading the file */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
         put?: never;
         post?: never;
         /**

--- a/web/app/src/app/features/chat/components/message-content/message-content.component.spec.ts
+++ b/web/app/src/app/features/chat/components/message-content/message-content.component.spec.ts
@@ -96,6 +96,32 @@ describe('MessageContentComponent', () => {
         expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:download');
     });
 
+    it('downloads a non-image attachment from the pill click', () => {
+        vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:file-download');
+        vi.spyOn(URL, 'revokeObjectURL').mockReturnValue(undefined);
+        const click = vi.fn().mockName('click');
+        const anchor = document.createElement('a');
+        const createElement = document.createElement.bind(document);
+        vi.spyOn(anchor, 'click').mockImplementation(click);
+        vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+            return tagName === 'a' ? anchor : createElement(tagName);
+        }) as typeof document.createElement);
+
+        fixture.componentRef.setInput('attachments', [fileAttachment('doc-1', 'notes.txt', 'text/plain')]);
+        fixture.detectChanges();
+
+        const button = fixture.nativeElement.querySelector('button.rounded-full') as HTMLButtonElement;
+        button.click();
+
+        httpMock.expectOne(req => req.urlWithParams.includes('/file-attachment/doc-1'))
+            .flush(new Blob(['notes'], { type: 'text/plain' }));
+
+        expect(anchor.download).toBe('notes.txt');
+        expect(anchor.href).toBe('blob:file-download');
+        expect(click).toHaveBeenCalled();
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:file-download');
+    });
+
     it('copies sanitized html and preserves list markers in plain text', () => {
         fixture.detectChanges();
         const setData = vi.fn().mockName('setData');
@@ -184,11 +210,15 @@ describe('MessageContentComponent', () => {
 });
 
 function imageAttachment(id: string, name: string) {
+    return fileAttachment(id, name, 'image/png');
+}
+
+function fileAttachment(id: string, name: string, fileType: string) {
     return {
         id,
         user_id: 'user-1',
         name,
-        file_type: 'image/png',
+        file_type: fileType,
         created_at: '',
     };
 }

--- a/web/app/src/app/features/chat/components/message-content/message-content.component.spec.ts
+++ b/web/app/src/app/features/chat/components/message-content/message-content.component.spec.ts
@@ -28,6 +28,7 @@ describe('MessageContentComponent', () => {
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         httpMock.verify();
     });
 

--- a/web/app/src/app/features/chat/components/message-content/message-content.component.spec.ts
+++ b/web/app/src/app/features/chat/components/message-content/message-content.component.spec.ts
@@ -123,6 +123,18 @@ describe('MessageContentComponent', () => {
         expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:file-download');
     });
 
+    it('treats uppercase image MIME types as image attachments', () => {
+        fixture.componentRef.setInput('attachments', [fileAttachment('img-1', 'cover.PNG', 'IMAGE/PNG')]);
+        fixture.detectChanges();
+
+        const previewCards = fixture.nativeElement.querySelectorAll('.message-images__card');
+        expect(previewCards.length).toBe(1);
+        expect(fixture.nativeElement.querySelector('button.rounded-full')).toBeNull();
+
+        httpMock.expectOne(req => req.urlWithParams.includes('/image-gallery/img-1?size=thumbnail'))
+            .flush(new Blob(['thumb'], { type: 'image/png' }));
+    });
+
     it('copies sanitized html and preserves list markers in plain text', () => {
         fixture.detectChanges();
         const setData = vi.fn().mockName('setData');

--- a/web/app/src/app/features/chat/components/message-content/message-content.component.ts
+++ b/web/app/src/app/features/chat/components/message-content/message-content.component.ts
@@ -1,8 +1,10 @@
 import { DOCUMENT } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { MarkdownModule } from 'ngx-markdown';
 
 import { FileAttachment } from '../../../../core/models/file-attachment.model';
+import { environment } from '../../../../../environments/environment';
 import { buildClipboardPayload } from '../../helpers/html-clipboard.helpers';
 import { extractImages } from '../../helpers/message-content.helpers';
 import { MessageImageAttachmentsComponent } from './message-image-attachments.component';
@@ -34,11 +36,13 @@ import { MessageImageAttachmentsComponent } from './message-image-attachments.co
     @if (nonImageAttachments().length) {
       <div class="mt-3 flex flex-wrap gap-2">
         @for (attachment of nonImageAttachments(); track attachment.id) {
-          <span
+          <button
+            type="button"
+            (click)="downloadAttachment(attachment)"
             class="rounded-full border border-border-base bg-surface-muted px-3 py-1 text-xs text-text-secondary hover:text-text-primary"
           >
             {{ attachment.name }}
-          </span>
+          </button>
         }
       </div>
     }
@@ -86,6 +90,8 @@ import { MessageImageAttachmentsComponent } from './message-image-attachments.co
 })
 export class MessageContentComponent {
   private readonly document = inject(DOCUMENT);
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = `${environment.apiUrl}/file-attachment`;
 
   readonly content = input('');
   readonly attachments = input<readonly FileAttachment[]>([]);
@@ -112,6 +118,17 @@ export class MessageContentComponent {
     if (payload.html) {
       clipboard.setData('text/html', payload.html);
     }
+  }
+
+  downloadAttachment(attachment: FileAttachment): void {
+    this.http.get(`${this.apiUrl}/${attachment.id}`, { responseType: 'blob' }).subscribe(blob => {
+      const url = URL.createObjectURL(blob);
+      const anchor = this.document.createElement('a');
+      anchor.href = url;
+      anchor.download = attachment.name || `attachment-${attachment.id}`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    });
   }
 }
 


### PR DESCRIPTION
## Overview

This PR adds two related capabilities to the agent and API surface:

1. **Extension seams around tool execution** so external hosts can inject per-chat tools, configuration, and hooks without forking core agent logic.
2. **End-to-end support for downloading tool-generated attachments**, including non-image binaries, via a new authenticated HTTP endpoint and corresponding client wiring.

These changes are motivated by the need to embed the agent into other systems (with custom tools and policies) while reliably persisting and serving all tool outputs (not just images) back to users.

---

## Key Changes

### 1. External tooling seams for host integration

New seams around the agent’s tool lifecycle allow an external host to extend and control tool behavior on a per-chat basis without modifying core logic:

- **Post-tool-loop attachment hook**
  - `Agent.handleAgentLoop` now collects additional attachments produced outside the normal tool loop by calling:
    - `appendPostToolLoopGeneratedAttachments(ctx, chatCtx, allGeneratedAttachments)` when the model produces a final answer or when a forced final response is generated.
  - `appendPostToolLoopGeneratedAttachments` defers to the injected `additionalGeneratedAttachmentsForChat` seam, if present, and appends any returned attachments to the final set.
  - This enables host code to generate and persist attachments after the built-in tool cycle completes while still having them show up in the final assistant message.

- **Per-tool execution attachment hook**
  - `executeToolUses` now calls `notifyToolUseGeneratedAttachments(chatCtx, use, generatedAttachments[i])` after each tool execution.
  - `notifyToolUseGeneratedAttachments` delegates to the `onToolUseGeneratedAttachmentsForChat` seam when available, passing the chat, the tool invocation, and newly generated attachments.
  - This provides a structured callback for hosts to observe or augment handling of every tool-generated attachment (e.g., auditing, mirroring to other storage, or custom logging).

- **Per-chat disabled tools seam**
  - `buildTurnToolPolicy` in `internal/agent/tools.go` now consults `additionalDisabledToolsForChat` and merges any per-chat disabled tool flags into `policy.disabledTools`.
  - This allows external hosts to dynamically disable specific tools based on chat context (e.g., tenant configuration, feature flags, or user permissions) without hardcoding logic in the agent core.

- **New seam implementations**
  - New files `internal/agent/external_tools_seam.go` and `internal/agent/tools/external_catalog_seam.go` define the extension points and associated plumbing for external tool catalogs, disabled tool sets, and attachment hooks.

Together, these seams make it possible to embed the agent into other systems and inject tools, context, or restrictions per chat, while retaining a clean separation between host-specific concerns and core agent behavior.

---

### 2. Persistent storage and recall of tool-generated attachments

Tool-generated attachments are now treated as first-class persisted artifacts, not just images:

- **Persist all tool-generated attachments to S3**
  - The datastore and tooling layers have been updated so that all binary outputs produced by tools are stored in S3 with a stable `s3_key`, not only image outputs.
  - This ensures that any type of binary tool output (documents, archives, etc.) can be consistently retrieved later.

- **Stable recall by attachment ID**
  - The recall tooling is updated so that recall results carry attachment IDs alongside other metadata.
  - Clients can use these attachment IDs to re-open or re-download the exact source files that were previously generated or referenced by the agent.

These changes improve reliability of tool outputs across sessions and allow client applications to confidently surface historical tool artifacts.

---

### 3. New authenticated endpoint for downloading attachments

To make tool-generated and uploaded attachments accessible to end users, this PR introduces a new API surface and handler logic.

#### HTTP handler and routing

- **Route registration**
  - `internal/handlers/fileattachment/handler.go` now registers a new GET route:
    - `GET /file-attachment/{id}` → `Handler.GetFileAttachmentContent`.

- **Attachment download handler**
  - `internal/handlers/fileattachment/fileattachment.go` implements `GetFileAttachmentContent` to:
    - Enforce authentication using the current user context; unauthenticated requests receive `401 Unauthorized`.
    - Parse and validate the `id` path parameter as a UUID; invalid values receive `400 Bad Request`.
    - Fetch the attachment metadata for the authenticated user via `ds.GetFileAttachment`; missing attachments return `404 Not Found` while other datastore errors return `500 Internal Server Error`.
    - Resolve the underlying S3 object key(s):
      - Prefer a stored `S3Key` when present.
      - Fallback to a deterministic key via `storage.FileKeyForAttachment(userID, attachment.ID, attachment.Name, attachment.FileType, attachment.ChatMessageID, attachment.PersonalityID)` to maintain compatibility with existing storage layouts.
    - Download the content from the configured file store (`agent.FileStore()`), returning a failure if storage is not configured or content cannot be retrieved.
    - If no non-empty blob is found, return `404` with a clear "File content not available" message.
    - Otherwise, respond with:
      - `Content-Type` derived from the attachment `FileType` (defaulting to `application/octet-stream`).
      - `Content-Disposition` set to `attachment; filename="<name-or-id>"` based on the stored `Name` or the attachment ID.
      - `Cache-Control: private, max-age=3600` and `X-Content-Type-Options: nosniff` for safe caching and content-type handling.
      - A `200 OK` status and the raw bytes of the attachment.

This design centralizes all download logic behind a user-scoped, authenticated endpoint, ensuring that only the owner of an attachment can retrieve its binary content.

#### OpenAPI specification and SDK schema

- **OpenAPI path definition**
  - `openapi.yaml` now documents the new endpoint under `paths` at `/file-attachment/{id}` with a `GET` operation:
    - **Summary & description**: Clearly indicates that it downloads binary content for a file attachment owned by the authenticated user.
    - **Path parameter**: `id` (UUID, required) describing the file attachment ID.
    - **Responses**:
      - `200`: binary content (`application/octet-stream`, `format: binary`).
      - `400`: invalid attachment ID (JSON `Error` schema).
      - `401`: unauthorized (JSON `Error` schema).
      - `404`: attachment not found or content unavailable (JSON `Error` schema).
      - `500`: internal error while downloading (JSON `Error` schema).

- **SDK / TypeScript schema alignment**
  - `web/app/e2e/sdk/schema.d.ts` is updated to include the new GET `/file-attachment/{id}` operation so that client-side code and tests can rely on a typed representation of the updated OpenAPI contract.

---

### 4. Web client improvements for non-image attachments

The chat UI is enhanced so that tool-produced documents and other non-image files can be downloaded directly by users:

- `web/app/src/app/features/chat/components/message-content/message-content.component.ts` is updated to:
  - Recognize non-image attachments in assistant messages.
  - Call the new authenticated `GET /file-attachment/{id}` endpoint when a user interacts with a downloadable attachment.
  - Trigger browser downloads using the response content so users can open or save tool-generated files.

- Corresponding tests in `message-content.component.spec.ts`:
  - Ensure that message content behavior correctly differentiates between image and non-image attachments.
  - Verify that interactions with non-image attachments invoke the new download flow.
  - Restore Vitest mocks after each run to prevent cross-test leakage and maintain deterministic behavior.

This closes the loop from tools generating attachments → persisted in storage → surfaced in UI → downloadable by the end user.

---

### 5. Datastore and file chunk test alignment

To keep tests in sync with the storage and schema changes:

- `internal/datastore/filechunk.go` and `internal/datastore/filechunk_test.go` are updated to:
  - Reflect the new chunk ID column and any additional fields used to support the enhanced attachment storage.
  - Adjust query expectations to align with the modified schema and ensure all chunk-level operations remain correct and well-tested.

These updates reduce the risk of regressions in file storage behavior as binary outputs become more central to the product.

---

## Rationale and Trade-offs

- **Why introduce seams instead of hard-coded logic?**
  - The agent is designed to be embedded into multiple host environments, each with different tool catalogs, policies, and storage needs.
  - Seams provide a clean boundary where hosts can plug in their own behavior (e.g., dynamic tool disabling, custom tools, extra attachment processing) without diverging the core agent implementation.

- **Why a dedicated download endpoint?**
  - Direct S3 URLs or pre-signed links would complicate access control and tenant isolation.
  - A single, authenticated `GET /file-attachment/{id}` endpoint centralizes authorization, auditability, and error handling, and provides a stable contract to clients.

- **Storage key strategy**
  - Maintaining both the stored `S3Key` and a deterministic fallback key (`FileKeyForAttachment`) balances backward compatibility with flexibility.
  - If the stored key is missing or changes in the future, the deterministic key remains a reliable way to locate content for existing attachments.

- **Security considerations**
  - All downloads are scoped to the authenticated user and attachment ownership, avoiding cross-user data exposure.
  - Conservative headers (`nosniff`, explicit `Content-Type`, `Content-Disposition`) reduce the risk of content-type based attacks in the browser.

---

## Impact

- **Developers / Hosts**
  - Gain robust extension points for tooling (custom tools, disabled tools, attachment hooks) on a per-chat basis.
  - Can integrate What-Iff into more complex systems without forking or patching the core agent.

- **End users**
  - Can now reliably download any tool-generated file (not only images) directly from assistant messages.
  - Benefit from more stable recall of past tool outputs thanks to durable storage and explicit attachment IDs.

- **Codebase**
  - 556 additions and 66 deletions across 18 modified files and 2 new files.
  - Clear separation between core agent behavior, external seams, and HTTP/SDK surfaces makes future extension and maintenance easier.