### PR TITLE
Restore Run Now behavior on current job detail

### DIFF
--- a/web/app/src/app/features/agent-job/job-detail-page.component.html
+++ b/web/app/src/app/features/agent-job/job-detail-page.component.html
@@ -18,14 +18,16 @@
             Open chat
           </button>
         }
-        <button
-          type="button"
-          class="rounded-lg border border-border-base px-3 py-2 text-xs text-text-secondary"
-          [disabled]="runningNow()"
-          [attr.aria-disabled]="runningNow()"
-          (click)="runNow()">
-          {{ runningNow() ? 'Running…' : 'Run now' }}
-        </button>
+        @if (canRunNow()) {
+          <button
+            type="button"
+            class="rounded-lg border border-border-base px-3 py-2 text-xs text-text-secondary"
+            [disabled]="runningNow()"
+            [attr.aria-disabled]="runningNow()"
+            (click)="runNow()">
+            {{ runningNow() ? 'Running…' : 'Run now' }}
+          </button>
+        }
         @if (current.status === 'active' || current.status === 'paused') {
           <button
             type="button"

--- a/web/app/src/app/features/agent-job/job-detail-page.component.spec.ts
+++ b/web/app/src/app/features/agent-job/job-detail-page.component.spec.ts
@@ -21,6 +21,7 @@ describe('JobDetailPageComponent', () => {
     let modelService: Pick<MockedObject<ModelService>, 'getModels'>;
     let personalityService: Pick<MockedObject<PersonalityService>, 'listPersonalities'>;
     let ritualService: Pick<MockedObject<RitualService>, 'listRituals'>;
+    let router: { navigate: ReturnType<typeof vi.fn> };
     let route: {
         snapshot: {
             paramMap: {
@@ -81,11 +82,11 @@ describe('JobDetailPageComponent', () => {
         } as unknown as Pick<MockedObject<PersonalityService>, 'listPersonalities'>;
         ritualService = {
             listRituals: vi.fn().mockName("RitualService.listRituals")
-        } as unknown as Pick<MockedObject<RitualService>, 'listRituals'>;
+        } as unknown as Pick<MockedObject<RitualService>, 'listRituals' | never>;
         const confirmation = {
             confirm: vi.fn().mockName("ConfirmationService.confirm")
         };
-        const router = {
+        router = {
             navigate: vi.fn().mockName("Router.navigate")
         };
         route = { snapshot: { paramMap: { get: vi.fn().mockName('get').mockReturnValue('job-1') } } };
@@ -146,6 +147,17 @@ describe('JobDetailPageComponent', () => {
         expect(host.querySelector('app-job-run-history')).not.toBeNull();
     });
 
+    it('opens the associated chat after a successful run-now trigger', () => {
+        agentJobService.runNow.mockReturnValue(of({ status: 'triggered' }));
+        fixture.detectChanges();
+
+        fixture.componentInstance.runNow();
+
+        expect(agentJobService.runNow).toHaveBeenCalledWith('job-1');
+        expect(chatService.setLastChatId).toHaveBeenCalledWith('chat-1');
+        expect(router.navigate).toHaveBeenCalledWith(['/chat']);
+    });
+
     it('renders every attached and available skill, and hides ineligible actions', () => {
         fixture.detectChanges();
         const component = fixture.componentInstance;
@@ -159,6 +171,7 @@ describe('JobDetailPageComponent', () => {
         expect(host.textContent).toContain('+ Weekly review');
         expect(host.textContent).not.toContain('No attached skills.');
         expect(host.textContent).not.toContain('Open chat');
+        expect(host.textContent).not.toContain('Run now');
         expect(host.textContent).not.toContain('Pause');
         expect(host.textContent).not.toContain('Resume');
     });

--- a/web/app/src/app/features/agent-job/job-detail-page.component.ts
+++ b/web/app/src/app/features/agent-job/job-detail-page.component.ts
@@ -269,13 +269,23 @@ export class JobDetailPageComponent implements OnInit, OnDestroy {
     });
   }
 
+  canRunNow(): boolean {
+    const status = this.job()?.status;
+    return status === 'active' || status === 'paused';
+  }
+
   runNow(): void {
     const current = this.job();
-    if (!current) return;
+    if (!current || !this.canRunNow()) return;
     this.runningNow.set(true);
+    this.error.set(null);
     this.agentJobService.runNow(current.id).subscribe({
       next: () => {
         this.runningNow.set(false);
+        if (current.chat_id) {
+          this.openChat();
+          return;
+        }
         this.startPollingIfNeeded(current.status);
       },
       error: error => {


### PR DESCRIPTION
Follow-up to merged PR #61 / issue #37.

## Diagnosis

#61 implemented the Run Now breadcrumb in the old `AgentJobDetailComponent`. The current `/agent-jobs/:id` route now renders `JobDetailPageComponent`, whose pre-fix `runNow()` only triggered the API and restarted polling. The merged behavior was therefore lost when the job-detail UI was replaced.

The current page also rendered Run Now for terminal jobs even though the backend only accepts active/paused jobs.

## Fix

- Restore the successful Run Now breadcrumb on the component the router actually uses.
- When an active/paused job already has a chat, successful Run Now selects that chat and navigates to `/chat`.
- Jobs without an existing chat keep the current polling behavior.
- Hide and method-guard Run Now for non-runnable terminal statuses.

## Regression coverage

- successful Run Now on a job with `chat_id` must call the API, select that chat, and navigate to `/chat`;
- terminal job detail must not expose Run Now.

This intentionally does not add live execution-state UI or change scheduler semantics.

## Validation

Head `d95217c`:

- Frontend PR Validation: **passed** (type-checking, unit tests, coverage, production build).
- E2E local-LLM backend: **passed**.
- Separate long mock-backend E2E: queued at the time of this update and not represented as passed.

## BSD-main (14) final narrow evaluation

Evaluation `eval-9e8e4690-0787-4079-863b-41741d43f0ab`.

Evaluated claim: the active routed job-detail component restores #61's associated-chat breadcrumb for successful Run Now, matches backend active/paused eligibility, preserves no-chat polling, and does not redesign scheduler execution.

- main mechanistic chain: `CERTIFIED_WITH_LIMITS`
- structural reasoning reliability: `0.75` (`MEASURED`; not truth probability)
- evidence mass: `1.0` (`MEASURED`; evidence engagement/coverage, not truth probability)
- competing “still only trigger/poll” chain: `REJECTED`
- PPI: `UNAVAILABLE` because canonical support for a second surviving structure was unavailable
- response policy: `DIRECT` with `MISSING_INFORMATION` and `PPI_UNAVAILABLE`

BSD limitations: source and regression tests are one dependent evidence group; the separate mock-browser E2E was still pending; no manual live-browser click was captured; GitHub evidence is caller-supplied/unverified in the local BSD runtime.