### PR TITLE
Separate auto-saving chat defaults from profile save

### DIFF
--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
@@ -72,41 +72,41 @@
             </select>
           </label>
 
-          <fieldset
-            class="profile-settings__callout profile-settings__form"
-            data-testid="chat-defaults">
-            <legend>Chat defaults</legend>
-            <small>Choose what new chats start with. You can leave personality unset.</small>
-
-            <label class="profile-settings__field">
-              <span>Default model</span>
-              <select
-                [value]="preferences()?.default_model_id ?? ''"
-                [disabled]="loadingAction()"
-                (change)="onDefaultModelChange($any($event.target).value)">
-                @for (model of models(); track model.id) {
-                  <option [value]="model.id">{{ model.display_name }}</option>
-                }
-              </select>
-            </label>
-            <label class="profile-settings__field">
-              <span>Default personality</span>
-              <select
-                [value]="preferences()?.default_personality_id ?? ''"
-                [disabled]="loadingAction()"
-                (change)="onDefaultPersonalityChange($any($event.target).value)">
-                <option value="">No default personality</option>
-                @for (personality of personalities(); track personality.id) {
-                  <option [value]="personality.id">{{ personality.name }}</option>
-                }
-              </select>
-            </label>
-          </fieldset>
-
           <button class="profile-settings__button profile-settings__button--primary" type="submit" [disabled]="loadingAction()">
-            Save Changes
+            Save profile
           </button>
         </form>
+
+        <fieldset
+          class="profile-settings__callout profile-settings__form"
+          data-testid="chat-defaults">
+          <legend>Chat defaults</legend>
+          <small>Choose what new chats start with. Changes save immediately; you can leave personality unset.</small>
+
+          <label class="profile-settings__field">
+            <span>Default model</span>
+            <select
+              [value]="preferences()?.default_model_id ?? ''"
+              [disabled]="loadingAction()"
+              (change)="onDefaultModelChange($any($event.target).value)">
+              @for (model of models(); track model.id) {
+                <option [value]="model.id">{{ model.display_name }}</option>
+              }
+            </select>
+          </label>
+          <label class="profile-settings__field">
+            <span>Default personality</span>
+            <select
+              [value]="preferences()?.default_personality_id ?? ''"
+              [disabled]="loadingAction()"
+              (change)="onDefaultPersonalityChange($any($event.target).value)">
+              <option value="">No default personality</option>
+              @for (personality of personalities(); track personality.id) {
+                <option [value]="personality.id">{{ personality.name }}</option>
+              }
+            </select>
+          </label>
+        </fieldset>
 
         <form class="profile-settings__form profile-settings__password-form" [formGroup]="passwordForm" (ngSubmit)="savePassword()">
           <label class="profile-settings__field">

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.html
@@ -73,7 +73,7 @@
           </label>
 
           <button class="profile-settings__button profile-settings__button--primary" type="submit" [disabled]="loadingAction()">
-            Save profile
+            Save Changes
           </button>
         </form>
 

--- a/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
+++ b/web/app/src/app/features/profile-settings/profile-settings-modal.component.spec.ts
@@ -118,6 +118,16 @@ describe('ProfileSettingsModalComponent (open-source profile-only)', () => {
     expect(defaults?.textContent).toContain('No default personality');
   });
 
+  it('keeps auto-saving chat defaults outside the profile submit form', async () => {
+    const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
+    await openAndWaitForProfile(fixture);
+
+    const defaults = fixture.nativeElement.querySelector('[data-testid="chat-defaults"]') as HTMLElement | null;
+    expect(defaults).not.toBeNull();
+    expect(defaults?.closest('form')).toBeNull();
+    expect(defaults?.querySelector('button[type="submit"]')).toBeNull();
+  });
+
   it('persists a changed default model without dropping other preferences', async () => {
     const fixture = TestBed.createComponent(ProfileSettingsModalComponent);
     const component = fixture.componentInstance;


### PR DESCRIPTION
Follow-up to merged PR #69.

## Diagnosis

#69 restored default model/personality selectors inside the existing profile `<form>`, immediately above its pre-existing `Save Changes` button. The defaults already save immediately through `UserPreferencesService`, so placing them inside the profile submit form makes the UI imply that the button is required for those settings.

The button itself was not introduced by #69; it is the existing submit action for email/name profile edits.

## Fix

- Move the auto-saving Chat defaults fieldset outside the profile submit form.
- Keep model/personality changes immediate-save with the existing preferences service.
- Preserve the existing profile submit button and label for profile edits.
- Add copy that tells users Chat default changes save immediately.

## Regression coverage

The component test now requires the Chat defaults fieldset to have no containing form and no submit button, while preserving the existing preference-persistence tests.

No preferences API or persistence behavior changes in this follow-up.

## Validation

Head `ee9cd56`:

- Frontend PR Validation: **passed** (type-checking, unit tests, coverage, production build).
- E2E local-LLM backend: **passed**.
- Separate long mock-backend E2E: still running at the time of this update and not represented as passed.

## BSD-main (14) final narrow evaluation

Evaluation `eval-8b779e54-b0d2-43d7-90d2-fb0bea906a62`.

Evaluated claim: Chat defaults are structurally separated from the profile submit form while retaining their existing immediate-save preference handlers and persistence path, and the existing profile Save Changes action remains scoped to profile edits.

- main mechanistic chain: `CERTIFIED_WITH_LIMITS`
- structural reasoning reliability: `0.75` (`MEASURED`; not truth probability)
- evidence mass: `1.0` (`MEASURED`; evidence engagement/coverage, not truth probability)
- competing “defaults still appear to require Save Changes” chain: `REJECTED`
- PPI: `UNAVAILABLE` because canonical support for a second surviving structure was unavailable
- response policy: `DIRECT` with `MISSING_INFORMATION` and `PPI_UNAVAILABLE`

BSD limitations: source and component regression are one dependent evidence group; the separate mock-browser E2E was still running; no manual visual-inspection receipt was captured; GitHub evidence is caller-supplied/unverified in the local BSD runtime.