### PR TITLE
Make visual baseline regen self-contained

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,11 @@ services:
       # datastore.ValidateTokenEncryptionSecret.
       OPENAI_API_KEY:
       ANTHROPIC_API_KEY:
+      # LLM backend selector (ADR 0x018). Empty default preserves the app's
+      # real-provider behaviour for normal `docker compose up`; set
+      # LLM_BACKEND=mock in your shell to run the in-process deterministic mock
+      # (no provider egress/keys) — what the @mock-only e2e/visual suites need.
+      LLM_BACKEND: ${LLM_BACKEND:-}
       JWT_SECRET:
       JWT_REFRESH_SECRET:
       TOKEN_ENCRYPTION_SECRET:

--- a/web/app/e2e/README.md
+++ b/web/app/e2e/README.md
@@ -651,11 +651,23 @@ covered screens; the container run is what actually validates the diff, not
 a local eyeball on a macOS-rendered screenshot.
 
 **Prerequisites** for the `:docker` scripts (see `e2e/scripts/visual-docker.sh`
-for the fully commented version): Postgres + the backend API running on the
-host at `:8080` (`make db-up`, then `make dev-up` / `make run-mock` /
-`make run-local`). The Angular dev server itself is started _inside_ the
-container by Playwright's normal `webServer` config — nothing extra to run
-for that.
+for the fully commented version): a backend API reachable on the host at
+`:8080`. The script ensures this itself — if nothing is already serving
+`:8080` it brings up the self-contained compose `api` service (which carries
+its own Postgres), so you don't need the old `make db-up` + `make dev-up` /
+`make run-mock` / `make run-local` dance (that leaned on your local `.env` and
+a host Postgres). An already-running backend is reused untouched, and anything
+the script starts is left running afterwards. If you'd rather start it
+yourself first, `docker compose up -d api` is the same thing. The Angular dev
+server is started _inside_ the container by Playwright's normal `webServer`
+config — nothing extra to run for that.
+
+> **Apple Silicon note:** the container is forced to `linux/amd64` for
+> render parity with CI, so on an arm64 Mac the in-container Angular build
+> runs under emulation and a cold `npm start` can exceed Playwright's
+> `webServer` timeout. If the run dies with `Timed out waiting … from
+> config.webServer`, regenerate on a native x86_64 host (or in CI) rather
+> than chasing the timeout.
 
 **The recipe that actually works on Docker Desktop for macOS:**
 `--network host` is a no-op there (unlike native Linux Docker), so the

--- a/web/app/e2e/README.md
+++ b/web/app/e2e/README.md
@@ -653,21 +653,31 @@ a local eyeball on a macOS-rendered screenshot.
 **Prerequisites** for the `:docker` scripts (see `e2e/scripts/visual-docker.sh`
 for the fully commented version): a backend API reachable on the host at
 `:8080`. The script ensures this itself — if nothing is already serving
-`:8080` it brings up the self-contained compose `api` service (which carries
-its own Postgres), so you don't need the old `make db-up` + `make dev-up` /
-`make run-mock` / `make run-local` dance (that leaned on your local `.env` and
-a host Postgres). An already-running backend is reused untouched, and anything
-the script starts is left running afterwards. If you'd rather start it
-yourself first, `docker compose up -d api` is the same thing. The Angular dev
-server is started _inside_ the container by Playwright's normal `webServer`
-config — nothing extra to run for that.
+`:8080` it **builds from current source** and starts the self-contained
+compose `api` service (which carries its own Postgres) **in mock mode**
+(`ENV=development LLM_BACKEND=mock`), so you don't need the old `make db-up` +
+`make dev-up` / `make run-mock` / `make run-local` dance. Both details are
+load-bearing: the visual suite is `@mock-only`, and a _stale_ prebuilt image
+silently 404s any endpoint added since it was built — which surfaces as a
+misleading CORS / "failed to load" error inside a baseline rather than a clean
+failure. If you start the backend yourself, match that:
+`ENV=development LLM_BACKEND=mock docker compose up -d --build api`. An
+already-running backend is reused (the script warns that it must be current +
+mock). The Angular dev server needs nothing extra either: on a native amd64
+host it is started _inside_ the container by Playwright's normal `webServer`
+config; on other hosts the script serves it on the host instead (see the Apple
+Silicon note below).
 
-> **Apple Silicon note:** the container is forced to `linux/amd64` for
-> render parity with CI, so on an arm64 Mac the in-container Angular build
-> runs under emulation and a cold `npm start` can exceed Playwright's
-> `webServer` timeout. If the run dies with `Timed out waiting … from
-> config.webServer`, regenerate on a native x86_64 host (or in CI) rather
-> than chasing the timeout.
+> **Apple Silicon:** the container is forced to `linux/amd64` for render
+> parity with CI, so an in-container Angular build would run under emulation
+> and a cold `npm start` there overruns Playwright's `webServer` timeout. The
+> script handles this automatically: on a non-amd64 host it serves the app
+> _natively_ on the host (`:4200`, bound to `0.0.0.0`) and routes only
+> Chromium's rendering through the amd64 container — the app bundle is
+> platform-independent, so only the rasterization that must match CI stays
+> emulated. Nothing extra to run; if `:4200` is already serving (bound to
+> `0.0.0.0`) it's reused, otherwise a dev server is started and torn down with
+> the run. This is why regenerating baselines now works on an arm64 Mac.
 
 **The recipe that actually works on Docker Desktop for macOS:**
 `--network host` is a no-op there (unlike native Linux Docker), so the

--- a/web/app/e2e/playwright.config.mock-llm.ts
+++ b/web/app/e2e/playwright.config.mock-llm.ts
@@ -2,6 +2,20 @@ import { defineConfig } from '@playwright/test';
 import { MOCK_TEST_TIMEOUT } from './timeouts';
 import { baseConfig, localWebServer } from './playwright.config.base';
 
+// Set by e2e/scripts/visual-docker.sh on a non-amd64 host, where it serves the
+// app on the host and points the container's Chromium at it (see the webServer
+// note below). It requires `baseURL` to stay http://localhost:4200 so the app
+// origin — and thus CORS/cookies and the committed baselines — is unchanged;
+// that only holds while E2E_BASE_URL is unset, so guard the contradiction
+// rather than silently rewriting the origin.
+const reuseHostWebServer = process.env['E2E_REUSE_HOST_WEBSERVER'] === '1';
+if (reuseHostWebServer && process.env['E2E_BASE_URL']) {
+  throw new Error(
+    'E2E_REUSE_HOST_WEBSERVER=1 expects E2E_BASE_URL to be unset so baseURL stays ' +
+      'http://localhost:4200 (the app origin the host-served dev server and CORS rely on).',
+  );
+}
+
 /**
  * Default config: local backend running with LLM_BACKEND=mock (deterministic
  * replies), Playwright starting only the Angular dev server. The backend
@@ -35,5 +49,14 @@ export default defineConfig({
   grepInvert: /@visual/,
   // A cold `npm start` compiles the whole app, which is far slower than
   // anything the tests themselves wait on — hence the outlier value.
-  webServer: { ...localWebServer, timeout: 120 * 1000 },
+  //
+  // `E2E_REUSE_HOST_WEBSERVER=1` omits the managed dev server entirely: the
+  // caller has already started (and waited on) an Angular dev server elsewhere
+  // and is routing the browser to it — e.g. `visual-docker.sh` on an arm64
+  // host, which serves the app natively and remaps `localhost:4200` into the
+  // amd64 render container via `--host-resolver-rules` to dodge an emulated
+  // build. `baseURL` stays `localhost:4200` so the app's origin (and thus
+  // CORS/cookies) is unchanged. When set, `E2E_BASE_URL` must be left unset so
+  // that default holds.
+  ...(reuseHostWebServer ? {} : { webServer: { ...localWebServer, timeout: 120 * 1000 } }),
 });

--- a/web/app/e2e/scripts/visual-docker.sh
+++ b/web/app/e2e/scripts/visual-docker.sh
@@ -10,9 +10,13 @@
 #   e2e/scripts/visual-docker.sh            # check mode (fails on mismatch)
 #   e2e/scripts/visual-docker.sh --update   # regenerate baselines
 #
-# Prerequisites (this repo's local stack, not started by this script):
-#   - Postgres + backend API reachable on the HOST at :8080 (make db-up,
-#     make dev-up / make run-mock / make run-local).
+# Backend: a backend API must be reachable on the HOST at :8080. This script
+# now ensures that itself — if nothing is already serving :8080 it brings up
+# the self-contained compose `api` service (which carries its own Postgres),
+# so you no longer need the old `make db-up` + `make dev-up`/`run-mock` dance
+# (which leaned on your local .env and a host Postgres). An already-running
+# backend is reused untouched, and anything this script starts is left
+# running afterwards rather than torn out from under you.
 #
 # The Angular dev server is started *inside* the container (same as a normal
 # local run — see `localWebServer` in playwright.config.base.ts) rather than
@@ -94,6 +98,29 @@ fi
 npm_script="e2e:mock-llm:visual"
 if [[ "${1:-}" == "--update" ]]; then
   npm_script="e2e:mock-llm:visual:update"
+fi
+
+# Ensure a backend is reachable on the host at :8080 (the container reaches it
+# via host.docker.internal — see the networking notes above). Reuse whatever is
+# already there; otherwise start the self-contained compose `api` service (it
+# depends on, and brings up, its own `db`). Left running on exit — this script
+# never tears down a backend it may not own.
+backend_health="http://localhost:8080/api/health"
+if curl -fsS -o /dev/null --max-time 3 "${backend_health}" 2>/dev/null; then
+  echo "Backend already reachable on :8080 — reusing it."
+else
+  echo "No backend on :8080 — starting the compose 'api' service (db + api)…"
+  docker compose -f "${repo_root}/docker-compose.yml" up -d api
+  echo "Waiting for backend readiness on :8080 (up to 120s)…"
+  for _ in $(seq 1 60); do
+    curl -fsS -o /dev/null --max-time 3 "${backend_health}" 2>/dev/null && break
+    sleep 2
+  done
+  if ! curl -fsS -o /dev/null --max-time 3 "${backend_health}" 2>/dev/null; then
+    echo "❌ Backend did not become ready on :8080 within 120s — see 'docker compose logs api'." >&2
+    exit 1
+  fi
+  echo "✅ Backend ready on :8080 (left running; stop later with 'docker compose stop api db')."
 fi
 
 echo "Using image ${image}"

--- a/web/app/e2e/scripts/visual-docker.sh
+++ b/web/app/e2e/scripts/visual-docker.sh
@@ -11,12 +11,16 @@
 #   e2e/scripts/visual-docker.sh --update   # regenerate baselines
 #
 # Backend: a backend API must be reachable on the HOST at :8080. This script
-# now ensures that itself — if nothing is already serving :8080 it brings up
-# the self-contained compose `api` service (which carries its own Postgres),
-# so you no longer need the old `make db-up` + `make dev-up`/`run-mock` dance
-# (which leaned on your local .env and a host Postgres). An already-running
-# backend is reused untouched, and anything this script starts is left
-# running afterwards rather than torn out from under you.
+# now ensures that itself — if nothing is already serving :8080 it builds (from
+# current source) and starts the self-contained compose `api` service (which
+# carries its own Postgres) in mock mode, so you no longer need the old
+# `make db-up` + `make dev-up`/`run-mock` dance. The `--build` and mock mode
+# both matter: the @visual suite is @mock-only, and a stale prebuilt image
+# silently 404s any endpoint added since it was built (which shows up as a
+# misleading CORS/"failed to load" error inside a baseline). An already-running
+# backend is reused (with a warning that it must be current + mock), and
+# anything this script starts is left running rather than torn out from under
+# you. See the ensure-backend block below for the details.
 #
 # The Angular dev server is started *inside* the container (same as a normal
 # local run — see `localWebServer` in playwright.config.base.ts) rather than
@@ -100,27 +104,98 @@ if [[ "${1:-}" == "--update" ]]; then
   npm_script="e2e:mock-llm:visual:update"
 fi
 
+# Poll an HTTP endpoint until it answers (2xx/3xx), up to `attempts` tries 2s
+# apart. Returns non-zero on timeout so the caller can emit a context-specific
+# error. Used for both the backend and the host dev-server waits below.
+wait_for_http() {
+  local url="$1" attempts="$2" i
+  for (( i = 1; i <= attempts; i++ )); do
+    curl -fsS -o /dev/null --max-time 3 "${url}" 2>/dev/null && return 0
+    sleep 2
+  done
+  return 1
+}
+
 # Ensure a backend is reachable on the host at :8080 (the container reaches it
-# via host.docker.internal — see the networking notes above). Reuse whatever is
-# already there; otherwise start the self-contained compose `api` service (it
-# depends on, and brings up, its own `db`). Left running on exit — this script
-# never tears down a backend it may not own.
+# via host.docker.internal — see the networking notes above). The visual suite
+# is @mock-only, so the backend it renders against MUST be:
+#   * in mock mode (ENV=development LLM_BACKEND=mock) — the app refuses mock
+#     unless ENV is explicitly a local env, hence both are set here; and
+#   * built from the current source — a stale image silently 404s any endpoint
+#     added since it was built, which surfaces as a misleading CORS/"failed to
+#     load" error in a baseline rather than a clean failure.
+# So when this script starts the backend it uses `--build` + mock; the compose
+# `api` service carries its own `db`. It is left running on exit.
 backend_health="http://localhost:8080/api/health"
 if curl -fsS -o /dev/null --max-time 3 "${backend_health}" 2>/dev/null; then
   echo "Backend already reachable on :8080 — reusing it."
+  echo "  NOTE: the @mock-only visual suite needs a CURRENT, mock-mode backend. If a baseline"
+  echo "  fails to load data (e.g. a 404/CORS error on a newer endpoint), your backend is stale"
+  echo "  or not in mock mode — stop it and re-run so this script can start a fresh one."
 else
-  echo "No backend on :8080 — starting the compose 'api' service (db + api)…"
-  docker compose -f "${repo_root}/docker-compose.yml" up -d api
-  echo "Waiting for backend readiness on :8080 (up to 120s)…"
-  for _ in $(seq 1 60); do
-    curl -fsS -o /dev/null --max-time 3 "${backend_health}" 2>/dev/null && break
-    sleep 2
-  done
-  if ! curl -fsS -o /dev/null --max-time 3 "${backend_health}" 2>/dev/null; then
-    echo "❌ Backend did not become ready on :8080 within 120s — see 'docker compose logs api'." >&2
+  echo "No backend on :8080 — building and starting the compose 'api' service (db + api) in mock mode…"
+  ENV=development LLM_BACKEND=mock \
+    docker compose -f "${repo_root}/docker-compose.yml" up -d --build api
+  echo "Waiting for backend readiness on :8080 (up to ~180s)…"
+  if ! wait_for_http "${backend_health}" 90; then
+    echo "❌ Backend did not become ready on :8080 within ~180s — see 'docker compose logs api'." >&2
     exit 1
   fi
-  echo "✅ Backend ready on :8080 (left running; stop later with 'docker compose stop api db')."
+  echo "✅ Backend ready on :8080 (mock mode; left running — stop later with 'docker compose stop api db')."
+fi
+
+# On a native amd64 host the container both builds and serves the app itself
+# (the `webServer` block in playwright.config.mock-llm.ts). On any other host
+# that build runs under emulation, where a cold `ng serve` is so slow it
+# overruns Playwright's webServer timeout — the whole reason this used to be
+# "regenerate on an x86_64 box instead". But the rendering that has to match CI
+# is Chromium's rasterization inside the amd64 container, NOT the app bundle,
+# which is platform-independent. So on an emulated host, serve the app natively
+# on the host and route only Chromium through the container: extend the
+# host-resolver remap to cover localhost:4200 as well as localhost:8080, and
+# set E2E_REUSE_HOST_WEBSERVER so Playwright skips its own (emulated) dev
+# server. The app's origin stays localhost:4200 — CORS, cookies and the
+# committed baselines are byte-for-byte the same as the in-container path.
+resolver_rules="MAP localhost:8080 host.docker.internal:8080"
+reuse_webserver_env=()
+# PID of the backgrounded dev-server subshell, when THIS script started one.
+# Empty means we reused an existing :4200 (or never started one), so the trap
+# must not signal anything.
+dev_server_pid=""
+stop_host_dev_server() {
+  [[ -n "${dev_server_pid}" ]] || return 0
+  echo "Stopping the host Angular dev server (pid/pgid ${dev_server_pid})…"
+  # Started under `set -m`, so the backgrounded subshell leads its own process
+  # group whose id equals its PID ($!); signalling the negative PID takes down
+  # `ng serve` and its build workers together. Fall back to the bare PID if the
+  # group is already gone.
+  kill -TERM "-${dev_server_pid}" 2>/dev/null || kill -TERM "${dev_server_pid}" 2>/dev/null || true
+}
+if [[ ${#platform_flag[@]} -gt 0 ]]; then
+  frontend_url="http://localhost:4200"
+  if curl -fsS -o /dev/null --max-time 3 "${frontend_url}" 2>/dev/null; then
+    echo "Angular dev server already on :4200 — reusing it (it must be bound to 0.0.0.0 to be reachable from the container)."
+  else
+    echo "Emulated render container — serving the app natively on the host (:4200) to skip an emulated build…"
+    # `set -m` puts the backgrounded subshell in its own process group so the
+    # EXIT trap can take down `ng serve` and its build workers, not just the
+    # npm wrapper. Bound to 0.0.0.0 because the container reaches it via
+    # host.docker.internal — a default localhost-only bind would refuse that.
+    set -m
+    ( cd "${repo_root}/${app_dir}" && npm start -- --host 0.0.0.0 --port 4200 --live-reload=false ) \
+      >/tmp/visual-host-webserver.log 2>&1 &
+    dev_server_pid=$!
+    set +m
+    trap stop_host_dev_server EXIT
+    echo "Waiting for the host dev server on :4200 (up to ~240s — a cold native build)…"
+    if ! wait_for_http "${frontend_url}" 120; then
+      echo "❌ Host dev server did not come up on :4200 — see /tmp/visual-host-webserver.log" >&2
+      exit 1
+    fi
+    echo "✅ Host dev server ready on :4200."
+  fi
+  resolver_rules="${resolver_rules},MAP localhost:4200 host.docker.internal:4200"
+  reuse_webserver_env=(-e "E2E_REUSE_HOST_WEBSERVER=1")
 fi
 
 echo "Using image ${image}"
@@ -137,7 +212,8 @@ docker run --rm \
   -v "/repo/${app_dir}/node_modules" \
   -w "/repo/${app_dir}" \
   -e "E2E_API_BASE_URL=http://host.docker.internal:8080/api" \
-  -e "E2E_CHROMIUM_HOST_RESOLVER_RULES=MAP localhost:8080 host.docker.internal:8080" \
+  -e "E2E_CHROMIUM_HOST_RESOLVER_RULES=${resolver_rules}" \
+  ${reuse_webserver_env[@]+"${reuse_webserver_env[@]}"} \
   -e "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1" \
   "${image}" \
   /bin/bash -lc "npm ci && npm run ${npm_script}"

--- a/web/app/e2e/scripts/visual-docker.sh
+++ b/web/app/e2e/scripts/visual-docker.sh
@@ -164,12 +164,30 @@ reuse_webserver_env=()
 dev_server_pid=""
 stop_host_dev_server() {
   [[ -n "${dev_server_pid}" ]] || return 0
+  # Guard against PID/PGID reuse: only signal if a node/npm process is still
+  # alive in our process group. The subshell runs `cd && npm start`, so bash
+  # does not exec-replace itself — the group leader stays a shell with node/npm
+  # children sharing its pgid. If that subshell already died on its own, its PID
+  # may have been recycled by an unrelated process, and blindly TERMing the
+  # negative PID would take down a stranger's group. Confirm the group is still
+  # ours before touching it. `ps -A -o pgid=,command=` is portable across the
+  # BSD (macOS) and GNU ps this script may run under.
+  if ! ps -A -o pgid=,command= 2>/dev/null \
+       | awk -v pg="${dev_server_pid}" '$1 == pg' \
+       | grep -Eiq 'node|npm'; then
+    echo "Host Angular dev server (pgid ${dev_server_pid}) already gone — nothing to stop."
+    dev_server_pid=""
+    return 0
+  fi
   echo "Stopping the host Angular dev server (pid/pgid ${dev_server_pid})…"
   # Started under `set -m`, so the backgrounded subshell leads its own process
   # group whose id equals its PID ($!); signalling the negative PID takes down
   # `ng serve` and its build workers together. Fall back to the bare PID if the
   # group is already gone.
   kill -TERM "-${dev_server_pid}" 2>/dev/null || kill -TERM "${dev_server_pid}" 2>/dev/null || true
+  # Idempotent: the EXIT trap fires once, but clearing avoids any re-entry
+  # re-signalling a PID that is no longer ours.
+  dev_server_pid=""
 }
 if [[ ${#platform_flag[@]} -gt 0 ]]; then
   frontend_url="http://localhost:4200"


### PR DESCRIPTION
## Summary

- Make `e2e/scripts/visual-docker.sh` bring up its own backend so regenerating baselines no longer needs the `make db-up` + `make dev-up`/`run-mock`/`run-local` dance (which leaned on a contributor's local `.env` and host Postgres). It builds and starts the self-contained compose `api` service **from current source, in mock mode** (`ENV=development LLM_BACKEND=mock`) — both are load-bearing for the `@mock-only` suite: a stale prebuilt image silently 404s newer endpoints, which shows up as a misleading CORS/"failed to load" error inside a baseline. An already-running backend is reused (with a warning it must be current + mock).
- **Make baseline regen work on non-amd64 hosts (Apple Silicon).** The render container is forced to `linux/amd64` for CI parity, so an in-container `ng serve` builds under emulation and overruns Playwright's `webServer` timeout. Since only Chromium's rasterization must match CI (the app bundle is platform-independent), on a non-amd64 host the script serves the app natively on the host (`:4200`, bound `0.0.0.0`) and routes only Chromium through the container via an extended host-resolver remap (`localhost:4200` + `localhost:8080`). `playwright.config.mock-llm.ts` skips its managed dev server when `E2E_REUSE_HOST_WEBSERVER=1` (and errors if `E2E_BASE_URL` is also set, so the app origin stays `localhost:4200` and CORS/cookies/baselines are unchanged).
- Add an empty-default `LLM_BACKEND` passthrough to the compose `api` service so mock mode can be selected without affecting a normal `docker compose up`.
- Update the e2e README to document the mock-mode/fresh-build backend requirement and the non-amd64 flow.

## Test plan

- [ ] `make pre-commit` (not applicable — e2e tooling, config, docs; no Go/frontend sources)
- [x] Frontend lint: `npm run lint:e2e` passes
- [x] Manually verified end to end on an arm64 Mac: from nothing on `:8080`, the script builds + starts the mock backend, serves the app natively on `:4200`, and the full visual suite (14 specs) passes through the amd64 container. Also verified the reuse-existing-backend path and clean teardown of the host dev server.

## Checklist

- [x] No credentials, personal exports, generated local state, or production config committed
- [x] Public defaults still work without hosted services
- [ ] Updated architecture docs (only if this touches system boundaries)
- [ ] Regenerated the e2e SDK (only if `openapi.yaml` changed)
