### PR TITLE
feat(metering): link a recorded turn to its assistant message

### DIFF
--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -2105,12 +2105,20 @@ func (a *Agent) postMessageProcessing(ctx context.Context, userID uuid.UUID, cha
 		if hasSystemRitual(chatMessage.Rituals, SystemRitualIDImageGenerate) {
 			recordAction = models.ActionTypeImageGeneration
 		}
+		// Link this turn's primary billed event to the assistant message that owns
+		// its Context X-ray, so an implementation can surface the turn's cost on the
+		// X-ray later. Empty when the turn produced no assistant message.
+		var messageID string
+		if agentMessage != nil {
+			messageID = agentMessage.ID.String()
+		}
 		a.meter.Record(ctx, qd, metering.Usage{
 			UserID:     userID,
 			ActionType: recordAction,
 			Model:      chatCtx.model,
 			ChatID:     chatMessage.ChatID.String(),
 			Tokens:     chatMessage.Tokens,
+			MessageID:  messageID,
 		})
 
 		if actionType == models.ActionTypeChatMessage && chatCtx != nil && chatCtx.webSearchCount > 0 {

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -2105,7 +2105,7 @@ func (a *Agent) postMessageProcessing(ctx context.Context, userID uuid.UUID, cha
 		if hasSystemRitual(chatMessage.Rituals, SystemRitualIDImageGenerate) {
 			recordAction = models.ActionTypeImageGeneration
 		}
-		// Link this turn's primary billed event to the assistant message that owns
+		// Link this turn's primary metered event to the assistant message that owns
 		// its Context X-ray, so an implementation can surface the turn's cost on the
 		// X-ray later. Empty when the turn produced no assistant message.
 		var messageID string

--- a/internal/metering/_PACKAGE_SUMMARY.md
+++ b/internal/metering/_PACKAGE_SUMMARY.md
@@ -25,6 +25,7 @@ Defines the implementation-independent metering contract used by the agent.
 ## Non-obvious decisions
 
 - The agent reads only `Decision.Allowed` and `Decision.FreeChat`; `State` remains owned by the implementation.
+- `Usage.MessageID` is a plain fact the agent owns (the assistant message the turn produced), not metering data. It exists so an implementation can persist a link from a recorded turn to the message whose Context X-ray it paid for; `NoopMeter` ignores it and the core reads it back nowhere.
 - `New` is intentionally nil when no implementation is linked. `Agent.NewAgent` then chooses `NoopMeter`, so removing the production meter does not require agent or server changes.
 
 ## Testing

--- a/internal/metering/meter.go
+++ b/internal/metering/meter.go
@@ -71,6 +71,12 @@ type Usage struct {
 	Model      string
 	ChatID     string
 	Tokens     int64
+	// MessageID is the assistant message this turn produced — the same message
+	// that owns the turn's Context X-ray snapshot. Optional (empty when no
+	// assistant message exists, e.g. a failed turn); it carries no metering
+	// meaning here. An implementation may persist it so per-turn cost can later
+	// be looked up by message; NoopMeter ignores it.
+	MessageID string
 	// Metadata augments the recorded usage event (e.g. cancellation details).
 	Metadata map[string]interface{}
 	// SubagentRun marks the usage as originating from a subagent job.

--- a/web/app/src/app/extensions/context-cost-outlet.component.ts
+++ b/web/app/src/app/extensions/context-cost-outlet.component.ts
@@ -6,23 +6,29 @@ import { InputAPICostEstimate } from '../features/chat/helpers/api-pricing.helpe
 /**
  * Mount point for the Context X-ray cost display. The default build renders
  * the estimated input API cost; a private build replaces this file (via the
- * overlay) to render its credit-cost UI instead. The Context X-ray renders
- * this outlet unconditionally whenever a cost estimate is available.
+ * overlay) to render its credit-cost UI instead.
+ *
+ * The X-ray mounts this outlet whenever it has either a cost estimate or the
+ * owning message id, so inputs are optional: the default build renders nothing
+ * without a `cost` and ignores `messageId`; the private build keys its
+ * per-turn credit lookup off `messageId`.
  */
 @Component({
   selector: 'app-context-cost-outlet',
   standalone: true,
   imports: [DecimalPipe],
   template: `
-    <span
-      class="gauge__cost"
-      [title]="
-        'Standard input-token rate checked ' +
-        cost().pricingCheckedAt +
-        '. Excludes output tokens, cached-input discounts, tool fees, batch/priority tiers, regional uplifts, and account-specific pricing.'
-      "
-      >Est. &#36;{{ cost().amountUsd | number: '1.3-3' }}</span
-    >
+    @if (cost(); as c) {
+      <span
+        class="gauge__cost"
+        [title]="
+          'Standard input-token rate checked ' +
+          c.pricingCheckedAt +
+          '. Excludes output tokens, cached-input discounts, tool fees, batch/priority tiers, regional uplifts, and account-specific pricing.'
+        "
+        >Est. &#36;{{ c.amountUsd | number: '1.3-3' }}</span
+      >
+    }
   `,
   styles: [
     `
@@ -37,5 +43,7 @@ import { InputAPICostEstimate } from '../features/chat/helpers/api-pricing.helpe
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ContextCostOutletComponent {
-  readonly cost = input.required<InputAPICostEstimate>();
+  readonly cost = input<InputAPICostEstimate | null>(null);
+  /** Assistant message that owns this X-ray. Unused by the default build; the private build looks up its charged credits by it. */
+  readonly messageId = input<string | null>(null);
 }

--- a/web/app/src/app/features/chat/chat-page.component.ts
+++ b/web/app/src/app/features/chat/chat-page.component.ts
@@ -683,7 +683,7 @@ export class ChatPageComponent implements OnInit, OnDestroy {
   openContextForMessage(message: ChatMessage): void {
     const breakdown = message.context_breakdown;
     if (!breakdown) return;
-    this.contextPanel.selectBreakdown(breakdown);
+    this.contextPanel.selectBreakdown(breakdown, message.id);
     this.contextPanel.setActiveTab('context');
     this.contextPanel.setDesktopVisible(true);
     if (this.isMobileViewport()) {

--- a/web/app/src/app/features/chat/components/context-panel/context-panel.component.ts
+++ b/web/app/src/app/features/chat/components/context-panel/context-panel.component.ts
@@ -85,7 +85,10 @@ import { XIconComponent } from '../../../../shared/ui/icons/icons';
           <app-context-tools-tab [chat]="context.activeChat()" [toolCalls]="context.toolCalls()" />
           }
           @case ('context') {
-          <app-context-breakdown-tab [breakdown]="context.shownBreakdown()" />
+          <app-context-breakdown-tab
+            [breakdown]="context.shownBreakdown()"
+            [messageId]="context.shownBreakdownId()"
+          />
           }
         }
       </div>

--- a/web/app/src/app/features/chat/components/context-panel/tabs/context-breakdown-tab.component.spec.ts
+++ b/web/app/src/app/features/chat/components/context-panel/tabs/context-breakdown-tab.component.spec.ts
@@ -70,6 +70,22 @@ describe('ContextBreakdownTabComponent', () => {
         expect(gauge.querySelector('.gauge__cost')).toBeNull();
     });
 
+    it('mounts the cost outlet when only a message id is available, without a dollar estimate', () => {
+        // An unknown-priced model has no cost estimate, but the outlet must still mount so a
+        // private build can render its per-turn credit cost from the message id. The default
+        // build renders nothing there.
+        fixture.componentRef.setInput('breakdown', {
+            ...sampleBreakdown,
+            provider: 'local',
+            model: 'my-custom-model',
+        } satisfies ContextBreakdown);
+        fixture.componentRef.setInput('messageId', 'msg-1');
+        fixture.detectChanges();
+        const gauge = fixture.nativeElement.querySelector('.gauge') as HTMLElement;
+        expect(gauge.querySelector('app-context-cost-outlet')).not.toBeNull();
+        expect(gauge.querySelector('.gauge__cost')).toBeNull();
+    });
+
     it('never lets the denominator fall below usage and flags over-budget', () => {
         fixture.componentRef.setInput('breakdown', {
             ...sampleBreakdown,

--- a/web/app/src/app/features/chat/components/context-panel/tabs/context-breakdown-tab.component.ts
+++ b/web/app/src/app/features/chat/components/context-panel/tabs/context-breakdown-tab.component.ts
@@ -61,8 +61,8 @@ interface BreakdownRow {
             <div class="gauge__top">
               <span class="gauge__total">{{ format(total()) }}</span>
               <span class="gauge__budget">/ {{ format(displayBudget()) }} tokens</span>
-              @if (inputCost(); as cost) {
-                <app-context-cost-outlet [cost]="cost" />
+              @if (inputCost() || messageId()) {
+                <app-context-cost-outlet [cost]="inputCost()" [messageId]="messageId()" />
               }
             </div>
             <div
@@ -236,6 +236,8 @@ interface BreakdownRow {
 })
 export class ContextBreakdownTabComponent {
   readonly breakdown = input<ContextBreakdown | null>(null);
+  /** Owning message id of the shown breakdown; forwarded to the cost outlet (used by private builds). */
+  readonly messageId = input<string | null>(null);
   readonly inputCost = computed(() => estimateInputAPICost(this.breakdown()));
 
   readonly total = computed(() => {

--- a/web/app/src/app/features/chat/services/context-panel.service.spec.ts
+++ b/web/app/src/app/features/chat/services/context-panel.service.spec.ts
@@ -69,10 +69,12 @@ describe('ContextPanelService', () => {
         const latest = breakdown(5000);
         service.setLatestBreakdown(latest, 'msg-latest');
         expect(service.shownBreakdown()).toBe(latest);
+        expect(service.shownBreakdownId()).toBe('msg-latest');
 
         const pinned = breakdown(1200);
-        service.selectBreakdown(pinned);
+        service.selectBreakdown(pinned, 'msg-pinned');
         expect(service.shownBreakdown()).toBe(pinned);
+        expect(service.shownBreakdownId()).toBe('msg-pinned');
     });
 
     it('clears a pinned past turn when a genuinely new turn lands', () => {
@@ -89,5 +91,17 @@ describe('ContextPanelService', () => {
         const newest = breakdown(6000);
         service.setLatestBreakdown(newest, 'msg-2');
         expect(service.shownBreakdown()).toBe(newest);
+    });
+
+    it('resolves shownBreakdownId to the pinned turn, else the latest', () => {
+        service.setLatestBreakdown(breakdown(5000), 'msg-latest');
+        expect(service.shownBreakdownId()).toBe('msg-latest');
+
+        service.selectBreakdown(breakdown(1200), 'msg-pinned');
+        expect(service.shownBreakdownId()).toBe('msg-pinned');
+
+        // A new turn clears the pin, so the id falls back to the latest.
+        service.setLatestBreakdown(breakdown(6000), 'msg-newest');
+        expect(service.shownBreakdownId()).toBe('msg-newest');
     });
 });

--- a/web/app/src/app/features/chat/services/context-panel.service.ts
+++ b/web/app/src/app/features/chat/services/context-panel.service.ts
@@ -20,6 +20,9 @@ export class ContextPanelService {
   private readonly _latestBreakdownId = signal<string | null>(null);
   // A specific past turn the user pinned via "Show context"; cleared when a new turn lands.
   private readonly _pinnedBreakdown = signal<ContextBreakdown | null>(null);
+  // The owning message id of the pinned past turn, tracked alongside it so the shown
+  // breakdown always resolves to a message id (see shownBreakdownId).
+  private readonly _pinnedBreakdownId = signal<string | null>(null);
 
   readonly activeChat = this._activeChat.asReadonly();
   readonly mobileOpen = this._mobileOpen.asReadonly();
@@ -29,6 +32,10 @@ export class ContextPanelService {
   readonly latestBreakdown = this._latestBreakdown.asReadonly();
   /** The breakdown the Context tab should render: a pinned past turn, else the latest. */
   readonly shownBreakdown = computed(() => this._pinnedBreakdown() ?? this._latestBreakdown());
+  /** Owning message id of shownBreakdown, or null. Mirrors the pinned-else-latest choice above. */
+  readonly shownBreakdownId = computed(() =>
+    this._pinnedBreakdown() ? this._pinnedBreakdownId() : this._latestBreakdownId(),
+  );
   readonly visible = computed(() => this.rightPanel.visible());
   readonly activeChatId = computed(() => this._activeChat()?.id ?? null);
   readonly activeTab = computed<ContextPanelTab>(() => {
@@ -52,14 +59,16 @@ export class ContextPanelService {
     // panel follows the conversation forward after each send.
     if (messageId !== null && messageId !== this._latestBreakdownId()) {
       this._pinnedBreakdown.set(null);
+      this._pinnedBreakdownId.set(null);
     }
     this._latestBreakdown.set(breakdown);
     this._latestBreakdownId.set(messageId);
   }
 
   /** Pin a specific past turn's breakdown in the Context tab (from a message's "Show context"). */
-  selectBreakdown(breakdown: ContextBreakdown | null): void {
+  selectBreakdown(breakdown: ContextBreakdown | null, messageId: string | null = null): void {
     this._pinnedBreakdown.set(breakdown);
+    this._pinnedBreakdownId.set(messageId);
   }
 
   setActiveTab(tab: ContextPanelTab): void {


### PR DESCRIPTION
## Why

Follow-up to #72 (Context X-ray cost). That PR deliberately kept the open-source core BYOK-only — it shows an *estimated input API cost*, not hosted billing. A private build wants the X-ray to show the **actual credits charged** for the turn instead, and to do that it needs one fact the core doesn't currently expose: *which assistant message a recorded turn produced*.

This PR adds that link and threads the message id to the swappable cost outlet. **No billing concepts enter the OSS tree** — `NoopMeter` ignores the new field and the core reads it back nowhere.

## Changes

**Metering seam**
- Add optional `MessageID` to `metering.Usage` — the assistant message the turn produced (the same message that owns the turn's Context X-ray). It's a fact the agent already owns; an implementation *may* persist it so a turn's cost can be looked up by message later.
- `internal/agent`: set it on the primary chat-turn `Record` (guarded — empty when a turn produced no assistant message).

**Context X-ray UI**
- `ContextPanelService` now tracks the pinned past turn's message id alongside the latest, exposed as `shownBreakdownId` (mirrors the existing pinned-else-latest `shownBreakdown`).
- The id flows `context-panel` → `context-breakdown-tab` → `app-context-cost-outlet` (new optional `messageId` input).
- The outlet's inputs are now **optional**, so the X-ray mounts it whenever it has *either* a cost estimate or a message id. The default build's behavior is unchanged: it renders only the estimated input API cost and ignores `messageId`.

## Testing
- `make generate` + `go build ./...`, `go vet`/`go test ./internal/metering/...` green.
- Frontend: `context-panel.service` and `context-breakdown-tab` specs updated + passing; full `ng build` typechecks all templates.

No `openapi.yaml` change (internal Go field + frontend plumbing only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)