### PR TITLE
feat(e2e): add design review report with before/after screens

### DIFF
--- a/.agents/skills/design-review/SKILL.md
+++ b/.agents/skills/design-review/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: design-review
+description: >-
+  Produce a visual before/after review of a branch or pull request — a
+  self-contained HTML report showing every screen the Playwright visual suite
+  covers, as it looked on main and as it looks now, with a slider/onion/pixel-
+  difference comparison, plus what the change touched and which design files
+  no screen covers. Use whenever someone wants to SEE a change rather than
+  read its diff: "what does my PR look like", "show me the visual impact",
+  "design review for this branch", "did the layout change", "before and after
+  screenshots for the PR", "which screens did I break". Also use when a
+  designer's change lands on a screen with no visual baseline and one should
+  be added.
+---
+
+# Design review
+
+Turns a branch into a picture of itself. The audience is whoever has to
+answer "does this look right?" — usually the person who designed it, who
+should not have to read a unified diff of a Tailwind class list to find out.
+
+## The one thing to understand first
+
+A passing visual suite proves nothing about an intentional design change.
+
+When a designer changes a screen they also regenerate its baseline and commit
+it, so by review time `toHaveScreenshot()` compares the new render against
+the new baseline and passes. The Playwright report is green and empty. The
+change is invisible *because it was done correctly*.
+
+So this report does not read a test run. It reads git: the **before** is the
+baseline committed at the merge base, the **after** is the baseline on this
+branch. That is why it needs no backend, no browser and no Docker, and why it
+finishes in about a second.
+
+The visual suite still matters — it is what catches the *unintended* change,
+where the code moved and the baseline did not. That is a different question
+with its own command; see "When to also run the suite" below.
+
+## Produce the report
+
+From `web/app/`:
+
+```bash
+npm run design:review
+```
+
+Or from the repo root, `make design-review`. Either writes
+`.dev/design-review/report.html` — one self-contained file with the images
+inlined, so it can be sent to someone who will never clone the repo.
+
+Useful variants:
+
+| Goal | Command |
+|---|---|
+| My uncommitted work, against `main` | `npm run design:review` |
+| My branch as committed | `npm run design:review -- --head HEAD` |
+| Someone else's PR | `git fetch origin pull/<N>/head:pr-<N>` then `-- --head pr-<N>` |
+| Everything since a release | `npm run design:review -- --base v1.4.0` |
+| Open it immediately | add `-- --open` |
+| Machine-readable, for a CI assertion | add `-- --json <path>` |
+
+The default `--head` is the **working tree**, not `HEAD`. An uncommitted or
+untracked baseline shows up, which is the point when iterating.
+
+## Read the report back to the user
+
+Do not just hand over a file path. Open the JSON model (`--json`) and say
+what is in it, because that is what the person asked:
+
+1. **Which screens changed**, by name, and how much of each differs. A screen
+   at 15% differing pixels was restructured; one at 0.3% moved a border.
+2. **Anything new or removed.** A removed baseline with no explanation in the
+   PR is worth a question — it usually means a spec was deleted or renamed
+   rather than a screen genuinely retired.
+3. **The "changed, but not shown above" list.** These are templates, styles
+   and assets the branch touched that no screen in the report renders. This
+   is the report's most actionable output and the easiest to skip past.
+4. **Send the HTML file to the user** so they can actually look at it.
+
+## When nothing changed
+
+`0 changed · 0 new · 0 removed` with design files in the impact list means one
+of two things, and they need different responses:
+
+- **The change is on a screen with no visual coverage.** Check the uncovered
+  list. Offer to add a visual spec — see below.
+- **The designer changed the code but did not regenerate the baselines.** The
+  report cannot tell you this; the visual suite can, and will fail. Say so
+  rather than reporting "no visual impact", which would be wrong.
+
+## Adding coverage for an uncovered screen
+
+If a changed screen has no baseline, the fix is a new spec in
+`web/app/e2e/tests/visual/`. Follow the `playwright-e2e` skill for the
+mechanics and `web/app/e2e/tests/visual/README.md` for what belongs there.
+Two constraints that decide whether a screen *can* be covered at all:
+
+- **It must be deterministic.** Nothing downstream of an assistant reply,
+  no timestamps, no generated names. Existing specs use fixed persona names
+  for exactly this reason.
+- **Baselines are generated in Docker**, never on a developer's machine —
+  macOS font rasterization does not match CI's. Use
+  `npm run e2e:mock-llm:visual:docker:update`.
+
+A new spec's screenshot name becomes the screen's identity in every future
+report, so name it for the screen (`gallery-empty`), not for the change.
+
+## When to also run the suite
+
+Run `npm run e2e:mock-llm:visual:docker` when you need to know whether the
+branch changed a screen *by accident* — a shared component edit, a global
+style change, a dependency bump. It renders the app and compares against the
+committed baselines, which is the check this report deliberately does not do.
+
+Expect it to take minutes and to need Docker. It is not part of producing a
+design review and should not be run automatically as though it were.
+
+## What the report will not tell you
+
+Be straight about these when reporting findings:
+
+- **The related-files and uncovered lists are name matches, not a dependency
+  graph.** A shared component that renders a screen without sharing a word
+  with its name will be missed.
+- **Only screens with baselines appear.** Coverage is six screens' worth at
+  the time of writing; "no screen changed" is not "nothing changed".
+- **Byte-identical is the test for unchanged.** A re-encoded but visually
+  identical baseline reads as changed, and should — it is worth asking about.

--- a/.agents/skills/design-review/SKILL.md
+++ b/.agents/skills/design-review/SKILL.md
@@ -10,7 +10,8 @@ description: >-
   "design review for this branch", "did the layout change", "before and after
   screenshots for the PR", "which screens did I break". Also use when a
   designer's change lands on a screen with no visual baseline and one should
-  be added.
+  be added. Covers the `design-review` PR label that builds the same report
+  in CI.
 ---
 
 # Design review
@@ -37,6 +38,23 @@ The visual suite still matters — it is what catches the *unintended* change,
 where the code moved and the baseline did not. That is a different question
 with its own command; see "When to also run the suite" below.
 
+## The `design-review` label
+
+For a PR, the usual answer is not to run anything: add the **`design-review`**
+label. `.github/workflows/design-review.yml` builds the report, uploads it as
+the `design-review` artifact, and posts a sticky comment naming the screens
+that moved and by how much. Pushing to a labelled PR refreshes both.
+
+```bash
+gh pr edit <N> --add-label design-review
+```
+
+Prefer this when the PR is already pushed — the reviewer gets a permanent
+link on the PR rather than a file on someone's laptop. Build it locally when
+iterating on uncommitted work, which the label cannot see.
+
+Fork PRs get the artifact but no comment; their token is read-only.
+
 ## Produce the report
 
 From `web/app/`:
@@ -49,6 +67,9 @@ Or from the repo root, `make design-review`. Either writes
 `.dev/design-review/report.html` — one self-contained file with the images
 inlined, so it can be sent to someone who will never clone the repo.
 
+Add `-- --markdown <path>` for the same summary as a PR comment, ready to
+paste.
+
 Useful variants:
 
 | Goal | Command |
@@ -59,6 +80,7 @@ Useful variants:
 | Everything since a release | `npm run design:review -- --base v1.4.0` |
 | Open it immediately | add `-- --open` |
 | Machine-readable, for a CI assertion | add `-- --json <path>` |
+| A summary to paste into a PR | add `-- --markdown <path>` |
 
 The default `--head` is the **working tree**, not `HEAD`. An uncommitted or
 untracked baseline shows up, which is the point when iterating.
@@ -68,8 +90,9 @@ untracked baseline shows up, which is the point when iterating.
 Do not just hand over a file path. Open the JSON model (`--json`) and say
 what is in it, because that is what the person asked:
 
-1. **Which screens changed**, by name, and how much of each differs. A screen
-   at 15% differing pixels was restructured; one at 0.3% moved a border.
+1. **Which screens changed**, by name, and how much of each differs. The
+   model carries a `diff.ratio` per viewport, so quote it. A screen at 15%
+   differing pixels was restructured; one at 0.3% moved a border.
 2. **Anything new or removed.** A removed baseline with no explanation in the
    PR is worth a question — it usually means a spec was deleted or renamed
    rather than a screen genuinely retired.

--- a/.claude/skills/design-review
+++ b/.claude/skills/design-review
@@ -1,0 +1,1 @@
+../../.agents/skills/design-review

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -1,5 +1,21 @@
 name: Design Review
 
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ This must stay a `pull_request` workflow. Never `pull_request_target`.   │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# The job checks out the pull request's head and runs code from it
+# (`node e2e/design-review/cli.mjs`, which reads the working tree and shells
+# out to git). Under `pull_request` that is safe: a fork's token is
+# read-only, so the worst a hostile branch can do is produce a wrong report
+# about itself.
+#
+# `pull_request_target` would run the *same* code from the *same* untrusted
+# branch with a writable token and access to secrets. That is a
+# straightforward code-execution vector, and it is tempting precisely
+# because it is the usual fix for "the comment step is skipped on forks" —
+# which is a limitation this workflow accepts on purpose (see that step).
+#
 # Opt-in, by label. Most PRs do not change a screen, and a report that
 # appears on all of them is one people learn to scroll past — so this runs
 # only where someone has said the visual result is worth looking at.

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -1,0 +1,121 @@
+name: Design Review
+
+# Opt-in, by label. Most PRs do not change a screen, and a report that
+# appears on all of them is one people learn to scroll past — so this runs
+# only where someone has said the visual result is worth looking at.
+#
+# `labeled` is required in addition to the usual three: adding the label to
+# an already-open PR is the whole trigger, and without it nothing would run
+# until the next push. `synchronize` keeps a labelled PR's report current as
+# the branch moves, so a reviewer never opens a report for an older commit.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      base:
+        description: 'Ref to compare against (default: the repository default branch)'
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # One report per PR. A rapid series of pushes should leave the newest
+  # report standing, not race several runs to patch the same comment.
+  group: design-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Build design review report
+    runs-on: ubuntu-latest
+    # `labeled` fires for every label, not just this one, so the event alone
+    # is not the gate — the check is whether the label is present now, which
+    # also covers `synchronize` on an already-labelled PR.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'design-review')
+
+    steps:
+      # Full history: the report's "before" is the baseline at the merge base,
+      # which a shallow clone cannot compute. Checking out the head commit
+      # rather than the default merge commit means the "after" is the branch
+      # as its author left it, not a speculative merge result whose baselines
+      # git resolved on their behalf.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      # No `npm ci` on purpose. The report has no dependencies — it reads
+      # committed baselines out of git — so installing the frontend toolchain
+      # here would be a minute of CI to run a script that does not use it.
+
+      - name: Resolve the base ref
+        id: base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || inputs.base || 'main' }}
+        run: |
+          # `actions/checkout` fetches all branches at depth 0, but fetching
+          # the base explicitly keeps this working if that ever changes — and
+          # a missing base ref is a silently wrong report, not a failure.
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          echo "ref=origin/${BASE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Build the report
+        env:
+          BASE: ${{ steps.base.outputs.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        working-directory: web/app
+        run: |
+          node e2e/design-review/cli.mjs \
+            --base "$BASE" \
+            --head HEAD \
+            --out "$RUNNER_TEMP/design-review.html" \
+            --json "$RUNNER_TEMP/design-review.json" \
+            --markdown "$RUNNER_TEMP/design-review.md" \
+            --report-link "$RUN_URL" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          cat "$RUNNER_TEMP/design-review.md" >> "$GITHUB_STEP_SUMMARY"
+
+      # The report is a single self-contained file; downloading the artifact
+      # and opening it is the whole workflow for a reviewer. `compression-
+      # level: 0` because the PNGs inside are already deflate-compressed and
+      # re-compressing them costs time for roughly nothing.
+      - name: Upload the report
+        uses: actions/upload-artifact@v4
+        with:
+          name: design-review
+          path: |
+            ${{ runner.temp }}/design-review.html
+            ${{ runner.temp }}/design-review.json
+          retention-days: 14
+          compression-level: 0
+
+      # Skipped for forks — same reasoning as the e2e workflows' identically
+      # named steps: a fork PR's token is read-only here, and the alternative
+      # (`pull_request_target`) would hand a write token to a job that runs
+      # the PR's own code.
+      - name: Post or update PR comment
+        if: >-
+          !cancelled() && github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/e2e-status-comment
+        with:
+          pr: ${{ github.event.pull_request.number }}
+          # Its own sticky comment rather than a section of the e2e one: this
+          # is label-triggered and answers a different question, so it should
+          # appear and update on its own cadence.
+          comment-key: design-review-comment
+          section: design-review
+          order: 10
+          body-file: ${{ runner.temp }}/design-review.md

--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Build the report
         env:
           BASE: ${{ steps.base.outputs.ref }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         working-directory: web/app
         run: |
           node e2e/design-review/cli.mjs \
@@ -82,16 +81,14 @@ jobs:
             --head HEAD \
             --out "$RUNNER_TEMP/design-review.html" \
             --json "$RUNNER_TEMP/design-review.json" \
-            --markdown "$RUNNER_TEMP/design-review.md" \
-            --report-link "$RUN_URL" \
             | tee -a "$GITHUB_STEP_SUMMARY"
-          cat "$RUNNER_TEMP/design-review.md" >> "$GITHUB_STEP_SUMMARY"
 
       # The report is a single self-contained file; downloading the artifact
       # and opening it is the whole workflow for a reviewer. `compression-
       # level: 0` because the PNGs inside are already deflate-compressed and
       # re-compressing them costs time for roughly nothing.
       - name: Upload the report
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: design-review
@@ -100,6 +97,26 @@ jobs:
             ${{ runner.temp }}/design-review.json
           retention-days: 14
           compression-level: 0
+
+      # Rendered after the upload, not with the report, so the comment can
+      # link straight at the artifact. `upload-artifact` only knows that URL
+      # once it has finished, and a link to the run page instead would leave
+      # the reader hunting for an "Artifacts" section at the bottom of it.
+      - name: Render the PR comment
+        env:
+          BASE: ${{ steps.base.outputs.ref }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        working-directory: web/app
+        run: |
+          node e2e/design-review/cli.mjs \
+            --base "$BASE" \
+            --head HEAD \
+            --out "$RUNNER_TEMP/discard.html" \
+            --markdown "$RUNNER_TEMP/design-review.md" \
+            --report-link "$ARTIFACT_URL" \
+            --run-link "$RUN_URL" >/dev/null
+          cat "$RUNNER_TEMP/design-review.md" >> "$GITHUB_STEP_SUMMARY"
 
       # Skipped for forks — same reasoning as the e2e workflows' identically
       # named steps: a fork PR's token is read-only here, and the alternative

--- a/.github/workflows/frontend-pr-validation.yml
+++ b/.github/workflows/frontend-pr-validation.yml
@@ -114,6 +114,15 @@ jobs:
         working-directory: web/app
         run: npm run e2e:check-visual-coverage
 
+      # The design review report reads git history and committed baselines,
+      # so its failure mode is a wrong answer rather than a crash — a broken
+      # merge-base calculation still renders a perfectly plausible report of
+      # the wrong change. These tests build throwaway repositories and assert
+      # on what comes back; they need no browser and no backend, and run in a
+      # couple of seconds.
+      - name: Test the design review report
+        run: make design-review-test
+
       - name: TypeScript type checking
         working-directory: web/app
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,11 @@
 - Backend: Go `testing` with table-driven tests when appropriate. Files end with `_test.go`; test funcs `TestXxx`. Run `go test ./...` or `make test`.
 - Frontend: `cd web/app && npm test`. Runs on Vitest via the `@angular/build:unit-test` builder (jsdom); Karma and Jasmine are gone.
 - Frontend coverage: `make web-unit-coverage` / `make admin-unit-coverage` run the same suites with V8 coverage and rewrite the lcov `SF:` paths to repo-root-relative so Codecov's components match. `make lcov-summary LCOV=<path>` prints a total.
+- Design review: `make design-review` (or `npm run design:review` from `web/app/`) writes a
+  self-contained HTML before/after of every screen the visual suite covers, read from git
+  rather than from a test run — a committed baseline update makes the visual suite pass, so
+  an intentional design change otherwise leaves no trace in any report. See the
+  `design-review` skill and `web/app/e2e/design-review/README.md`.
 - Frontend E2E: Playwright suite in `web/app/e2e/` (`poms/`,
   `fixtures/`, `sdk/`, `tests/{functional,journeys,visual,a11y}`) — run via
   `npm run e2e`/`e2e:mock-llm`/`e2e:local-llm`/`e2e:mock-llm:visual`

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,18 @@ web: $(WEB_DIR)/node_modules/.stamp ## Run the Angular dev server (:4200)
 web-e2e: $(WEB_DIR)/node_modules/.stamp ## Run Playwright frontend E2E tests (requires the API already running on :8080 — see web/app/e2e/README.md)
 	@cd $(WEB_DIR) && npm run e2e
 
+# Deliberately NOT dependent on node_modules/.stamp. The report reads
+# committed baselines out of git and has no npm dependencies at all, so it
+# runs in a fresh clone in about a second — which is the difference between
+# a tool a designer uses mid-iteration and one they run once and forget.
+.PHONY: design-review
+design-review: ## Before/after HTML of every screen this branch changes (ARGS="--base v1.2.0 --open")
+	@cd $(WEB_DIR) && node e2e/design-review/cli.mjs $(ARGS)
+
+.PHONY: design-review-test
+design-review-test: ## Test the design review report tooling (node --test, no deps, no browser)
+	@cd $(WEB_DIR) && npm run design:review:test
+
 # npm ci runs only when the manifests change, keyed via a stamp file.
 $(WEB_DIR)/node_modules/.stamp: $(WEB_DIR)/package.json $(WEB_DIR)/package-lock.json
 	@cd $(WEB_DIR) && npm ci

--- a/web/app/e2e/README.md
+++ b/web/app/e2e/README.md
@@ -137,6 +137,7 @@ e2e/
   api-tests/  # browserless suite, straight against the API — see below
   docs/
     what-runs-where.md # which config runs what, against which backend, and why
+  design-review/  # before/after HTML report of the screens a branch changes — see below
   scripts/
     visual-docker.sh   # runs tests/visual inside the Playwright Docker image
     check-visual-coverage.mjs # every visual spec must name a functional spec
@@ -705,6 +706,34 @@ with fixed test data — see the comments in `chat.visual.spec.ts` and
 `maxDiffPixelRatio` for a masked region whose _size_ (not content) shifts by
 a few pixels depending on async timing — a last resort after masking, not a
 substitute for it.
+
+### Reviewing a change, rather than guarding against one
+
+The suite above answers "did anything change by accident?". It cannot answer
+"what did we change on purpose, and does it look right?" — and for a design
+change the two come apart completely.
+
+The workflow is: edit the screen, regenerate the baseline, commit both. From
+that commit on, `toHaveScreenshot()` compares the new render against the new
+baseline and passes. The visual report is green and empty; the only surviving
+record of the previous design is a PNG blob in git history that no review tool
+renders. A reviewer is left approving a screen change from a Tailwind class
+diff.
+
+`e2e/design-review/` closes that gap. It reads the baseline at the merge base
+as the "before" and the baseline on the branch as the "after", and writes one
+self-contained HTML file with both, a slider/onion/pixel-difference
+comparison, and a summary of what the branch touched:
+
+```bash
+npm run design:review            # or, from the repo root: make design-review
+```
+
+Because it reads git rather than rendering anything, it needs no backend, no
+browser, no Docker and no `npm install`, and it finishes in about a second.
+It also lists the templates and styles a branch changed that *no* screen
+covers, which is the failure mode the suite itself is structurally unable to
+report. See `e2e/design-review/README.md`.
 
 ### Updating snapshots
 

--- a/web/app/e2e/design-review/README.md
+++ b/web/app/e2e/design-review/README.md
@@ -10,6 +10,22 @@ make design-review              # from the repo root
 
 Writes `.dev/design-review/report.html`. Add `-- --open` to open it.
 
+## On a pull request: the `design-review` label
+
+Add the **`design-review`** label to a PR and
+`.github/workflows/design-review.yml` builds the report for it, uploads it
+as the `design-review` artifact, and posts a sticky comment listing the
+screens that moved and by how much. Pushing to a labelled PR refreshes both.
+
+Opt-in rather than automatic, for the reason every label gate in this repo
+exists: most PRs do not change a screen, and a report that appears on all of
+them is one people learn to scroll past.
+
+The job runs no browser, no backend and no `npm ci`, so it costs seconds
+rather than minutes. Fork PRs get the artifact but no comment — their token
+is read-only, and the alternative (`pull_request_target`) would hand a write
+token to a job running the PR's own code.
+
 ## Why this exists separately from the visual suite
 
 The visual suite answers "did anything change by accident?". This answers
@@ -48,17 +64,25 @@ what makes it a second-long command rather than a twenty-minute one.
 | File | Role |
 |---|---|
 | `cli.mjs` | Argument parsing, output paths, the terminal summary. |
+| `markdown.mjs` | The model as a PR comment. Same source as the HTML, so the two cannot disagree. |
 | `collect.mjs` | Builds the model. Knows about screens, statuses and impact; produces no HTML. |
 | `render.mjs` | Model to HTML. Deduplicates images and inlines everything. |
 | `assets/report.css`, `assets/report.js` | The report's own UI, inlined at render time. |
 | `lib/git.mjs` | Refs, blobs, changed files. The only place that shells out to git. |
 | `lib/screens.mjs` | Baseline paths to screens; spec titles and doc comments. |
-| `lib/png.mjs` | IHDR dimensions, nothing more. |
+| `lib/png.mjs` | Dimensions from the header, plus a decoder for 8-bit non-interlaced PNGs. |
+| `lib/diff.mjs` | Changed-pixel comparison. Mirrors the rule `assets/report.js` runs on a canvas. |
 | `lib/impact.mjs` | File categories, feature areas, the name-match heuristic. |
 
 `collect.mjs` returning a plain object rather than writing files is what lets
-`--json` and the HTML report share one definition of "which screens changed",
-instead of two that drift.
+the HTML report, `--json` and the PR comment share one definition of "which
+screens changed", instead of three that drift.
+
+The changed-pixel figure is computed twice on purpose: in Node, so the
+comment and the JSON can quote a number without rendering anything, and in
+the browser, so the report's sensitivity slider can move without a round
+trip. Both implement the same rule from the same default threshold, and a
+test pins the boundary. Changing one means changing the other.
 
 ## Known limits
 

--- a/web/app/e2e/design-review/README.md
+++ b/web/app/e2e/design-review/README.md
@@ -84,6 +84,20 @@ the browser, so the report's sensitivity slider can move without a round
 trip. Both implement the same rule from the same default threshold, and a
 test pins the boundary. Changing one means changing the other.
 
+## `gh` is optional everywhere
+
+The only thing the GitHub CLI contributes is the pull request number and
+title in the report's header (`lib/gh.mjs`). A missing `gh`, an
+unauthenticated one, no network, or a branch with no PR all return null and
+cost one header line. The CI workflow never depends on it being present in
+the runner image, and nothing in the HTML, the JSON or the PR comment is
+derived from it.
+
+It is consulted only when the report's head is the checked-out branch.
+Asked for any other ref, `gh pr view` would return the *current* branch's
+pull request and stamp a report about one change with another change's
+title, so the lookup is skipped instead.
+
 ## Known limits
 
 - **Only screens with committed baselines appear.** "No screen changed" is not

--- a/web/app/e2e/design-review/README.md
+++ b/web/app/e2e/design-review/README.md
@@ -98,6 +98,23 @@ Asked for any other ref, `gh pr view` would return the *current* branch's
 pull request and stamp a report about one change with another change's
 title, so the lookup is skipped instead.
 
+## Where the classification rules live
+
+Three tables in `lib/impact.mjs` decide what a reader sees, and they are the
+first place to look when the report groups something oddly:
+
+| Constant | Decides |
+|---|---|
+| `CATEGORIES` | What kind of file this is, and how much of it counts as design surface. **Order is precedence** — the first match wins, which is why a baseline PNG is a baseline and not an asset. |
+| `CONTAINER_SEGMENTS` | Path segments that name no feature (`features`, `shared`, `core`…), so the area shown is `personality` rather than `features`. |
+| `STOP_WORDS` | Words too common to mean anything when matching a changed file to a screen. Without them every file "relates to" every screen via `component` or `page`. |
+
+Each is covered by `tests/units.test.mjs`, so a change that alters the
+grouping fails there rather than silently shifting what the report claims.
+Adding a category means deciding its `weight` too: that is what feeds the
+"design surface" percentage, and a new entry defaulting to zero will quietly
+drag that figure down.
+
 ## Known limits
 
 - **Only screens with committed baselines appear.** "No screen changed" is not

--- a/web/app/e2e/design-review/README.md
+++ b/web/app/e2e/design-review/README.md
@@ -1,0 +1,72 @@
+# Design review report
+
+A before/after view of every screen the visual suite covers, as one
+self-contained HTML file.
+
+```bash
+npm run design:review           # from web/app/
+make design-review              # from the repo root
+```
+
+Writes `.dev/design-review/report.html`. Add `-- --open` to open it.
+
+## Why this exists separately from the visual suite
+
+The visual suite answers "did anything change by accident?". This answers
+"what did we change on purpose, and what does it look like?" — and the two
+are close to opposites in practice.
+
+When a designer changes a screen, they regenerate its baseline and commit it.
+From that moment `toHaveScreenshot()` compares the new render against the new
+baseline and passes. The visual report is green and empty. The change is
+invisible *precisely because the workflow was followed correctly*, and the
+only remaining record of what the screen used to look like is a binary blob
+in the git history that no review tool renders.
+
+So the "before" here is the baseline at the merge base and the "after" is the
+baseline on this branch. Nothing is rendered, nothing is executed, no backend
+or browser or Docker is involved, and there are no npm dependencies — which is
+what makes it a second-long command rather than a twenty-minute one.
+
+## What the report contains
+
+- **Every covered screen**, changed ones first, desktop and mobile side by
+  side, sized so a phone reads as a phone next to a laptop.
+- **Four ways to compare** a changed screen: a drag slider, side by side,
+  onion-skin cross-fade, and a pixel difference overlay with adjustable
+  sensitivity. All four are computed in the browser from the two images the
+  page already holds.
+- **Impact**: what categories of file changed, which feature areas, and how
+  much of the frontend change is design surface rather than logic.
+- **"Changed, but not shown above"**: templates, styles and assets the branch
+  touched that no screen in the report renders. The quiet failure mode of any
+  visual suite is a restyled component with no baseline; this is the line
+  that makes it loud.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `cli.mjs` | Argument parsing, output paths, the terminal summary. |
+| `collect.mjs` | Builds the model. Knows about screens, statuses and impact; produces no HTML. |
+| `render.mjs` | Model to HTML. Deduplicates images and inlines everything. |
+| `assets/report.css`, `assets/report.js` | The report's own UI, inlined at render time. |
+| `lib/git.mjs` | Refs, blobs, changed files. The only place that shells out to git. |
+| `lib/screens.mjs` | Baseline paths to screens; spec titles and doc comments. |
+| `lib/png.mjs` | IHDR dimensions, nothing more. |
+| `lib/impact.mjs` | File categories, feature areas, the name-match heuristic. |
+
+`collect.mjs` returning a plain object rather than writing files is what lets
+`--json` and the HTML report share one definition of "which screens changed",
+instead of two that drift.
+
+## Known limits
+
+- **Only screens with committed baselines appear.** "No screen changed" is not
+  "nothing changed" — read the uncovered list alongside it.
+- **Related files are matched by name, not by imports.** A shared component
+  that renders a screen without sharing a word with its name will be missed.
+  The report says so where it shows them.
+- **Unchanged means byte-identical.** A re-encoded baseline that renders the
+  same reads as changed. That is deliberate: it is still something a reviewer
+  should ask about.

--- a/web/app/e2e/design-review/assets/report.css
+++ b/web/app/e2e/design-review/assets/report.css
@@ -1,0 +1,353 @@
+/*
+ * Design review report.
+ *
+ * Deliberately neutral: this page frames screenshots of a product that has
+ * its own colour language, so anything opinionated here would compete with
+ * the thing being reviewed. Greys, one accent, and all the saturation
+ * reserved for status (changed / new / removed) and for the diff overlay.
+ *
+ * Dark by default because that is what a screenshot with a light UI reads
+ * best against, with a light theme one keystroke away for the opposite case.
+ */
+
+:root {
+  color-scheme: dark;
+  --bg: #0d0f13;
+  --bg-raised: #151920;
+  --bg-sunken: #090b0e;
+  --border: #242a34;
+  --border-strong: #333b48;
+  --text: #e8ecf2;
+  --text-dim: #98a2b3;
+  --text-faint: #6b7585;
+  --accent: #7aa2f7;
+  --changed: #f0a04b;
+  --added: #5ec98a;
+  --removed: #e5646e;
+  --unchanged: #5a6474;
+  --shadow: 0 1px 2px rgb(0 0 0 / 0.4), 0 8px 24px rgb(0 0 0 / 0.24);
+  --radius: 10px;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+}
+
+[data-theme='light'] {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --bg-raised: #ffffff;
+  --bg-sunken: #eceef2;
+  --border: #dfe3ea;
+  --border-strong: #c3cad6;
+  --text: #12161c;
+  --text-dim: #58616f;
+  --text-faint: #838d9c;
+  --accent: #3060c8;
+  --changed: #b06a12;
+  --added: #237d4c;
+  --removed: #bb2d3a;
+  --unchanged: #97a0ae;
+  --shadow: 0 1px 2px rgb(16 24 40 / 0.06), 0 8px 24px rgb(16 24 40 / 0.08);
+}
+
+* { box-sizing: border-box; }
+
+/*
+ * The compare modes switch layers with the `hidden` attribute, and every
+ * rule below that gives a layer a `display` would otherwise win against the
+ * user-agent's `[hidden] { display: none }` on specificity alone — leaving
+ * the slider, the side-by-side pair and the difference canvas all painted on
+ * top of each other. This is the one place `!important` is the correct
+ * tool: it restores a UA default that later rules were never meant to
+ * override.
+ */
+[hidden] { display: none !important; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); }
+
+.wrap { max-width: 1380px; margin: 0 auto; padding: 0 28px 96px; }
+
+/* ---------- header ---------- */
+
+.masthead { padding: 40px 0 24px; border-bottom: 1px solid var(--border); }
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  margin: 0 0 10px;
+}
+.masthead h1 { margin: 0 0 14px; font-size: 27px; line-height: 1.25; font-weight: 650; letter-spacing: -0.015em; }
+.masthead h1 a { text-decoration: none; }
+.masthead h1 a:hover { text-decoration: underline; }
+
+/* The base→head line. Monospace so two shas line up under each other. */
+.refline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  align-items: center;
+  font-size: 12.5px;
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+.refline .sha { color: var(--text); background: var(--bg-sunken); border: 1px solid var(--border); border-radius: 5px; padding: 1px 7px; }
+.refline .arrow { color: var(--text-faint); }
+
+/* ---------- summary tiles ---------- */
+
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(146px, 1fr)); gap: 12px; margin: 26px 0 0; }
+.tile {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px 13px;
+  position: relative;
+  overflow: hidden;
+}
+/* A 3px status rail rather than a tinted card: the number stays readable and
+   the colour still reads at a glance from across a desk. */
+.tile::before { content: ''; position: absolute; inset: 0 auto 0 0; width: 3px; background: var(--rail, transparent); }
+.tile .n { font-size: 26px; font-weight: 620; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
+.tile .k { font-size: 11.5px; color: var(--text-dim); margin-top: 1px; }
+.tile.changed { --rail: var(--changed); }
+.tile.added { --rail: var(--added); }
+.tile.removed { --rail: var(--removed); }
+.tile.unchanged { --rail: var(--unchanged); }
+.tile.surface { --rail: var(--accent); }
+
+/* ---------- toolbar ---------- */
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 20px;
+  align-items: center;
+  padding: 12px 28px;
+  margin: 28px -28px 0;
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+}
+.group { display: flex; align-items: center; gap: 8px; }
+.group > .lbl { font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-faint); }
+
+.seg { display: flex; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: 8px; padding: 2px; gap: 2px; }
+.seg button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12.5px;
+  padding: 4px 11px;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.seg button:hover { color: var(--text); }
+.seg button[aria-pressed='true'] { background: var(--bg-raised); color: var(--text); box-shadow: var(--shadow); }
+.seg button .count { color: var(--text-faint); font-variant-numeric: tabular-nums; margin-left: 5px; }
+.seg button[aria-pressed='true'] .count { color: var(--text-dim); }
+
+input[type='range'] { accent-color: var(--accent); width: 108px; }
+.spacer { flex: 1 1 auto; }
+
+/* ---------- screen cards ---------- */
+
+.screens { display: flex; flex-direction: column; gap: 22px; margin-top: 26px; }
+
+.card { background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+.card > header { display: flex; align-items: baseline; gap: 11px; flex-wrap: wrap; padding: 15px 18px 13px; }
+.card h2 { margin: 0; font-size: 16.5px; font-weight: 600; letter-spacing: -0.01em; }
+.card .group-name { color: var(--text-faint); font-size: 13px; }
+.card .spec { font-family: var(--mono); font-size: 11.5px; color: var(--text-faint); margin-left: auto; }
+
+.badge {
+  font-size: 10.5px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  font-weight: 640;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+.badge.changed { color: var(--changed); }
+.badge.added { color: var(--added); }
+.badge.removed { color: var(--removed); }
+.badge.unchanged { color: var(--unchanged); }
+
+.note {
+  margin: 0 18px 14px;
+  padding: 10px 13px;
+  background: var(--bg-sunken);
+  border-left: 2px solid var(--border-strong);
+  border-radius: 0 6px 6px 0;
+  font-size: 13px;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+}
+
+.viewports { display: grid; gap: 1px; background: var(--border); border-top: 1px solid var(--border); align-items: start; }
+/* Desktop gets the wider column; a mobile baseline is capped by height in
+   any case (MAX_STAGE_HEIGHT) and would only pad the extra space. */
+.viewports.pair { grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr); }
+.viewport { background: var(--bg-raised); padding: 14px 18px 18px; min-width: 0; }
+.viewport > .vhead { display: flex; align-items: center; gap: 9px; margin-bottom: 11px; font-size: 12.5px; color: var(--text-dim); }
+.viewport .device { font-family: var(--mono); font-size: 11px; color: var(--text-faint); }
+.viewport .delta { margin-left: auto; font-variant-numeric: tabular-nums; font-size: 12px; }
+.viewport .delta.hot { color: var(--changed); }
+
+/* ---------- comparison stage ---------- */
+
+/*
+ * Every compare mode stacks its layers in this one element, sized by an
+ * aspect-ratio the collector read out of the PNG header. Reserving the box
+ * before any image decodes is what keeps a gallery of a dozen screens from
+ * reflowing line by line as they load.
+ */
+.stage {
+  position: relative;
+  width: 100%;
+  background: var(--stage-bg, var(--bg-sunken));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: default;
+}
+.stage img,
+.stage canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
+.stage.checker { --stage-bg: transparent; background-image: linear-gradient(45deg, #2a2f3a 25%, transparent 25%), linear-gradient(-45deg, #2a2f3a 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #2a2f3a 75%), linear-gradient(-45deg, transparent 75%, #2a2f3a 75%); background-size: 18px 18px; background-position: 0 0, 0 9px, 9px -9px, -9px 0; }
+
+/* Side-by-side is the only mode that is a grid rather than a stack. */
+.sbs { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.sbs figure { margin: 0; min-width: 0; }
+.sbs figcaption { font-size: 11px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--text-faint); margin-bottom: 6px; }
+.sbs .before figcaption { color: var(--removed); }
+.sbs .after figcaption { color: var(--added); }
+
+/* Slider: the "after" layer is clipped to the handle position. */
+.stage .clip { position: absolute; inset: 0; overflow: hidden; }
+.stage .handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 0.35);
+  pointer-events: none;
+}
+.stage .handle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 26px;
+  height: 26px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.45);
+}
+.stage.slider { cursor: ew-resize; }
+
+.empty-side {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 12.5px;
+  color: var(--text-faint);
+  background: repeating-linear-gradient(135deg, transparent 0 9px, color-mix(in srgb, var(--border) 60%, transparent) 9px 10px);
+}
+
+/* ---------- impact ---------- */
+
+.impact { margin-top: 44px; }
+.impact h2 { font-size: 18px; margin: 0 0 4px; letter-spacing: -0.01em; }
+.impact .sub { color: var(--text-dim); font-size: 13px; margin: 0 0 18px; }
+.impact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(310px, 1fr)); gap: 18px; }
+.panel { background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px 18px; }
+.panel h3 { margin: 0 0 13px; font-size: 12px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--text-faint); font-weight: 620; }
+
+.bars { display: flex; flex-direction: column; gap: 9px; }
+.bar { display: grid; grid-template-columns: 1fr auto; gap: 3px 10px; font-size: 13px; }
+.bar .name { color: var(--text); }
+.bar .val { color: var(--text-dim); font-variant-numeric: tabular-nums; font-size: 12px; }
+.bar .track { grid-column: 1 / -1; height: 5px; border-radius: 3px; background: var(--bg-sunken); overflow: hidden; }
+.bar .fill { height: 100%; border-radius: 3px; background: var(--accent); }
+
+.files {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 380px;
+  overflow-y: auto;
+  /* Fades the last row rather than slicing it. A hard cut mid-row reads as a
+     rendering bug; a fade reads as "there is more, scroll". */
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 26px), transparent);
+}
+/* One row per file, one line each. The filename leads because that is what
+   a reader scans for; the directory follows, dimmed, and is the part allowed
+   to truncate when the panel is narrow. Full path stays in the title. */
+.files li {
+  display: grid;
+  grid-template-columns: auto minmax(0, auto) minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  padding: 3px 0;
+}
+.files .dir,
+.files .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.files .dir { color: var(--text-faint); }
+.files .name { color: var(--text); }
+.files .churn { white-space: nowrap; font-variant-numeric: tabular-nums; }
+.panel .prefix { font-family: var(--mono); font-size: 11px; color: var(--text-faint); margin: -6px 0 11px; }
+.files .churn .add { color: var(--added); }
+.files .churn .del { color: var(--removed); }
+.files .st { width: 7px; height: 7px; border-radius: 2px; flex: none; align-self: center; }
+.files .st.added { background: var(--added); }
+.files .st.modified { background: var(--changed); }
+.files .st.deleted { background: var(--removed); }
+.files .st.renamed { background: var(--accent); }
+
+/* The uncovered-files panel spans the grid it follows and takes the warning
+   accent, because it is the one panel that is a prompt rather than a report. */
+.panel.gap { margin-top: 18px; border-left: 3px solid var(--changed); }
+.panel.gap .files { max-height: 260px; }
+
+.related { margin: 0 18px 16px; font-size: 12px; color: var(--text-dim); }
+.related summary { cursor: pointer; color: var(--text-faint); font-size: 11.5px; letter-spacing: 0.04em; text-transform: uppercase; }
+.related ul { list-style: none; margin: 9px 0 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
+.related li { font-family: var(--mono); font-size: 11.5px; }
+
+.hint { color: var(--text-faint); font-size: 11.5px; margin-top: 9px; }
+.nothing { padding: 46px 20px; text-align: center; color: var(--text-faint); }
+
+footer.meta { margin-top: 44px; padding-top: 18px; border-top: 1px solid var(--border); font-size: 11.5px; color: var(--text-faint); display: flex; flex-wrap: wrap; gap: 6px 18px; }
+
+@media (max-width: 760px) {
+  .wrap { padding: 0 16px 64px; }
+  .toolbar { margin: 22px -16px 0; padding: 11px 16px; }
+  .viewports.pair { grid-template-columns: 1fr; }
+  .sbs { grid-template-columns: 1fr; }
+}
+
+@media print {
+  .toolbar { position: static; backdrop-filter: none; }
+  .card { break-inside: avoid; }
+}

--- a/web/app/e2e/design-review/assets/report.css
+++ b/web/app/e2e/design-review/assets/report.css
@@ -223,9 +223,32 @@ input[type='range'] { accent-color: var(--accent); width: 108px; }
   border-radius: 8px;
   overflow: hidden;
   cursor: default;
+  /*
+   * Both of these keep a drag alive, and without them the comparison slider
+   * moves once and then freezes.
+   *
+   * A press lands on the screenshot, and an <img> is natively draggable — so
+   * the moment the pointer moves, Chromium starts a drag-and-drop of the
+   * image, fires `pointercancel`, and releases the pointer capture the
+   * handler depends on. `touch-action` is the same failure on a touch
+   * screen: the browser claims the gesture as a pan and cancels the stream.
+   * Selection is disabled for the same reason a text drag would interfere.
+   */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
 }
 .stage img,
-.stage canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
+.stage canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  -webkit-user-drag: none;
+  /* The stage owns the gesture; layers must never be the pointer target. */
+  pointer-events: none;
+}
 .stage.checker { --stage-bg: transparent; background-image: linear-gradient(45deg, #2a2f3a 25%, transparent 25%), linear-gradient(-45deg, #2a2f3a 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #2a2f3a 75%), linear-gradient(-45deg, transparent 75%, #2a2f3a 75%); background-size: 18px 18px; background-position: 0 0, 0 9px, 9px -9px, -9px 0; }
 
 /* Side-by-side is the only mode that is a grid rather than a stack. */
@@ -235,7 +258,17 @@ input[type='range'] { accent-color: var(--accent); width: 108px; }
 .sbs .before figcaption { color: var(--removed); }
 .sbs .after figcaption { color: var(--added); }
 
-/* Slider: the "after" layer is clipped to the handle position. */
+/*
+ * Slider: the "after" layer is revealed up to the handle position.
+ *
+ * The reveal is a `clip-path` on a box that always fills the stage, never a
+ * width on a box that shrinks. Shrinking the box also shrinks the image
+ * inside it — its `width` is a percentage of its positioned parent — so the
+ * whole "after" screenshot squeezed into the revealed strip instead of being
+ * cut off at the handle, and the two sides no longer lined up at all. The
+ * clip path leaves the layer laid out exactly as its "before" counterpart
+ * and hides part of it, which is what a comparison slider has to do.
+ */
 .stage .clip { position: absolute; inset: 0; overflow: hidden; }
 .stage .handle {
   position: absolute;

--- a/web/app/e2e/design-review/assets/report.js
+++ b/web/app/e2e/design-review/assets/report.js
@@ -25,12 +25,17 @@
     filter: data.summary.changed + data.summary.added + data.summary.removed > 0 ? 'touched' : 'all',
     viewport: 'both',
     mode: 'slider',
-    // 8% of full channel range. Low enough to catch a genuine one-shade
-    // colour change, high enough that subpixel antialiasing along a text
-    // edge does not light up the whole screen.
+    // Must equal DEFAULT_THRESHOLD in lib/diff.mjs. The generator computes
+    // each screen's changed-pixel figure in Node so a PR comment can quote
+    // it; this page recomputes only when the slider moves. Starting from a
+    // different value would make the page silently disagree with the number
+    // that brought the reader here.
     threshold: 0.08,
     checker: false,
   };
+
+  /** Mirrors DEFAULT_THRESHOLD in lib/diff.mjs — see `state.threshold`. */
+  const DEFAULT_THRESHOLD = 0.08;
 
   /** Stage controllers, so a mode change updates in place instead of re-rendering. */
   let stages = [];
@@ -218,9 +223,16 @@
     );
 
     const sensitivity = el('input', { type: 'range', min: '0', max: '40', value: String(state.threshold * 100), title: 'Diff sensitivity' });
+    // Debounced: `input` fires for every pixel of a drag, and each one would
+    // otherwise re-compare every visible screen at full resolution. A short
+    // delay still feels live while collapsing a whole gesture into one pass.
+    let pending;
     sensitivity.addEventListener('input', () => {
       state.threshold = Number(sensitivity.value) / 100;
-      for (const stage of stages) stage.setThreshold(state.threshold);
+      clearTimeout(pending);
+      pending = setTimeout(() => {
+        for (const stage of stages) stage.setThreshold(state.threshold);
+      }, 120);
     });
 
     const checkerSeg = segmented(
@@ -524,6 +536,12 @@
       }
     }
 
+    /** Shows a changed-pixel figure, flagging it when it is not the default. */
+    function showDelta(ratio, custom) {
+      deltaNode.textContent = `${pct(ratio)} of pixels differ${custom ? ' at this sensitivity' : ''}`;
+      deltaNode.classList.toggle('hot', ratio > 0.005);
+    }
+
     /** Repaints the difference overlay and the header's changed-pixel figure. */
     async function refreshDiff() {
       if (!pixels) {
@@ -536,8 +554,7 @@
       }
       const result = computeDiff(pixels, threshold);
       canvas.getContext('2d').putImageData(result.overlay, 0, 0);
-      deltaNode.textContent = `${pct(result.ratio)} of pixels differ`;
-      deltaNode.classList.toggle('hot', result.ratio > 0.005);
+      showDelta(result.ratio, threshold !== DEFAULT_THRESHOLD);
     }
 
     function applyMode() {
@@ -571,20 +588,13 @@
       if (stage.hasPointerCapture?.(event.pointerId)) track(event);
     });
 
-    // The headline "x% of pixels differ" is what most readers act on, so it
-    // is computed as soon as the card is near the viewport rather than only
-    // when someone switches to difference mode. Deferred via the observer
-    // because doing it for every screen on load would decode and compare
-    // every baseline in the report before the first paint.
-    const observer = new IntersectionObserver(
-      entries => {
-        if (!entries.some(entry => entry.isIntersecting)) return;
-        observer.disconnect();
-        void refreshDiff();
-      },
-      { rootMargin: '400px' },
-    );
-    observer.observe(stage);
+    // The headline figure comes from the model, computed by the generator
+    // with the same rule this page uses. Canvas work is therefore deferred
+    // until someone actually asks for the overlay or moves the slider —
+    // which is what keeps a report of a dozen screens from decoding and
+    // comparing every baseline before its first paint.
+    if (variant.diff) showDelta(variant.diff.ratio, false);
+    else deltaNode.textContent = 'changed';
 
     applyMode();
 
@@ -595,7 +605,12 @@
       },
       setThreshold(next) {
         threshold = next;
-        pixels && void refreshDiff();
+        // Returning to the default is answered from the model rather than by
+        // decoding images to re-derive a number that shipped with the page.
+        // Any other value is an explicit request and gets a real comparison,
+        // even on a stage that has never been compared before.
+        if (next === DEFAULT_THRESHOLD && variant.diff && !pixels) showDelta(variant.diff.ratio, false);
+        else void refreshDiff();
       },
       setChecker(on) {
         stage.classList.toggle('checker', on);

--- a/web/app/e2e/design-review/assets/report.js
+++ b/web/app/e2e/design-review/assets/report.js
@@ -423,19 +423,26 @@
    * translucent in a region is a real change that an RGB-only test over
    * premultiplied-looking data can miss entirely.
    */
-  function computeDiff(pixels, threshold) {
+  function computeDiff(pixels, threshold, { withOverlay = true } = {}) {
     const { width, height, before, after } = pixels;
     const cutoff = Math.round(threshold * 255);
-    const overlay = new ImageData(width, height);
     const a = before.data;
     const b = after.data;
-    const out = overlay.data;
+    // Only difference mode paints. Every other mode wants the count and
+    // nothing else, and building the image anyway meant allocating a
+    // full-resolution ImageData and writing four bytes per pixel — around
+    // 3.7MB for one desktop screen — to immediately discard it, on every
+    // variant, on every nudge of the sensitivity control.
+    const overlay = withOverlay ? new ImageData(width, height) : null;
+    const out = overlay?.data;
     let changed = 0;
 
     for (let i = 0; i < a.length; i += 4) {
       const delta = Math.max(Math.abs(a[i] - b[i]), Math.abs(a[i + 1] - b[i + 1]), Math.abs(a[i + 2] - b[i + 2]), Math.abs(a[i + 3] - b[i + 3]));
-      if (delta > cutoff) {
-        changed++;
+      const differs = delta > cutoff;
+      if (differs) changed++;
+      if (!out) continue;
+      if (differs) {
         // Solid magenta: the one hue that appears in almost no real UI, so
         // an overlay pixel is never mistaken for content underneath it.
         out[i] = 255;
@@ -562,8 +569,11 @@
           return;
         }
       }
-      const result = computeDiff(pixels, threshold);
-      canvas.getContext('2d').putImageData(result.overlay, 0, 0);
+      // `applyMode` calls back into here whenever difference mode is
+      // selected, so a stage compared without an overlay still gets one the
+      // moment it is actually going to be shown.
+      const result = computeDiff(pixels, threshold, { withOverlay: mode === 'diff' });
+      if (result.overlay) canvas.getContext('2d').putImageData(result.overlay, 0, 0);
       showDelta(result.ratio, threshold !== DEFAULT_THRESHOLD);
     }
 

--- a/web/app/e2e/design-review/assets/report.js
+++ b/web/app/e2e/design-review/assets/report.js
@@ -547,7 +547,12 @@
       if (!pixels) {
         try {
           pixels = await readPixels();
-        } catch {
+        } catch (error) {
+          // Surfaced in the UI *and* logged. The UI text is all a reader
+          // needs, but a malformed baseline is a repository problem someone
+          // will have to go and look at, and "diff unavailable" on its own
+          // does not say which of eleven screens is the broken one.
+          console.warn(`[design review] could not compare ${variant.path}:`, error);
           deltaNode.textContent = 'diff unavailable';
           return;
         }

--- a/web/app/e2e/design-review/assets/report.js
+++ b/web/app/e2e/design-review/assets/report.js
@@ -358,7 +358,10 @@
   }
 
   function imageLayer(image, boxWidth, boxHeight, extraClass) {
-    const node = el('img', { src: data.assets[image.asset], alt: '', loading: 'lazy', decoding: 'async' });
+    // `draggable` as well as the CSS rule: the attribute is what actually
+    // stops a native image drag in Firefox, where `-webkit-user-drag` does
+    // nothing, and a started image drag cancels the comparison gesture.
+    const node = el('img', { src: data.assets[image.asset], alt: '', loading: 'lazy', decoding: 'async', draggable: false });
     if (extraClass) node.className = extraClass;
     placeLayer(node, image, boxWidth, boxHeight);
     return node;
@@ -525,14 +528,16 @@
     const readPixels = pixelReader(variant);
 
     function applyPosition() {
+      handle.style.left = `${position * 100}%`;
       if (mode === 'slider') {
-        clip.style.width = `${position * 100}%`;
+        // Reveal by clipping, not by resizing. The layer keeps the full
+        // stage box so it stays pixel-aligned with the "before" underneath;
+        // only how much of it is painted changes.
+        clip.style.clipPath = `inset(0 ${(1 - position) * 100}% 0 0)`;
         clip.style.opacity = '1';
-        handle.style.left = `${position * 100}%`;
       } else if (mode === 'onion') {
-        clip.style.width = '100%';
+        clip.style.clipPath = 'none';
         clip.style.opacity = String(position);
-        handle.style.left = `${position * 100}%`;
       }
     }
 
@@ -584,14 +589,30 @@
       position = Math.min(1, Math.max(0, (event.clientX - box.left) / box.width));
       applyPosition();
     };
+    // An explicit flag rather than asking `hasPointerCapture` on every move.
+    // Capture answers "does this element own the pointer", which is not the
+    // same question as "is the user dragging" — the browser can take the
+    // pointer away mid-gesture (see `pointercancel` below), and reading
+    // capture state left the handler silently dead with no way to recover.
+    let dragging = false;
+    const endDrag = () => {
+      dragging = false;
+    };
+
     stage.addEventListener('pointerdown', event => {
       if (mode !== 'slider' && mode !== 'onion') return;
-      stage.setPointerCapture(event.pointerId);
+      dragging = true;
+      // Capture is still requested so a drag continuing outside the stage
+      // keeps tracking; it is no longer what the move handler trusts.
+      stage.setPointerCapture?.(event.pointerId);
       track(event);
     });
     stage.addEventListener('pointermove', event => {
-      if (stage.hasPointerCapture?.(event.pointerId)) track(event);
+      if (dragging) track(event);
     });
+    for (const ending of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+      stage.addEventListener(ending, endDrag);
+    }
 
     // The headline figure comes from the model, computed by the generator
     // with the same rule this page uses. Canvas work is therefore deferred

--- a/web/app/e2e/design-review/assets/report.js
+++ b/web/app/e2e/design-review/assets/report.js
@@ -1,0 +1,775 @@
+/*
+ * Design review report — behaviour.
+ *
+ * Plain DOM, no framework, no build step. The whole page is one file that has
+ * to open from a Downloads folder in five years, so the dependency count is
+ * the feature.
+ *
+ * The one genuinely interesting thing in here is that pixel comparison is
+ * done in the browser (see `computeDiff`) rather than baked into the report
+ * by the generator. Diffing in Node would have meant shipping a PNG decoder
+ * and producing a single fixed diff image; doing it on a canvas over images
+ * the page has already loaded gives the slider, the onion-skin and an
+ * adjustable sensitivity for free, and lets a reviewer answer "is that a real
+ * change or an antialiasing seam?" by dragging a control instead of by
+ * re-running anything.
+ */
+
+(() => {
+  'use strict';
+
+  const data = JSON.parse(document.getElementById('design-data').textContent);
+  const root = document.getElementById('app');
+
+  const state = {
+    filter: data.summary.changed + data.summary.added + data.summary.removed > 0 ? 'touched' : 'all',
+    viewport: 'both',
+    mode: 'slider',
+    // 8% of full channel range. Low enough to catch a genuine one-shade
+    // colour change, high enough that subpixel antialiasing along a text
+    // edge does not light up the whole screen.
+    threshold: 0.08,
+    checker: false,
+  };
+
+  /** Stage controllers, so a mode change updates in place instead of re-rendering. */
+  let stages = [];
+
+  // ---------------------------------------------------------------- helpers
+
+  function el(tag, props = {}, ...children) {
+    const node = document.createElement(tag);
+    for (const [key, value] of Object.entries(props)) {
+      // `aria-*`, `data-*` and `role` are attributes, not properties.
+      // Object.assign would hang them off the element as inert expandos and
+      // the accessibility tree would never see them.
+      if (key.includes('-') || key === 'role') node.setAttribute(key, value);
+      else node[key] = value;
+    }
+    for (const child of children.flat()) {
+      if (child == null || child === false) continue;
+      node.append(child.nodeType ? child : document.createTextNode(String(child)));
+    }
+    return node;
+  }
+
+  const pct = value => `${(value * 100).toFixed(value < 0.01 && value > 0 ? 2 : 1)}%`;
+  const shortSha = sha => (sha ? sha.slice(0, 8) : '—');
+
+  /** `a/b/c.ts` → `['a/b/', 'c.ts']`, for dimming the directory in file lists. */
+  function splitPath(filePath) {
+    const cut = filePath.lastIndexOf('/');
+    return cut === -1 ? ['', filePath] : [filePath.slice(0, cut + 1), filePath.slice(cut + 1)];
+  }
+
+  /**
+   * Longest directory prefix shared by every path given.
+   *
+   * Hoisted out of the rows and shown once above them. In this repo every
+   * frontend path starts `web/app/src/app/…`, which is thirteen characters
+   * of nothing repeated on every line — and it is precisely the part that
+   * pushes the filename, the part a reader is actually scanning for, off
+   * the end of the row.
+   */
+  function commonPrefix(paths) {
+    if (paths.length < 2) return '';
+    const segments = paths[0].split('/').slice(0, -1);
+    let shared = segments.length;
+    for (const candidate of paths.slice(1)) {
+      const parts = candidate.split('/').slice(0, -1);
+      let index = 0;
+      while (index < shared && index < parts.length && parts[index] === segments[index]) index++;
+      shared = index;
+      if (!shared) return '';
+    }
+    return shared ? `${segments.slice(0, shared).join('/')}/` : '';
+  }
+
+  const STATUS_LABEL = { changed: 'Changed', added: 'New', removed: 'Removed', unchanged: 'Unchanged' };
+
+  /** Screens matching the current filter. */
+  function visibleScreens() {
+    return data.screens.filter(screen => {
+      if (state.filter === 'all') return true;
+      if (state.filter === 'touched') return screen.status !== 'unchanged';
+      return screen.status === state.filter;
+    });
+  }
+
+  /** Variants of a screen matching the current viewport filter. */
+  function visibleVariants(screen) {
+    return screen.variants.filter(variant => state.viewport === 'both' || variant.form === state.viewport);
+  }
+
+  // ------------------------------------------------------------- masthead
+
+  function renderMasthead() {
+    const heading = data.pr
+      ? el('h1', {}, el('a', { href: data.pr.url, target: '_blank', rel: 'noopener' }, `#${data.pr.number} ${data.pr.title}`))
+      : el('h1', {}, data.head.branch || data.head.ref);
+
+    const refs = el(
+      'div',
+      { className: 'refline' },
+      el('span', {}, data.base.ref),
+      el('span', { className: 'sha' }, shortSha(data.base.sha)),
+      el('span', { className: 'arrow' }, '→'),
+      el('span', {}, data.head.worktree ? 'working tree' : data.head.ref),
+      el('span', { className: 'sha' }, shortSha(data.head.sha)),
+      data.head.subject ? el('span', {}, `· ${data.head.subject}`) : null,
+      data.pr?.author ? el('span', {}, `· @${data.pr.author}`) : null,
+    );
+
+    const summary = data.summary;
+    const tiles = el(
+      'div',
+      { className: 'tiles' },
+      tile('changed', summary.changed, 'screens changed'),
+      summary.added ? tile('added', summary.added, 'new screens') : null,
+      summary.removed ? tile('removed', summary.removed, 'screens removed') : null,
+      tile('unchanged', summary.unchanged, 'unchanged'),
+      tile('surface', pct(data.impact.designShare), 'of frontend files are design surface'),
+      tile('', data.impact.frontendFileCount, 'frontend files touched'),
+    );
+
+    return el(
+      'header',
+      { className: 'masthead' },
+      el('p', { className: 'eyebrow' }, 'Visual design review'),
+      heading,
+      refs,
+      tiles,
+    );
+  }
+
+  function tile(kind, value, label) {
+    return el('div', { className: `tile ${kind}` }, el('div', { className: 'n' }, value), el('div', { className: 'k' }, label));
+  }
+
+  // -------------------------------------------------------------- toolbar
+
+  function segmented(label, options, current, onPick) {
+    const seg = el('div', { className: 'seg', role: 'group', 'aria-label': label });
+    for (const option of options) {
+      const button = el(
+        'button',
+        { type: 'button' },
+        option.label,
+        option.count != null ? el('span', { className: 'count' }, option.count) : null,
+      );
+      button.setAttribute('aria-pressed', String(option.id === current()));
+      button.addEventListener('click', () => {
+        onPick(option.id);
+        for (const sibling of seg.children) sibling.setAttribute('aria-pressed', String(sibling === button));
+      });
+      seg.append(button);
+    }
+    return el('div', { className: 'group' }, el('span', { className: 'lbl' }, label), seg);
+  }
+
+  function countBy(predicate) {
+    return data.screens.filter(predicate).length;
+  }
+
+  function renderToolbar() {
+    const touched = countBy(screen => screen.status !== 'unchanged');
+
+    const filters = segmented(
+      'Show',
+      [
+        { id: 'touched', label: 'Changed', count: touched },
+        { id: 'all', label: 'All', count: data.screens.length },
+        { id: 'unchanged', label: 'Unchanged', count: countBy(screen => screen.status === 'unchanged') },
+      ],
+      () => state.filter,
+      value => {
+        state.filter = value;
+        renderScreens();
+      },
+    );
+
+    const viewports = segmented(
+      'Viewport',
+      [
+        { id: 'both', label: 'Both' },
+        { id: 'desktop', label: 'Desktop' },
+        { id: 'mobile', label: 'Mobile' },
+      ],
+      () => state.viewport,
+      value => {
+        state.viewport = value;
+        renderScreens();
+      },
+    );
+
+    const modes = segmented(
+      'Compare',
+      [
+        { id: 'slider', label: 'Slider' },
+        { id: 'sbs', label: 'Side by side' },
+        { id: 'onion', label: 'Onion' },
+        { id: 'diff', label: 'Difference' },
+      ],
+      () => state.mode,
+      value => {
+        state.mode = value;
+        for (const stage of stages) stage.setMode(value);
+      },
+    );
+
+    const sensitivity = el('input', { type: 'range', min: '0', max: '40', value: String(state.threshold * 100), title: 'Diff sensitivity' });
+    sensitivity.addEventListener('input', () => {
+      state.threshold = Number(sensitivity.value) / 100;
+      for (const stage of stages) stage.setThreshold(state.threshold);
+    });
+
+    const checkerSeg = segmented(
+      'Backdrop',
+      [
+        { id: false, label: 'Plain' },
+        { id: true, label: 'Checker' },
+      ],
+      () => state.checker,
+      value => {
+        state.checker = value;
+        for (const stage of stages) stage.setChecker(value);
+      },
+    );
+
+    const theme = segmented(
+      'Theme',
+      [
+        { id: 'dark', label: 'Dark' },
+        { id: 'light', label: 'Light' },
+      ],
+      () => document.documentElement.dataset.theme,
+      value => {
+        document.documentElement.dataset.theme = value;
+      },
+    );
+
+    return el(
+      'div',
+      { className: 'toolbar' },
+      filters,
+      viewports,
+      modes,
+      el('div', { className: 'group' }, el('span', { className: 'lbl' }, 'Sensitivity'), sensitivity),
+      checkerSeg,
+      el('div', { className: 'spacer' }),
+      theme,
+    );
+  }
+
+  // --------------------------------------------------------------- screens
+
+  function renderScreens() {
+    stages = [];
+    const host = document.getElementById('screens');
+    host.textContent = '';
+    const screens = visibleScreens();
+    if (!screens.length) {
+      host.append(el('div', { className: 'nothing' }, 'No screens match this filter.'));
+      return;
+    }
+    for (const screen of screens) host.append(renderCard(screen));
+  }
+
+  function renderCard(screen) {
+    const variants = visibleVariants(screen);
+    const header = el(
+      'header',
+      {},
+      el('h2', {}, screen.title),
+      screen.group ? el('span', { className: 'group-name' }, screen.group) : null,
+      el('span', { className: `badge ${screen.status}` }, STATUS_LABEL[screen.status]),
+      el('span', { className: 'spec' }, splitPath(screen.specPath)[1]),
+    );
+
+    const viewports = el('div', { className: `viewports${variants.length > 1 ? ' pair' : ''}` });
+    for (const variant of variants) viewports.append(renderViewport(screen, variant));
+
+    return el(
+      'section',
+      { className: 'card' },
+      header,
+      screen.note ? el('div', { className: 'note' }, screen.note) : null,
+      screen.related.length ? renderRelated(screen) : null,
+      variants.length ? viewports : el('div', { className: 'nothing' }, 'No baseline for this viewport.'),
+    );
+  }
+
+  function renderRelated(screen) {
+    return el(
+      'details',
+      { className: 'related' },
+      el('summary', {}, `${screen.related.length} changed file${screen.related.length === 1 ? '' : 's'} mention this screen`),
+      el('ul', {}, screen.related.map(filePath => el('li', {}, el('span', { className: 'dir' }, splitPath(filePath)[0]), splitPath(filePath)[1]))),
+      el('p', { className: 'hint' }, 'Matched by name, not by imports — a shared component that renders this screen may not be listed.'),
+    );
+  }
+
+  function renderViewport(screen, variant) {
+    const delta = el('span', { className: 'delta' }, variant.status === 'unchanged' ? 'identical' : '');
+    const head = el(
+      'div',
+      { className: 'vhead' },
+      el('strong', {}, variant.label),
+      variant.device ? el('span', { className: 'device' }, variant.device) : null,
+      el('span', { className: `badge ${variant.status}` }, STATUS_LABEL[variant.status]),
+      delta,
+    );
+
+    const holder = el('div', {});
+    const controller = mountStage(holder, variant, delta);
+    stages.push(controller);
+    return el('div', { className: 'viewport', 'data-form': variant.form }, head, holder);
+  }
+
+  // ------------------------------------------------------- comparison stage
+
+  /**
+   * Positions one image inside a box sized to the *larger* of the two sides,
+   * anchored top-left at its true scale.
+   *
+   * Stretching both images to fill the box would be the easy thing and the
+   * wrong thing: when a change makes a page taller, stretching hides exactly
+   * that — the two would overlay perfectly and the diff would light up every
+   * element below the insertion point as if it had been restyled. Anchored
+   * top-left, a height change reads as what it is, with the shorter side
+   * ending early against the backdrop.
+   */
+  function placeLayer(node, image, boxWidth, boxHeight) {
+    node.style.inset = '0 auto auto 0';
+    node.style.width = `${((image.width ?? boxWidth) / boxWidth) * 100}%`;
+    node.style.height = `${((image.height ?? boxHeight) / boxHeight) * 100}%`;
+  }
+
+  function imageLayer(image, boxWidth, boxHeight, extraClass) {
+    const node = el('img', { src: data.assets[image.asset], alt: '', loading: 'lazy', decoding: 'async' });
+    if (extraClass) node.className = extraClass;
+    placeLayer(node, image, boxWidth, boxHeight);
+    return node;
+  }
+
+  /** A hatched placeholder for the side of a comparison that does not exist. */
+  function missingLayer(text) {
+    return el('div', { className: 'empty-side' }, text);
+  }
+
+  /**
+   * Decodes both sides into pixel buffers once, on a canvas sized to the
+   * union of the two.
+   *
+   * Both are drawn at natural size into the top-left of a common box, so a
+   * page that grew taller compares like-for-like down to where the shorter
+   * side ends, and the region only one side covers is counted as changed —
+   * which is true, and is usually the most important part of the change.
+   */
+  function pixelReader(variant) {
+    let pending = null;
+    return () => {
+      if (pending) return pending;
+      pending = (async () => {
+        const boxWidth = Math.max(variant.before?.width ?? 0, variant.after?.width ?? 0);
+        const boxHeight = Math.max(variant.before?.height ?? 0, variant.after?.height ?? 0);
+        if (!boxWidth || !boxHeight) throw new Error('unknown image dimensions');
+
+        const read = async image => {
+          const canvas = document.createElement('canvas');
+          canvas.width = boxWidth;
+          canvas.height = boxHeight;
+          const context = canvas.getContext('2d', { willReadFrequently: true });
+          if (image) {
+            const bitmap = new Image();
+            bitmap.src = data.assets[image.asset];
+            await bitmap.decode();
+            context.drawImage(bitmap, 0, 0);
+          }
+          return context.getImageData(0, 0, boxWidth, boxHeight);
+        };
+
+        return { width: boxWidth, height: boxHeight, before: await read(variant.before), after: await read(variant.after) };
+      })();
+      return pending;
+    };
+  }
+
+  /**
+   * Per-pixel comparison at a given sensitivity, returning both the headline
+   * ratio and an overlay to paint.
+   *
+   * The test is max-per-channel rather than a Euclidean distance in RGB: a
+   * designer's "did this colour change" question is about the largest shift
+   * in any one channel, and a distance metric lets a big change in one
+   * channel hide under small ones in the others.
+   *
+   * Alpha is compared too, because a screenshot that went from opaque to
+   * translucent in a region is a real change that an RGB-only test over
+   * premultiplied-looking data can miss entirely.
+   */
+  function computeDiff(pixels, threshold) {
+    const { width, height, before, after } = pixels;
+    const cutoff = Math.round(threshold * 255);
+    const overlay = new ImageData(width, height);
+    const a = before.data;
+    const b = after.data;
+    const out = overlay.data;
+    let changed = 0;
+
+    for (let i = 0; i < a.length; i += 4) {
+      const delta = Math.max(Math.abs(a[i] - b[i]), Math.abs(a[i + 1] - b[i + 1]), Math.abs(a[i + 2] - b[i + 2]), Math.abs(a[i + 3] - b[i + 3]));
+      if (delta > cutoff) {
+        changed++;
+        // Solid magenta: the one hue that appears in almost no real UI, so
+        // an overlay pixel is never mistaken for content underneath it.
+        out[i] = 255;
+        out[i + 1] = 32;
+        out[i + 2] = 168;
+        out[i + 3] = 255;
+      } else {
+        // Unchanged regions are kept as a dim greyscale of the "after" image
+        // so the highlighted pixels stay locatable — a diff on a black field
+        // tells you how much changed but not where.
+        const grey = (b[i] * 0.299 + b[i + 1] * 0.587 + b[i + 2] * 0.114) * 0.32;
+        out[i] = out[i + 1] = out[i + 2] = grey;
+        out[i + 3] = 255;
+      }
+    }
+
+    return { ratio: changed / (width * height), changed, total: width * height, overlay };
+  }
+
+  /**
+   * Builds one comparison and returns the handles the toolbar drives it with.
+   *
+   * Modes share a single set of layers rather than re-rendering, so dragging
+   * the slider, flipping to onion and back, and nudging sensitivity all keep
+   * their positions — which is the entire way this gets used in practice
+   * (park the slider on the bit you care about, then flip modes).
+   */
+  /**
+   * Tallest a screenshot is allowed to render at, in CSS pixels.
+   *
+   * This is what makes a phone look like a phone. Left to fill its grid
+   * column, a 412x915 mobile baseline renders *larger* than a 1280x720
+   * desktop one beside it — the reader's first impression of the pair is
+   * then exactly backwards. Capping height instead of width sizes both by
+   * the one dimension they share, so the desktop shot stays wide and the
+   * mobile one stays narrow, in the proportion the devices actually have.
+   */
+  const MAX_STAGE_HEIGHT = 620;
+
+  /** Sizes a stage from its image's true aspect ratio, under the height cap. */
+  function sizeStage(node, boxWidth, boxHeight) {
+    node.style.aspectRatio = `${boxWidth} / ${boxHeight}`;
+    node.style.maxWidth = `${Math.round((MAX_STAGE_HEIGHT * boxWidth) / boxHeight)}px`;
+  }
+
+  function mountStage(holder, variant, deltaNode) {
+    const boxWidth = Math.max(variant.before?.width ?? 0, variant.after?.width ?? 0) || 1;
+    const boxHeight = Math.max(variant.before?.height ?? 0, variant.after?.height ?? 0) || 1;
+    const comparable = Boolean(variant.before && variant.after && variant.status !== 'unchanged');
+
+    const stage = el('div', { className: 'stage' });
+    sizeStage(stage, boxWidth, boxHeight);
+
+    // An unchanged or one-sided screen has nothing to compare; it renders as
+    // a plain screenshot and ignores the compare controls entirely rather
+    // than offering a slider that does nothing.
+    if (!comparable) {
+      const single = variant.after ?? variant.before;
+      stage.append(single ? imageLayer(single, boxWidth, boxHeight) : missingLayer('no baseline'));
+      holder.append(stage);
+      return { setMode() {}, setThreshold() {}, setChecker: on => stage.classList.toggle('checker', on) };
+    }
+
+    const beforeLayer = imageLayer(variant.before, boxWidth, boxHeight);
+    const clip = el('div', { className: 'clip' });
+    const afterLayer = imageLayer(variant.after, boxWidth, boxHeight);
+    clip.append(afterLayer);
+    const handle = el('div', { className: 'handle' });
+    const canvas = el('canvas', {});
+    canvas.width = boxWidth;
+    canvas.height = boxHeight;
+    canvas.hidden = true;
+    stage.append(beforeLayer, clip, handle, canvas);
+
+    // Side-by-side is a different box shape, so it gets its own subtree that
+    // is swapped in wholesale rather than being coaxed out of the stack.
+    const sideBySide = el(
+      'div',
+      { className: 'sbs' },
+      el('figure', { className: 'before' }, el('figcaption', {}, 'Before'), sideStage(variant.before, boxWidth, boxHeight, 'no before')),
+      el('figure', { className: 'after' }, el('figcaption', {}, 'After'), sideStage(variant.after, boxWidth, boxHeight, 'no after')),
+    );
+    sideBySide.hidden = true;
+    holder.append(stage, sideBySide);
+
+    let position = 0.5;
+    let mode = state.mode;
+    let threshold = state.threshold;
+    let pixels = null;
+    const readPixels = pixelReader(variant);
+
+    function applyPosition() {
+      if (mode === 'slider') {
+        clip.style.width = `${position * 100}%`;
+        clip.style.opacity = '1';
+        handle.style.left = `${position * 100}%`;
+      } else if (mode === 'onion') {
+        clip.style.width = '100%';
+        clip.style.opacity = String(position);
+        handle.style.left = `${position * 100}%`;
+      }
+    }
+
+    /** Repaints the difference overlay and the header's changed-pixel figure. */
+    async function refreshDiff() {
+      if (!pixels) {
+        try {
+          pixels = await readPixels();
+        } catch {
+          deltaNode.textContent = 'diff unavailable';
+          return;
+        }
+      }
+      const result = computeDiff(pixels, threshold);
+      canvas.getContext('2d').putImageData(result.overlay, 0, 0);
+      deltaNode.textContent = `${pct(result.ratio)} of pixels differ`;
+      deltaNode.classList.toggle('hot', result.ratio > 0.005);
+    }
+
+    function applyMode() {
+      const showing = mode === 'sbs';
+      sideBySide.hidden = !showing;
+      stage.hidden = showing;
+      const diffing = mode === 'diff';
+      canvas.hidden = !diffing;
+      clip.hidden = diffing;
+      beforeLayer.hidden = diffing;
+      handle.hidden = diffing;
+      stage.classList.toggle('slider', mode === 'slider' || mode === 'onion');
+      applyPosition();
+      if (diffing) void refreshDiff();
+    }
+
+    // Dragging anywhere on the stage moves the comparison point — no separate
+    // handle to hit. In onion mode the same gesture cross-fades, so the
+    // muscle memory is the same in both.
+    const track = event => {
+      const box = stage.getBoundingClientRect();
+      position = Math.min(1, Math.max(0, (event.clientX - box.left) / box.width));
+      applyPosition();
+    };
+    stage.addEventListener('pointerdown', event => {
+      if (mode !== 'slider' && mode !== 'onion') return;
+      stage.setPointerCapture(event.pointerId);
+      track(event);
+    });
+    stage.addEventListener('pointermove', event => {
+      if (stage.hasPointerCapture?.(event.pointerId)) track(event);
+    });
+
+    // The headline "x% of pixels differ" is what most readers act on, so it
+    // is computed as soon as the card is near the viewport rather than only
+    // when someone switches to difference mode. Deferred via the observer
+    // because doing it for every screen on load would decode and compare
+    // every baseline in the report before the first paint.
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries.some(entry => entry.isIntersecting)) return;
+        observer.disconnect();
+        void refreshDiff();
+      },
+      { rootMargin: '400px' },
+    );
+    observer.observe(stage);
+
+    applyMode();
+
+    return {
+      setMode(next) {
+        mode = next;
+        applyMode();
+      },
+      setThreshold(next) {
+        threshold = next;
+        pixels && void refreshDiff();
+      },
+      setChecker(on) {
+        stage.classList.toggle('checker', on);
+        for (const node of sideBySide.querySelectorAll('.stage')) node.classList.toggle('checker', on);
+      },
+    };
+  }
+
+  /** One half of the side-by-side view, or a hatched panel if that side is absent. */
+  function sideStage(image, boxWidth, boxHeight, missingText) {
+    const node = el('div', { className: 'stage' });
+    sizeStage(node, boxWidth, boxHeight);
+    node.append(image ? imageLayer(image, boxWidth, boxHeight) : missingLayer(missingText));
+    return node;
+  }
+
+  // ---------------------------------------------------------------- impact
+
+  /**
+   * A horizontal bar, scaled against the largest value in its own group.
+   *
+   * Relative rather than absolute scaling because these groups measure
+   * different things — file counts next to line churn — and the only
+   * comparison that means anything is within a group.
+   */
+  function bar(name, value, max, label) {
+    return el(
+      'div',
+      { className: 'bar' },
+      el('span', { className: 'name' }, name),
+      el('span', { className: 'val' }, label),
+      el('div', { className: 'track' }, Object.assign(el('div', { className: 'fill' }), { style: `width: ${max ? (value / max) * 100 : 0}%` })),
+    );
+  }
+
+  function renderImpact() {
+    const { byCategory, byArea, files } = data.impact;
+
+    const categoryMax = Math.max(1, ...byCategory.map(entry => entry.count));
+    const categories = el(
+      'div',
+      { className: 'panel' },
+      el('h3', {}, 'What changed'),
+      el(
+        'div',
+        { className: 'bars' },
+        byCategory.map(entry =>
+          bar(entry.label, entry.count, categoryMax, `${entry.count} file${entry.count === 1 ? '' : 's'}${entry.added + entry.deleted ? ` · ${entry.added + entry.deleted} lines` : ''}`),
+        ),
+      ),
+    );
+
+    const areaMax = Math.max(1, ...byArea.map(entry => entry.churn));
+    const areas = el(
+      'div',
+      { className: 'panel' },
+      el('h3', {}, 'Feature areas touched'),
+      byArea.length
+        ? el(
+            'div',
+            { className: 'bars' },
+            byArea.map(entry => bar(entry.area, entry.churn, areaMax, `${entry.churn} lines · ${pct(entry.designWeight)} surface`)),
+          )
+        : el('p', { className: 'hint' }, 'No frontend source files changed.'),
+      el('p', { className: 'hint' }, '“Surface” is the share of an area’s changed files that are templates, styles or assets rather than logic.'),
+    );
+
+    // The file list is limited to what a designer can act on. A PR that also
+    // rewrites a Go handler is not more interesting for listing the handler
+    // here; it is less readable.
+    const designFiles = files.filter(file => ['template', 'style', 'asset', 'component', 'baseline'].includes(file.category));
+    const prefix = commonPrefix(designFiles.map(file => file.path));
+    const fileList = el(
+      'div',
+      { className: 'panel' },
+      el('h3', {}, `Design-relevant files (${designFiles.length})`),
+      prefix ? el('p', { className: 'prefix' }, prefix) : null,
+      designFiles.length
+        ? el(
+            'ul',
+            { className: 'files' },
+            designFiles.map(file => {
+              const [dir, name] = splitPath(file.path.slice(prefix.length));
+              return el(
+                'li',
+                { title: `${file.path} — ${file.status}` },
+                el('span', { className: `st ${file.status}` }),
+                el('span', { className: 'name' }, name),
+                el('span', { className: 'dir' }, dir),
+                el(
+                  'span',
+                  { className: 'churn' },
+                  file.added == null
+                    ? el('span', { className: 'dir' }, 'binary')
+                    : [el('span', { className: 'add' }, `+${file.added}`), ' ', el('span', { className: 'del' }, `−${file.deleted}`)],
+                ),
+              );
+            }),
+          )
+        : el('p', { className: 'hint' }, 'Nothing under the app’s templates, styles or assets changed.'),
+    );
+
+    return el(
+      'section',
+      { className: 'impact' },
+      el('h2', {}, 'Impact'),
+      el('p', { className: 'sub' }, 'Where the change lands in the codebase, for the conversation that follows “does this look right?”.'),
+      el('div', { className: 'impact-grid' }, categories, areas, fileList),
+      renderUncovered(),
+    );
+  }
+
+  /**
+   * The gap panel: design files that changed with no screen above showing
+   * them. Rendered full-width and last, because it is the part of the report
+   * that asks for a decision rather than reporting a fact.
+   */
+  function renderUncovered() {
+    const uncovered = data.impact.uncovered ?? [];
+    if (!uncovered.length) return null;
+    const prefix = commonPrefix(uncovered.map(file => file.path));
+    return el(
+      'div',
+      { className: 'panel gap' },
+      el('h3', {}, `Changed, but not shown above (${uncovered.length})`),
+      el(
+        'p',
+        { className: 'hint' },
+        'These templates, styles and assets changed, but no screen in this report appears to render them — so nothing here proves what they now look like. Each one is either covered by a screen whose name does not resemble it, or a candidate for a new visual spec.',
+      ),
+      prefix ? el('p', { className: 'prefix' }, prefix) : null,
+      el(
+        'ul',
+        { className: 'files' },
+        uncovered.map(file => {
+          const [dir, name] = splitPath(file.path.slice(prefix.length));
+          return el(
+            'li',
+            { title: file.path },
+            el('span', { className: 'st modified' }),
+            el('span', { className: 'name' }, name),
+            el('span', { className: 'dir' }, dir),
+            el('span', { className: 'churn' }, file.area ?? ''),
+          );
+        }),
+      ),
+    );
+  }
+
+  function renderFooter() {
+    const covered = data.screens.length;
+    return el(
+      'footer',
+      { className: 'meta' },
+      el('span', {}, `Generated ${new Date(data.generatedAt).toLocaleString()}`),
+      el('span', {}, `${covered} screen${covered === 1 ? '' : 's'} under visual coverage`),
+      el('span', {}, 'Before = baseline committed at the merge base. After = baseline on this branch.'),
+      data.base.sha ? null : el('span', {}, 'No merge base found — showing the current state only.'),
+    );
+  }
+
+  // ----------------------------------------------------------------- boot
+
+  root.append(
+    el(
+      'div',
+      { className: 'wrap' },
+      renderMasthead(),
+      renderToolbar(),
+      el('div', { className: 'screens', id: 'screens' }),
+      renderImpact(),
+      renderFooter(),
+    ),
+  );
+  renderScreens();
+  root.removeAttribute('aria-busy');
+})();

--- a/web/app/e2e/design-review/cli.mjs
+++ b/web/app/e2e/design-review/cli.mjs
@@ -34,7 +34,7 @@ Options
   --markdown <p>   Also write a pull-request-comment summary as markdown.
   --report-link <url>  Direct download URL for the report, linked from that summary.
   --run-link <url>     CI run that produced it, linked as secondary context.
-  --open           Open the report when it is written.
+  --open           Open the report when it is written (interactive use only).
   --help           Show this.
 
 Examples
@@ -68,7 +68,13 @@ function parseArgs(argv) {
      * available here.
      */
     const next = () => {
-      if (inlineValue !== null) return inlineValue;
+      // `--base=` parses as an inline value of "", which is falsy but not
+      // absent. Passed through it reached git as an empty ref, which does
+      // not error — it resolves to nothing, and the report then claimed
+      // every screen was new. A confidently wrong answer is the worst
+      // outcome available here, so an empty value is treated as no value
+      // and takes the explicit "needs a value" path below.
+      if (inlineValue !== null) return inlineValue === '' ? undefined : inlineValue;
       const candidate = argv[i + 1];
       if (candidate === undefined || candidate.startsWith('--')) return undefined;
       i++;
@@ -163,6 +169,15 @@ async function main() {
   process.stdout.write('\n');
 
   if (options.open) {
+    // Interactive use only. `--open` hands a path to the platform opener,
+    // which is the right thing on a developer's machine and meaningless in
+    // CI — where, if it resolved to anything at all, it would be a process
+    // spawned by a flag nobody meant to pass. Refusing loudly beats
+    // spawning quietly.
+    if (process.env['CI'] || !process.stdout.isTTY) {
+      process.stderr.write('  --open is for interactive use and was ignored (no TTY, or CI is set).\n\n');
+      return;
+    }
     const { execFile } = await import('node:child_process');
     const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
     execFile(opener, [outPath], () => {});

--- a/web/app/e2e/design-review/cli.mjs
+++ b/web/app/e2e/design-review/cli.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * `npm run design:review` — build the visual design review report.
+ *
+ * Reads baselines out of git rather than running anything, so the default
+ * invocation takes about a second and needs no backend, no browser and no
+ * Docker. That is the point: a report you have to schedule twenty minutes
+ * for is a report nobody opens mid-iteration.
+ *
+ * Running the visual suite is still worth doing — it is what catches an
+ * *unintended* change, where the code moved and the baseline did not — but
+ * it answers a different question, and `e2e:mock-llm:visual:docker` already
+ * answers it. This tool shows the changes that were made on purpose, which
+ * is precisely the set that a passing visual suite renders invisible.
+ */
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { collect } from './collect.mjs';
+import { render, reportTitle } from './render.mjs';
+import { WORKTREE } from './lib/git.mjs';
+
+const USAGE = `
+Design review report — before/after of every screen the visual suite covers.
+
+  npm run design:review [-- <options>]
+
+Options
+  --base <ref>     Compare against this ref's merge base.   (default: origin/main)
+  --head <ref>     Treat this ref as "after".               (default: working tree)
+  --out <path>     Where to write the report.               (default: .dev/design-review/report.html)
+  --json <path>    Also write the underlying model as JSON.
+  --open           Open the report when it is written.
+  --help           Show this.
+
+Examples
+  npm run design:review                              # my uncommitted work vs main
+  npm run design:review -- --head HEAD               # my branch as committed
+  npm run design:review -- --base v1.4.0             # since a release
+  npm run design:review -- --head abc1234 --open
+`;
+
+function parseArgs(argv) {
+  const options = { base: 'origin/main', head: WORKTREE, out: null, json: null, open: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    // A `--flag=value` form is accepted alongside `--flag value` because npm
+    // run-script arguments get retyped constantly and both are muscle memory.
+    const [flag, inlineValue] = arg.startsWith('--') && arg.includes('=') ? [arg.slice(0, arg.indexOf('=')), arg.slice(arg.indexOf('=') + 1)] : [arg, null];
+    const next = () => inlineValue ?? argv[++i];
+    switch (flag) {
+      case '--base': options.base = next(); break;
+      case '--head': options.head = next(); break;
+      case '--out': options.out = next(); break;
+      case '--json': options.json = next(); break;
+      case '--open': options.open = true; break;
+      case '--help':
+      case '-h': options.help = true; break;
+      default:
+        throw new Error(`Unknown option: ${arg}\n${USAGE}`);
+    }
+  }
+  for (const key of ['base', 'head', 'out', 'json']) {
+    if (options[key] === undefined) throw new Error(`Option --${key} needs a value.\n${USAGE}`);
+  }
+  return options;
+}
+
+/**
+ * A path to show the reader.
+ *
+ * Relative to the repository root, not to `process.cwd()`. These commands
+ * are run from `web/app` (that is where the npm script lives) while the
+ * report lands in the repo's `.dev/`, so a cwd-relative path comes out as
+ * `../../.dev/design-review/report.html` — technically correct and useless
+ * to paste anywhere.
+ */
+function display(target, root) {
+  const relative = path.relative(root, target);
+  return relative.startsWith('..') ? target : relative;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const model = await collect({ cwd: process.cwd(), baseRef: options.base, headRef: options.head });
+
+  // `.dev/` is the repo's gitignored scratch directory. A report runs to a
+  // few megabytes of inlined PNGs, so writing it anywhere tracked would put
+  // it one careless `git add -A` away from the history of a public repo.
+  const outPath = path.resolve(options.out ?? path.join(model.repoRoot, '.dev', 'design-review', 'report.html'));
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, await render(model), 'utf8');
+
+  if (options.json) {
+    const jsonPath = path.resolve(options.json);
+    await mkdir(path.dirname(jsonPath), { recursive: true });
+    // Image buffers are dropped: the JSON exists for a CI job to assert on
+    // ("did any screen change?"), and megabytes of base64 would make it
+    // unreadable for the one case it is for.
+    await writeFile(
+      jsonPath,
+      JSON.stringify(
+        { ...model, screens: model.screens.map(screen => ({ ...screen, variants: screen.variants.map(({ before, after, ...rest }) => ({ ...rest, hasBefore: Boolean(before), hasAfter: Boolean(after) })) })) },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+    process.stdout.write(`  model  ${display(jsonPath, model.repoRoot)}\n`);
+  }
+
+  const { changed, added, removed, unchanged } = model.summary;
+  process.stdout.write(`\n  ${reportTitle(model)}\n\n`);
+  process.stdout.write(`  ${changed} changed · ${added} new · ${removed} removed · ${unchanged} unchanged\n`);
+  process.stdout.write(`  report ${display(outPath, model.repoRoot)}\n`);
+  if (!model.base.sha) {
+    process.stdout.write(`\n  No merge base with ${model.base.ref} — the report shows the current state with nothing to compare against.\n`);
+  } else if (changed + added + removed === 0) {
+    process.stdout.write(`\n  No baseline changed. If you expected one to, the screen may not have a visual spec yet.\n`);
+  }
+  process.stdout.write('\n');
+
+  if (options.open) {
+    const { execFile } = await import('node:child_process');
+    const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    execFile(opener, [outPath], () => {});
+  }
+}
+
+main().catch(error => {
+  process.stderr.write(`\n  ${error.message}\n\n`);
+  process.exitCode = 1;
+});

--- a/web/app/e2e/design-review/cli.mjs
+++ b/web/app/e2e/design-review/cli.mjs
@@ -18,6 +18,7 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { collect } from './collect.mjs';
 import { render, reportTitle } from './render.mjs';
+import { renderMarkdown } from './markdown.mjs';
 import { WORKTREE } from './lib/git.mjs';
 
 const USAGE = `
@@ -30,6 +31,8 @@ Options
   --head <ref>     Treat this ref as "after".               (default: working tree)
   --out <path>     Where to write the report.               (default: .dev/design-review/report.html)
   --json <path>    Also write the underlying model as JSON.
+  --markdown <p>   Also write a pull-request-comment summary as markdown.
+  --report-link <url>  URL to link to from that summary (where the report is published).
   --open           Open the report when it is written.
   --help           Show this.
 
@@ -38,10 +41,11 @@ Examples
   npm run design:review -- --head HEAD               # my branch as committed
   npm run design:review -- --base v1.4.0             # since a release
   npm run design:review -- --head abc1234 --open
+  npm run design:review -- --markdown /tmp/comment.md   # paste into a PR
 `;
 
 function parseArgs(argv) {
-  const options = { base: 'origin/main', head: WORKTREE, out: null, json: null, open: false };
+  const options = { base: 'origin/main', head: WORKTREE, out: null, json: null, markdown: null, reportLink: null, open: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     // A `--flag=value` form is accepted alongside `--flag value` because npm
@@ -53,6 +57,8 @@ function parseArgs(argv) {
       case '--head': options.head = next(); break;
       case '--out': options.out = next(); break;
       case '--json': options.json = next(); break;
+      case '--markdown': options.markdown = next(); break;
+      case '--report-link': options.reportLink = next(); break;
       case '--open': options.open = true; break;
       case '--help':
       case '-h': options.help = true; break;
@@ -60,7 +66,7 @@ function parseArgs(argv) {
         throw new Error(`Unknown option: ${arg}\n${USAGE}`);
     }
   }
-  for (const key of ['base', 'head', 'out', 'json']) {
+  for (const key of ['base', 'head', 'out', 'json', 'markdown', 'reportLink']) {
     if (options[key] === undefined) throw new Error(`Option --${key} needs a value.\n${USAGE}`);
   }
   return options;
@@ -112,6 +118,13 @@ async function main() {
       'utf8',
     );
     process.stdout.write(`  model  ${display(jsonPath, model.repoRoot)}\n`);
+  }
+
+  if (options.markdown) {
+    const markdownPath = path.resolve(options.markdown);
+    await mkdir(path.dirname(markdownPath), { recursive: true });
+    await writeFile(markdownPath, renderMarkdown(model, { reportLink: options.reportLink }), 'utf8');
+    process.stdout.write(`  comment ${display(markdownPath, model.repoRoot)}\n`);
   }
 
   const { changed, added, removed, unchanged } = model.summary;

--- a/web/app/e2e/design-review/cli.mjs
+++ b/web/app/e2e/design-review/cli.mjs
@@ -50,8 +50,29 @@ function parseArgs(argv) {
     const arg = argv[i];
     // A `--flag=value` form is accepted alongside `--flag value` because npm
     // run-script arguments get retyped constantly and both are muscle memory.
+    // A lone `--` is what everyone's fingers type after an npm script name,
+    // and npm only eats the first one — so `npm run design:review --` arrives
+    // here as a literal argument. Erroring on it would fail the simplest
+    // possible invocation, so it is skipped as the separator it is.
+    if (arg === '--') continue;
+
     const [flag, inlineValue] = arg.startsWith('--') && arg.includes('=') ? [arg.slice(0, arg.indexOf('=')), arg.slice(arg.indexOf('=') + 1)] : [arg, null];
-    const next = () => inlineValue ?? argv[++i];
+    /**
+     * The value for a flag.
+     *
+     * A following token that is itself a flag is treated as absent rather
+     * than consumed. `--base --open` would otherwise silently compare
+     * against a ref literally named "--open" and swallow the second flag —
+     * a wrong report rather than an error, which is the worst outcome
+     * available here.
+     */
+    const next = () => {
+      if (inlineValue !== null) return inlineValue;
+      const candidate = argv[i + 1];
+      if (candidate === undefined || candidate.startsWith('--')) return undefined;
+      i++;
+      return candidate;
+    };
     switch (flag) {
       case '--base': options.base = next(); break;
       case '--head': options.head = next(); break;
@@ -132,7 +153,8 @@ async function main() {
   process.stdout.write(`  ${changed} changed · ${added} new · ${removed} removed · ${unchanged} unchanged\n`);
   process.stdout.write(`  report ${display(outPath, model.repoRoot)}\n`);
   if (!model.base.sha) {
-    process.stdout.write(`\n  No merge base with ${model.base.ref} — the report shows the current state with nothing to compare against.\n`);
+    process.stdout.write(`\n  No merge base with ${model.base.ref}: ${model.base.reason}\n`);
+    process.stdout.write(`  The report shows the current state, with nothing to compare against.\n`);
   } else if (changed + added + removed === 0) {
     process.stdout.write(`\n  No baseline changed. If you expected one to, the screen may not have a visual spec yet.\n`);
   }

--- a/web/app/e2e/design-review/cli.mjs
+++ b/web/app/e2e/design-review/cli.mjs
@@ -32,7 +32,8 @@ Options
   --out <path>     Where to write the report.               (default: .dev/design-review/report.html)
   --json <path>    Also write the underlying model as JSON.
   --markdown <p>   Also write a pull-request-comment summary as markdown.
-  --report-link <url>  URL to link to from that summary (where the report is published).
+  --report-link <url>  Direct download URL for the report, linked from that summary.
+  --run-link <url>     CI run that produced it, linked as secondary context.
   --open           Open the report when it is written.
   --help           Show this.
 
@@ -45,7 +46,7 @@ Examples
 `;
 
 function parseArgs(argv) {
-  const options = { base: 'origin/main', head: WORKTREE, out: null, json: null, markdown: null, reportLink: null, open: false };
+  const options = { base: 'origin/main', head: WORKTREE, out: null, json: null, markdown: null, reportLink: null, runLink: null, open: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     // A `--flag=value` form is accepted alongside `--flag value` because npm
@@ -80,6 +81,7 @@ function parseArgs(argv) {
       case '--json': options.json = next(); break;
       case '--markdown': options.markdown = next(); break;
       case '--report-link': options.reportLink = next(); break;
+      case '--run-link': options.runLink = next(); break;
       case '--open': options.open = true; break;
       case '--help':
       case '-h': options.help = true; break;
@@ -87,7 +89,7 @@ function parseArgs(argv) {
         throw new Error(`Unknown option: ${arg}\n${USAGE}`);
     }
   }
-  for (const key of ['base', 'head', 'out', 'json', 'markdown', 'reportLink']) {
+  for (const key of ['base', 'head', 'out', 'json', 'markdown', 'reportLink', 'runLink']) {
     if (options[key] === undefined) throw new Error(`Option --${key} needs a value.\n${USAGE}`);
   }
   return options;
@@ -144,7 +146,7 @@ async function main() {
   if (options.markdown) {
     const markdownPath = path.resolve(options.markdown);
     await mkdir(path.dirname(markdownPath), { recursive: true });
-    await writeFile(markdownPath, renderMarkdown(model, { reportLink: options.reportLink }), 'utf8');
+    await writeFile(markdownPath, renderMarkdown(model, { reportLink: options.reportLink, runLink: options.runLink }), 'utf8');
     process.stdout.write(`  comment ${display(markdownPath, model.repoRoot)}\n`);
   }
 

--- a/web/app/e2e/design-review/collect.mjs
+++ b/web/app/e2e/design-review/collect.mjs
@@ -1,0 +1,185 @@
+/**
+ * Assembles the design review model: every screen the visual suite covers,
+ * as it looked at the merge base and as it looks now, plus what the change
+ * touched.
+ *
+ * The output is a plain object — no HTML, no file writing. That split is
+ * what lets the same model be rendered as the report, dumped as JSON for a
+ * CI job to assert on, or summarised as a PR comment, without any of those
+ * re-deriving "which screens changed" for themselves and drifting.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as git from './lib/git.mjs';
+import { readPngSize } from './lib/png.mjs';
+import { listBaselinePaths, parseBaselinePath, readSpecAnnotations, titleize, PROJECTS } from './lib/screens.mjs';
+import { summarizeImpact, relatedFiles } from './lib/impact.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Pull request context, when this is running somewhere `gh` is authenticated.
+ *
+ * Entirely optional. The report's whole value proposition is that it works
+ * on a local branch before anything is pushed, so an unauthenticated `gh`, a
+ * missing `gh`, or a branch with no PR yet all return null and cost the
+ * reader nothing but a header line.
+ */
+async function readPullRequest(root, headRef) {
+  if (headRef !== git.WORKTREE && !/^[\w./-]+$/.test(String(headRef))) return null;
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'view', '--json', 'number,title,url,author,headRefName,baseRefName,isDraft,body'],
+      { cwd: root, encoding: 'utf8', timeout: 15_000 },
+    );
+    const pr = JSON.parse(stdout);
+    return { number: pr.number, title: pr.title, url: pr.url, author: pr.author?.login, head: pr.headRefName, base: pr.baseRefName, draft: pr.isDraft };
+  } catch {
+    return null;
+  }
+}
+
+/** One rendered image on one side of a comparison, or null if absent there. */
+function toImage(buffer, relPath) {
+  if (!buffer) return null;
+  const size = readPngSize(buffer);
+  return { path: relPath, bytes: buffer.length, width: size?.width ?? null, height: size?.height ?? null, buffer };
+}
+
+/**
+ * Status of a single baseline across the two sides.
+ *
+ * Byte equality is the test for "unchanged" rather than a pixel comparison.
+ * Playwright writes baselines deterministically, so identical bytes mean an
+ * identical image; and the inverse — different bytes, visually identical —
+ * is not a false positive worth engineering away, because a re-encoded
+ * baseline that renders the same is still something a reviewer should see
+ * in the changed list and ask about.
+ */
+function variantStatus(before, after) {
+  if (before && !after) return 'removed';
+  if (!before && after) return 'added';
+  return before.buffer.equals(after.buffer) ? 'unchanged' : 'changed';
+}
+
+/** Worst status across a screen's viewports — what the card badge shows. */
+const STATUS_RANK = { changed: 3, added: 2, removed: 2, unchanged: 0 };
+function rollUpStatus(variants) {
+  return variants.reduce((worst, variant) => (STATUS_RANK[variant.status] > STATUS_RANK[worst] ? variant.status : worst), 'unchanged');
+}
+
+export async function collect({ cwd = process.cwd(), baseRef = 'origin/main', headRef = git.WORKTREE } = {}) {
+  const root = await git.repoRoot(cwd);
+  const base = await git.resolveBase(root, baseRef, headRef);
+  const head = await git.describe(root, headRef);
+
+  const baseSha = base.sha;
+  // With no merge base there is nothing to compare against, but the report is
+  // still worth producing: it degrades to a plain gallery of what the app
+  // looks like now, which is what a fresh clone or an orphan branch can
+  // honestly offer.
+  const beforePaths = baseSha ? await listBaselinePaths(root, baseSha) : [];
+  const afterPaths = await listBaselinePaths(root, headRef);
+  const allPaths = [...new Set([...beforePaths, ...afterPaths])].sort();
+
+  const files = await git.changedFiles(root, baseSha, headRef);
+  const impact = summarizeImpact(files);
+
+  // Annotations are read once per spec, from the head side — the current
+  // wording of a test is what describes the current screen.
+  const annotationCache = new Map();
+  const annotationsFor = async specPath => {
+    if (!annotationCache.has(specPath)) annotationCache.set(specPath, await readSpecAnnotations(root, headRef, specPath));
+    return annotationCache.get(specPath);
+  };
+
+  const screensByShot = new Map();
+  for (const relPath of allPaths) {
+    const parsed = parseBaselinePath(relPath);
+    if (!parsed) continue;
+
+    const before = toImage(baseSha ? await git.readBlob(root, baseSha, relPath) : null, relPath);
+    const after = toImage(await git.readBlob(root, headRef, relPath), relPath);
+    if (!before && !after) continue;
+
+    const key = `${parsed.specPath}::${parsed.shot}`;
+    if (!screensByShot.has(key)) {
+      const annotation = (await annotationsFor(parsed.specPath)).get(parsed.shot) ?? {};
+      screensByShot.set(key, {
+        id: key.replace(/[^\w.-]+/g, '_'),
+        shot: parsed.shot,
+        title: annotation.testTitle ? titleize(annotation.testTitle) : titleize(parsed.shot),
+        group: annotation.describeTitle ?? null,
+        note: annotation.note ?? null,
+        specPath: parsed.specPath,
+        variants: [],
+      });
+    }
+
+    const project = PROJECTS[parsed.project] ?? { label: parsed.project, form: 'unknown', order: 99 };
+    screensByShot.get(key).variants.push({
+      project: parsed.project,
+      label: project.label,
+      device: project.device ?? null,
+      form: project.form,
+      order: project.order,
+      path: relPath,
+      status: variantStatus(before, after),
+      before,
+      after,
+    });
+  }
+
+  const screens = [...screensByShot.values()]
+    .map(screen => {
+      screen.variants.sort((a, b) => a.order - b.order);
+      screen.status = rollUpStatus(screen.variants);
+      screen.related = relatedFiles(screen, impact.files);
+      return screen;
+    })
+    // Changed screens first — the report opens on what a reviewer came for,
+    // with the unchanged gallery below as context rather than as a wall to
+    // scroll past.
+    .sort((a, b) => STATUS_RANK[b.status] - STATUS_RANK[a.status] || a.specPath.localeCompare(b.specPath) || a.shot.localeCompare(b.shot));
+
+  /**
+   * Design-surface files this change touched that no screen in the report
+   * points at.
+   *
+   * The most expensive failure of a visual regression suite is the quiet
+   * one: a designer restyles a component, every baseline still passes, the
+   * report is green, and nobody notices that the screen in question has no
+   * baseline at all. Listing the uncovered files turns that silence into a
+   * line the reviewer can read — and, often, into the next spec someone
+   * writes.
+   *
+   * It leans on the same name-match heuristic as the per-screen "related
+   * files", so it inherits the same caveat and states it in the report: a
+   * file can be genuinely covered and still land here because nothing in
+   * its path resembles the screen's name.
+   */
+  const mentioned = new Set(screens.flatMap(screen => screen.related));
+  const uncovered = impact.files
+    .filter(file => ['template', 'style', 'asset'].includes(file.category))
+    .filter(file => !mentioned.has(file.path))
+    .map(file => ({ path: file.path, area: file.area, category: file.category, added: file.added, deleted: file.deleted }));
+
+  return {
+    generatedAt: new Date().toISOString(),
+    repoRoot: root,
+    base,
+    head,
+    pr: await readPullRequest(root, headRef),
+    screens,
+    impact: { ...impact, uncovered },
+    summary: {
+      screens: screens.length,
+      changed: screens.filter(screen => screen.status === 'changed').length,
+      added: screens.filter(screen => screen.status === 'added').length,
+      removed: screens.filter(screen => screen.status === 'removed').length,
+      unchanged: screens.filter(screen => screen.status === 'unchanged').length,
+    },
+  };
+}

--- a/web/app/e2e/design-review/collect.mjs
+++ b/web/app/e2e/design-review/collect.mjs
@@ -9,38 +9,12 @@
  * re-deriving "which screens changed" for themselves and drifting.
  */
 
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import * as git from './lib/git.mjs';
 import { readPngSize } from './lib/png.mjs';
 import { listBaselinePaths, parseBaselinePath, readSpecAnnotations, titleize, PROJECTS } from './lib/screens.mjs';
 import { summarizeImpact, relatedFiles } from './lib/impact.mjs';
 import { diffPngs } from './lib/diff.mjs';
-
-const execFileAsync = promisify(execFile);
-
-/**
- * Pull request context, when this is running somewhere `gh` is authenticated.
- *
- * Entirely optional. The report's whole value proposition is that it works
- * on a local branch before anything is pushed, so an unauthenticated `gh`, a
- * missing `gh`, or a branch with no PR yet all return null and cost the
- * reader nothing but a header line.
- */
-async function readPullRequest(root, headRef) {
-  if (headRef !== git.WORKTREE && !/^[\w./-]+$/.test(String(headRef))) return null;
-  try {
-    const { stdout } = await execFileAsync(
-      'gh',
-      ['pr', 'view', '--json', 'number,title,url,author,headRefName,baseRefName,isDraft,body'],
-      { cwd: root, encoding: 'utf8', timeout: 15_000 },
-    );
-    const pr = JSON.parse(stdout);
-    return { number: pr.number, title: pr.title, url: pr.url, author: pr.author?.login, head: pr.headRefName, base: pr.baseRefName, draft: pr.isDraft };
-  } catch {
-    return null;
-  }
-}
+import { readPullRequest } from './lib/gh.mjs';
 
 /** One rendered image on one side of a comparison, or null if absent there. */
 function toImage(buffer, relPath) {

--- a/web/app/e2e/design-review/collect.mjs
+++ b/web/app/e2e/design-review/collect.mjs
@@ -15,6 +15,7 @@ import * as git from './lib/git.mjs';
 import { readPngSize } from './lib/png.mjs';
 import { listBaselinePaths, parseBaselinePath, readSpecAnnotations, titleize, PROJECTS } from './lib/screens.mjs';
 import { summarizeImpact, relatedFiles } from './lib/impact.mjs';
+import { diffPngs } from './lib/diff.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -119,6 +120,12 @@ export async function collect({ cwd = process.cwd(), baseRef = 'origin/main', he
     }
 
     const project = PROJECTS[parsed.project] ?? { label: parsed.project, form: 'unknown', order: 99 };
+    const status = variantStatus(before, after);
+    // Only changed variants are compared. An unchanged one is byte-identical
+    // by definition, and a one-sided one has nothing to compare against — so
+    // decoding them would be work whose answer is already known, on every
+    // screen in the report rather than the few that moved.
+    const diff = status === 'changed' ? diffPngs(before.buffer, after.buffer) : null;
     screensByShot.get(key).variants.push({
       project: parsed.project,
       label: project.label,
@@ -126,7 +133,8 @@ export async function collect({ cwd = process.cwd(), baseRef = 'origin/main', he
       form: project.form,
       order: project.order,
       path: relPath,
-      status: variantStatus(before, after),
+      status,
+      diff,
       before,
       after,
     });
@@ -163,6 +171,12 @@ export async function collect({ cwd = process.cwd(), baseRef = 'origin/main', he
   const mentioned = new Set(screens.flatMap(screen => screen.related));
   const uncovered = impact.files
     .filter(file => ['template', 'style', 'asset'].includes(file.category))
+    // App source only. The category test is extension-based on purpose, so
+    // it also matches a stylesheet belonging to the tooling or the e2e suite
+    // — real style files, but not product surface, and listing them under
+    // "no screen shows this" would be noise that trains readers to skip the
+    // list. `area` is null for anything outside the app's src/.
+    .filter(file => file.area !== null)
     .filter(file => !mentioned.has(file.path))
     .map(file => ({ path: file.path, area: file.area, category: file.category, added: file.added, deleted: file.deleted }));
 

--- a/web/app/e2e/design-review/lib/diff.mjs
+++ b/web/app/e2e/design-review/lib/diff.mjs
@@ -1,0 +1,78 @@
+/**
+ * How much of a screen actually changed.
+ *
+ * Kept identical, deliberately, to the comparison the rendered report runs
+ * on a canvas (`assets/report.js`, `computeDiff`). There are two
+ * implementations because they answer the question in two places — Node so a
+ * PR comment and the JSON model can quote a number, the browser so the
+ * sensitivity slider can move without a round trip — and they must not
+ * disagree at the default threshold, or the comment and the report a
+ * reviewer opens from it will contradict each other.
+ *
+ * `DEFAULT_THRESHOLD` is the single value both start from; the browser
+ * imports nothing, so the constant is repeated there with a comment pointing
+ * here. Any change to the rule below has to be made in both.
+ */
+
+import { decodePng } from './png.mjs';
+
+/**
+ * 8% of full channel range.
+ *
+ * Low enough to catch a genuine one-shade colour change, high enough that
+ * subpixel antialiasing along a text edge does not light up every glyph on
+ * the page and report a restyled paragraph as a redesigned screen.
+ */
+export const DEFAULT_THRESHOLD = 0.08;
+
+/**
+ * Compares two PNG buffers, returning `{ ratio, changed, total, width,
+ * height }`, or null if either side cannot be decoded.
+ *
+ * Images are compared inside the union of their two sizes, each anchored at
+ * the top-left. Scaling them to a common size would be the easy thing and
+ * the wrong thing: when a change makes a page taller, scaling hides exactly
+ * that, and every element below the insertion point reads as restyled
+ * because it has been shifted. Anchored at the top-left, the region only one
+ * image covers counts as changed — which is true, and is usually the most
+ * important part of what happened.
+ */
+export function diffPngs(beforeBuffer, afterBuffer, threshold = DEFAULT_THRESHOLD) {
+  const before = decodePng(beforeBuffer);
+  const after = decodePng(afterBuffer);
+  if (!before || !after) return null;
+
+  const width = Math.max(before.width, after.width);
+  const height = Math.max(before.height, after.height);
+  const cutoff = Math.round(threshold * 255);
+  let changed = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const inBefore = x < before.width && y < before.height;
+      const inAfter = x < after.width && y < after.height;
+      // A pixel present in only one image is a change by definition — this
+      // is what makes a height or width difference show up as a magnitude
+      // rather than silently comparing nothing.
+      if (!inBefore || !inAfter) {
+        changed++;
+        continue;
+      }
+      const a = (y * before.width + x) * 4;
+      const b = (y * after.width + x) * 4;
+      // Max per channel, not Euclidean distance: the question a designer is
+      // asking is "did any channel shift noticeably", and a distance metric
+      // lets a large change in one channel hide under small ones elsewhere.
+      // Alpha is included so a region that became translucent still counts.
+      const delta = Math.max(
+        Math.abs(before.data[a] - after.data[b]),
+        Math.abs(before.data[a + 1] - after.data[b + 1]),
+        Math.abs(before.data[a + 2] - after.data[b + 2]),
+        Math.abs(before.data[a + 3] - after.data[b + 3]),
+      );
+      if (delta > cutoff) changed++;
+    }
+  }
+
+  return { ratio: changed / (width * height), changed, total: width * height, width, height, threshold };
+}

--- a/web/app/e2e/design-review/lib/gh.mjs
+++ b/web/app/e2e/design-review/lib/gh.mjs
@@ -1,0 +1,38 @@
+/**
+ * Pull request context, via the GitHub CLI.
+ *
+ * Entirely best-effort, and deliberately the only part of this tool that
+ * knows GitHub exists. A missing `gh`, an unauthenticated one, no network,
+ * or a branch with no pull request all return null, and the report loses one
+ * header line. Nothing downstream — not the HTML, not the JSON, not the PR
+ * comment — requires it; the CI workflow in particular never depends on `gh`
+ * being installed in the runner image.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { WORKTREE } from './git.mjs';
+
+const execFileAsync = promisify(execFile);
+
+export async function readPullRequest(root, headRef) {
+  // `gh pr view` with no argument resolves the pull request for the branch
+  // that is *checked out*, which is only the right answer when the report's
+  // head is that branch. Asked for some other ref — `--head v1.2.0`, or a
+  // colleague's commit — it would cheerfully return the current branch's PR
+  // and stamp a report about one change with another change's title. Better
+  // no header line than a confidently wrong one.
+  if (headRef !== WORKTREE && headRef !== 'HEAD') return null;
+
+  try {
+    const { stdout } = await execFileAsync('gh', ['pr', 'view', '--json', 'number,title,url,author,headRefName,baseRefName,isDraft'], {
+      cwd: root,
+      encoding: 'utf8',
+      timeout: 15_000,
+    });
+    const pr = JSON.parse(stdout);
+    return { number: pr.number, title: pr.title, url: pr.url, author: pr.author?.login, head: pr.headRefName, base: pr.baseRefName, draft: pr.isDraft };
+  } catch {
+    return null;
+  }
+}

--- a/web/app/e2e/design-review/lib/git.mjs
+++ b/web/app/e2e/design-review/lib/git.mjs
@@ -65,10 +65,18 @@ export async function resolveBase(root, baseRef, headRef) {
     const sha = (await git(root, ['merge-base', baseRef, head])).trim();
     return { ref: baseRef, sha };
   } catch {
-    // No common ancestor: an orphan branch, a shallow clone whose history
-    // was cut above the fork point, or a base ref that does not exist
-    // locally. Report it instead of silently comparing against nothing.
-    return { ref: baseRef, sha: null };
+    // Failure here has two very different causes that produce an identical
+    // empty report, so they are separated before returning. A typo'd or
+    // unfetched ref is the overwhelmingly common one and is fixable in
+    // seconds — but told only "no merge base", a reader reasonably concludes
+    // their branch is fine and the tool is broken.
+    let reason = 'no common ancestor — an orphan branch, or a clone shallow enough to have cut the fork point';
+    try {
+      await git(root, ['rev-parse', '--verify', `${baseRef}^{commit}`]);
+    } catch {
+      reason = `\`${baseRef}\` does not resolve to a commit here — check the spelling, or fetch it first`;
+    }
+    return { ref: baseRef, sha: null, reason };
   }
 }
 
@@ -108,6 +116,71 @@ export async function readBlob(root, ref, relPath) {
 }
 
 /**
+ * Splits `-z` output into its NUL-delimited fields.
+ *
+ * Every path-bearing git command here is asked for `-z`, which is the only
+ * way to get paths back verbatim. Without it git abbreviates a rename to
+ * `dir/{old => new}/file`, and separately backslash-quotes any path
+ * containing a space, a quote or a non-ASCII byte — so the "path" in the
+ * output is a display string, not a path, and reconstructing the real one
+ * from it is guesswork. An earlier version of this file guessed with a
+ * regex and turned `web/app/src/{billing => payments}/invoice.html` into
+ * `payments}/invoice.html`, a path that does not exist, reported as
+ * modified rather than renamed.
+ */
+function nulFields(output) {
+  const fields = output.split('\0');
+  // A trailing NUL terminates the last record rather than starting a new one.
+  if (fields.at(-1) === '') fields.pop();
+  return fields;
+}
+
+/** `R100`/`C75` carry a similarity score; everything else is a bare letter. */
+const STATUS_NAMES = { R: 'renamed', C: 'renamed', A: 'added', D: 'deleted', M: 'modified', T: 'modified' };
+
+/**
+ * Status per path from `--name-status -z`.
+ *
+ * Rename and copy records span three fields (code, old path, new path);
+ * every other status spans two. The new path is what the report links to.
+ */
+function parseNameStatus(output) {
+  const fields = nulFields(output);
+  const statuses = new Map();
+  for (let i = 0; i < fields.length; ) {
+    const code = fields[i][0];
+    if (code === 'R' || code === 'C') {
+      statuses.set(fields[i + 2], STATUS_NAMES[code]);
+      i += 3;
+    } else {
+      statuses.set(fields[i + 1], STATUS_NAMES[code] ?? 'modified');
+      i += 2;
+    }
+  }
+  return statuses;
+}
+
+/**
+ * Line counts per path from `--numstat -z`.
+ *
+ * A record is `<added>\t<deleted>\t<path>`, except for a rename, where the
+ * path is empty in that field and the old and new paths follow as their own
+ * two fields. `-` for a count means binary, which is every baseline PNG.
+ */
+function parseNumstat(output) {
+  const fields = nulFields(output);
+  const entries = [];
+  for (let i = 0; i < fields.length; ) {
+    const [added, deleted, inlinePath] = fields[i].split('\t');
+    const renamed = inlinePath === '';
+    const file = renamed ? fields[i + 2] : inlinePath;
+    entries.push({ path: file, added: added === '-' ? null : Number(added), deleted: deleted === '-' ? null : Number(deleted) });
+    i += renamed ? 3 : 1;
+  }
+  return entries;
+}
+
+/**
  * Files that differ between `baseSha` and the head, as
  * `{ path, status, added, deleted }`.
  *
@@ -119,48 +192,18 @@ export async function readBlob(root, ref, relPath) {
 export async function changedFiles(root, baseSha, headRef) {
   if (!baseSha) return [];
 
-  const numstatArgs =
-    headRef === WORKTREE
-      ? ['diff', '--numstat', '-M', baseSha, '--']
-      : ['diff', '--numstat', '-M', `${baseSha}..${headRef}`, '--'];
-  const statusArgs =
-    headRef === WORKTREE
-      ? ['diff', '--name-status', '-M', baseSha, '--']
-      : ['diff', '--name-status', '-M', `${baseSha}..${headRef}`, '--'];
-
-  const statusByPath = new Map();
-  for (const line of (await git(root, statusArgs)).split('\n')) {
-    if (!line) continue;
-    const parts = line.split('\t');
-    const code = parts[0][0];
-    // Rename/copy entries carry both the old and the new path; the new one
-    // is what the report links to.
-    const file = parts.length > 2 ? parts[2] : parts[1];
-    statusByPath.set(file, { R: 'renamed', A: 'added', D: 'deleted', M: 'modified' }[code] ?? 'modified');
-  }
-
-  const files = [];
-  for (const line of (await git(root, numstatArgs)).split('\n')) {
-    if (!line) continue;
-    const [added, deleted, ...rest] = line.split('\t');
-    // A rename's numstat path field is "old => new" (or an elided form with
-    // braces); the name-status pass above already recorded the real new
-    // path, so prefer a key it knows.
-    const raw = rest.join('\t');
-    const file = statusByPath.has(raw) ? raw : (raw.match(/\{.*? => (.*?)\}|.* => (.*)/)?.slice(1).find(Boolean) ?? raw);
-    files.push({
-      path: file,
-      status: statusByPath.get(file) ?? 'modified',
-      added: added === '-' ? null : Number(added),
-      deleted: deleted === '-' ? null : Number(deleted),
-    });
-  }
+  const range = headRef === WORKTREE ? [baseSha] : [`${baseSha}..${headRef}`];
+  const statuses = parseNameStatus(await git(root, ['diff', '--name-status', '-z', '-M', ...range, '--']));
+  const files = parseNumstat(await git(root, ['diff', '--numstat', '-z', '-M', ...range, '--'])).map(entry => ({
+    ...entry,
+    status: statuses.get(entry.path) ?? 'modified',
+  }));
 
   // Untracked files exist only when comparing against the working tree, and
   // they are how a brand-new screen's first baseline shows up before anyone
   // has staged it.
   if (headRef === WORKTREE) {
-    const untracked = (await git(root, ['ls-files', '--others', '--exclude-standard'])).split('\n').filter(Boolean);
+    const untracked = nulFields(await git(root, ['ls-files', '--others', '--exclude-standard', '-z']));
     for (const file of untracked) {
       files.push({ path: file, status: 'added', added: null, deleted: null, untracked: true });
     }

--- a/web/app/e2e/design-review/lib/git.mjs
+++ b/web/app/e2e/design-review/lib/git.mjs
@@ -1,0 +1,170 @@
+/**
+ * Git access for the design review report.
+ *
+ * Two things shape this file:
+ *
+ * 1. **The "before" side of every comparison comes out of git, not out of a
+ *    test run.** When a designer updates a baseline they commit the new PNG,
+ *    so by the time anyone reviews the PR `toHaveScreenshot()` passes and the
+ *    Playwright report shows nothing at all — the intended design change is
+ *    invisible precisely because it was done properly. Reading the old blob
+ *    at the merge base is what makes that change visible again, and it costs
+ *    no browser, no backend and no Docker.
+ *
+ * 2. **The head side defaults to the working tree, not to HEAD.** A designer
+ *    iterating on a change wants to see it before committing, so an
+ *    uncommitted or even untracked baseline has to show up in the report.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+/** Sentinel `head` ref meaning "whatever is on disk right now". */
+export const WORKTREE = Symbol.for('design-review.worktree');
+
+/**
+ * Runs git and returns stdout.
+ *
+ * `execFile` rather than `exec`: every caller below interpolates a ref or a
+ * pathspec that came from a command line, and argv-passing means a branch
+ * named something shell-hostile is just a string.
+ *
+ * `maxBuffer` is raised because `git show <ref>:<png>` streams a whole
+ * baseline image through stdout, and the default 1MB cap truncates a
+ * full-page desktop screenshot into a corrupt buffer rather than failing
+ * loudly.
+ */
+async function git(repoRoot, args, { encoding = 'utf8' } = {}) {
+  const { stdout } = await execFileAsync('git', ['-C', repoRoot, ...args], {
+    encoding,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+/** Absolute path of the repository containing `cwd`. */
+export async function repoRoot(cwd) {
+  const out = await execFileAsync('git', ['-C', cwd, 'rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  return out.stdout.trim();
+}
+
+/**
+ * Resolves the commit a comparison should treat as "before".
+ *
+ * This is the merge base, never the tip of the base branch. Diffing against
+ * the tip attributes every unrelated screen someone else changed on main to
+ * *this* PR, which is the fastest way to make a review report untrustworthy.
+ */
+export async function resolveBase(root, baseRef, headRef) {
+  const head = headRef === WORKTREE ? 'HEAD' : headRef;
+  try {
+    const sha = (await git(root, ['merge-base', baseRef, head])).trim();
+    return { ref: baseRef, sha };
+  } catch {
+    // No common ancestor: an orphan branch, a shallow clone whose history
+    // was cut above the fork point, or a base ref that does not exist
+    // locally. Report it instead of silently comparing against nothing.
+    return { ref: baseRef, sha: null };
+  }
+}
+
+/** `{ ref, sha, subject, author }` for a ref, or the working tree. */
+export async function describe(root, ref) {
+  if (ref === WORKTREE) {
+    const sha = (await git(root, ['rev-parse', 'HEAD'])).trim();
+    const branch = (await git(root, ['rev-parse', '--abbrev-ref', 'HEAD'])).trim();
+    return { ref: 'working tree', sha, branch, subject: 'uncommitted working tree', worktree: true };
+  }
+  const sha = (await git(root, ['rev-parse', ref])).trim();
+  const subject = (await git(root, ['log', '-1', '--format=%s', sha])).trim();
+  const author = (await git(root, ['log', '-1', '--format=%an', sha])).trim();
+  return { ref, sha, subject, author, worktree: false };
+}
+
+/**
+ * Reads a file's bytes at a ref, or null when it does not exist there.
+ *
+ * Null is the load-bearing case, not an error path: it is how an added
+ * screen ("no before") and a deleted screen ("no after") are told apart
+ * from a changed one.
+ */
+export async function readBlob(root, ref, relPath) {
+  if (ref === WORKTREE) {
+    try {
+      return await readFile(path.join(root, relPath));
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return await git(root, ['show', `${ref}:${relPath}`], { encoding: 'buffer' });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Files that differ between `baseSha` and the head, as
+ * `{ path, status, added, deleted }`.
+ *
+ * `-M` so a renamed component reads as a rename rather than as a delete plus
+ * an unrelated add. Binary files report `added`/`deleted` as null, which is
+ * every baseline PNG — the report shows a pixel delta for those instead, and
+ * a fake line count would be worse than an honest absence.
+ */
+export async function changedFiles(root, baseSha, headRef) {
+  if (!baseSha) return [];
+
+  const numstatArgs =
+    headRef === WORKTREE
+      ? ['diff', '--numstat', '-M', baseSha, '--']
+      : ['diff', '--numstat', '-M', `${baseSha}..${headRef}`, '--'];
+  const statusArgs =
+    headRef === WORKTREE
+      ? ['diff', '--name-status', '-M', baseSha, '--']
+      : ['diff', '--name-status', '-M', `${baseSha}..${headRef}`, '--'];
+
+  const statusByPath = new Map();
+  for (const line of (await git(root, statusArgs)).split('\n')) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    const code = parts[0][0];
+    // Rename/copy entries carry both the old and the new path; the new one
+    // is what the report links to.
+    const file = parts.length > 2 ? parts[2] : parts[1];
+    statusByPath.set(file, { R: 'renamed', A: 'added', D: 'deleted', M: 'modified' }[code] ?? 'modified');
+  }
+
+  const files = [];
+  for (const line of (await git(root, numstatArgs)).split('\n')) {
+    if (!line) continue;
+    const [added, deleted, ...rest] = line.split('\t');
+    // A rename's numstat path field is "old => new" (or an elided form with
+    // braces); the name-status pass above already recorded the real new
+    // path, so prefer a key it knows.
+    const raw = rest.join('\t');
+    const file = statusByPath.has(raw) ? raw : (raw.match(/\{.*? => (.*?)\}|.* => (.*)/)?.slice(1).find(Boolean) ?? raw);
+    files.push({
+      path: file,
+      status: statusByPath.get(file) ?? 'modified',
+      added: added === '-' ? null : Number(added),
+      deleted: deleted === '-' ? null : Number(deleted),
+    });
+  }
+
+  // Untracked files exist only when comparing against the working tree, and
+  // they are how a brand-new screen's first baseline shows up before anyone
+  // has staged it.
+  if (headRef === WORKTREE) {
+    const untracked = (await git(root, ['ls-files', '--others', '--exclude-standard'])).split('\n').filter(Boolean);
+    for (const file of untracked) {
+      files.push({ path: file, status: 'added', added: null, deleted: null, untracked: true });
+    }
+  }
+
+  return files;
+}

--- a/web/app/e2e/design-review/lib/git.mjs
+++ b/web/app/e2e/design-review/lib/git.mjs
@@ -37,11 +37,21 @@ export const WORKTREE = Symbol.for('design-review.worktree');
  * baseline image through stdout, and the default 1MB cap truncates a
  * full-page desktop screenshot into a corrupt buffer rather than failing
  * loudly.
+ *
+ * `timeout` is set because git has no inherent one. A tree scan over a
+ * network filesystem, a repository mid-gc, or an index lock held by another
+ * process will otherwise leave the report hanging with no output and no
+ * upper bound — in CI that is a job that burns its whole limit saying
+ * nothing. A minute is far beyond any healthy invocation here and far short
+ * of a wedged one.
  */
+export const GIT_TIMEOUT_MS = 60_000;
+
 async function git(repoRoot, args, { encoding = 'utf8' } = {}) {
   const { stdout } = await execFileAsync('git', ['-C', repoRoot, ...args], {
     encoding,
     maxBuffer: 64 * 1024 * 1024,
+    timeout: GIT_TIMEOUT_MS,
   });
   return stdout;
 }

--- a/web/app/e2e/design-review/lib/impact.mjs
+++ b/web/app/e2e/design-review/lib/impact.mjs
@@ -1,0 +1,160 @@
+/**
+ * The "what did this PR actually touch" half of the report.
+ *
+ * A before/after gallery answers *how it looks*; this answers *how much of
+ * the product is involved*, which is the question a designer gets asked in
+ * review and currently has to answer by reading a diff. Everything here is
+ * derived from file paths — no build graph, no AST — because a path-based
+ * answer is one a reader can check at a glance, and a wrong-but-confident
+ * dependency graph is worse than an obviously approximate list.
+ */
+
+import path from 'node:path';
+import { isBaselinePath } from './screens.mjs';
+
+const APP_SRC = 'web/app/src/';
+
+/**
+ * File categories, in the order they are presented.
+ *
+ * `weight` drives the "design surface" score: how much of the change is
+ * something a designer owns. Templates, styles and assets are pure surface;
+ * a component `.ts` is partly surface and partly logic; specs and backend
+ * code are neither.
+ */
+const CATEGORIES = [
+  { id: 'baseline', label: 'Visual baselines', weight: 0, test: p => isBaselinePath(p) },
+  { id: 'style', label: 'Styles', weight: 1, test: p => /\.(css|scss|sass|less)$/.test(p) },
+  { id: 'template', label: 'Templates', weight: 1, test: p => p.startsWith(APP_SRC) && p.endsWith('.html') },
+  {
+    id: 'asset',
+    label: 'Assets',
+    weight: 1,
+    test: p => /\.(svg|png|jpe?g|gif|webp|avif|woff2?|ttf|otf)$/.test(p) && !isBaselinePath(p),
+  },
+  { id: 'spec', label: 'Tests', weight: 0, test: p => /\.spec\.ts$/.test(p) || p.includes('/e2e/') },
+  { id: 'component', label: 'Components & logic', weight: 0.5, test: p => p.startsWith(APP_SRC) && p.endsWith('.ts') },
+  { id: 'config', label: 'Config & build', weight: 0, test: p => /(^|\/)(package(-lock)?\.json|angular\.json|tsconfig[^/]*\.json|.*\.ya?ml)$/.test(p) },
+  { id: 'docs', label: 'Docs', weight: 0, test: p => /\.(md|mdx)$/.test(p) },
+  { id: 'other', label: 'Other', weight: 0, test: () => true },
+];
+
+/** First matching category — order above is the precedence, deliberately. */
+export function categorize(relPath) {
+  return CATEGORIES.find(category => category.test(relPath)) ?? CATEGORIES.at(-1);
+}
+
+/**
+ * Grouping buckets whose own name says nothing about the product.
+ *
+ * `features/personality` and `shared/ui` are meaningful areas; `features`
+ * and `shared` are just where the router and the component library happen
+ * to live, and collapsing to them would put most of the app in one bucket
+ * called "features" — which is the same as having no grouping at all.
+ */
+const CONTAINER_SEGMENTS = new Set(['features', 'shared', 'core', 'modules', 'pages', 'components']);
+
+/**
+ * Feature area a file belongs to: the first meaningful path segment under
+ * the app's `app/` directory (`chat`, `personality`, `shared/ui`…).
+ */
+export function featureArea(relPath) {
+  if (!relPath.startsWith(APP_SRC)) return null;
+  const rest = relPath.slice(APP_SRC.length).replace(/^app\//, '');
+  const segments = path.posix.dirname(rest).split('/').filter(segment => segment && segment !== '.');
+  if (!segments.length) return 'app root';
+  // Descend past container segments, but keep the container's name in the
+  // label when it disambiguates — `shared/ui` reads better than a bare `ui`,
+  // which could be either the design system or a feature's own folder.
+  if (CONTAINER_SEGMENTS.has(segments[0]) && segments[1]) {
+    return segments[0] === 'features' ? segments[1] : `${segments[0]}/${segments[1]}`;
+  }
+  return segments[0];
+}
+
+/**
+ * Tokens from a path that are worth matching a screen name against —
+ * lowercase words of 4+ characters, minus the boilerplate every Angular
+ * filename carries.
+ *
+ * The length floor and the stop list exist for the same reason: without
+ * them every screen "relates to" every file, via `app`, `ts` or `component`,
+ * and a relevance hint that fires on everything is just noise with extra
+ * steps.
+ */
+const STOP_WORDS = new Set(['component', 'components', 'service', 'services', 'spec', 'html', 'scss', 'index', 'shared', 'page', 'pages', 'app', 'src', 'web']);
+
+function tokens(text) {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(word => word.length >= 4 && !STOP_WORDS.has(word)),
+  );
+}
+
+/**
+ * Changed files whose path shares a meaningful word with a screen's name or
+ * spec.
+ *
+ * This is a *hint*, and the report labels it as one. It is a name match, not
+ * a dependency: it will miss a shared component that has no word in common
+ * with the screen it renders, and it will occasionally suggest a file that
+ * turns out to be unrelated. Both are acceptable for what it is used for —
+ * putting "you probably want to look at these files" next to a screen that
+ * changed — and neither would be fixed by a more elaborate heuristic that
+ * merely fails less legibly.
+ */
+export function relatedFiles(screen, files) {
+  const screenTokens = new Set([...tokens(screen.shot), ...tokens(path.posix.basename(screen.specPath))]);
+  if (!screenTokens.size) return [];
+  return files
+    .filter(file => !isBaselinePath(file.path) && file.category !== 'spec')
+    .filter(file => [...tokens(file.path)].some(word => screenTokens.has(word)))
+    .map(file => file.path);
+}
+
+/**
+ * Annotates changed files and rolls them up into the report's impact
+ * section.
+ */
+export function summarizeImpact(files) {
+  const annotated = files.map(file => {
+    const category = categorize(file.path);
+    return { ...file, category: category.id, categoryLabel: category.label, weight: category.weight, area: featureArea(file.path) };
+  });
+
+  const byCategory = CATEGORIES.map(category => {
+    const matched = annotated.filter(file => file.category === category.id);
+    return {
+      id: category.id,
+      label: category.label,
+      count: matched.length,
+      added: matched.reduce((sum, file) => sum + (file.added ?? 0), 0),
+      deleted: matched.reduce((sum, file) => sum + (file.deleted ?? 0), 0),
+    };
+  }).filter(entry => entry.count > 0);
+
+  const byArea = [...new Map(annotated.filter(file => file.area).map(file => [file.area, null])).keys()]
+    .map(area => {
+      const matched = annotated.filter(file => file.area === area);
+      return {
+        area,
+        count: matched.length,
+        churn: matched.reduce((sum, file) => sum + (file.added ?? 0) + (file.deleted ?? 0), 0),
+        // An area is "design-heavy" when most of what changed in it is
+        // template, style or asset rather than logic.
+        designWeight: matched.reduce((sum, file) => sum + file.weight, 0) / matched.length,
+      };
+    })
+    .sort((a, b) => b.churn - a.churn || b.count - a.count);
+
+  // Share of the *frontend* change that is design surface. Backend files are
+  // excluded from both sides rather than counted as zero: a PR that happens
+  // to also touch Go should not read as "barely a design change" when every
+  // frontend file in it is a stylesheet.
+  const frontend = annotated.filter(file => file.path.startsWith(APP_SRC));
+  const designShare = frontend.length ? frontend.reduce((sum, file) => sum + file.weight, 0) / frontend.length : 0;
+
+  return { files: annotated, byCategory, byArea, designShare, frontendFileCount: frontend.length };
+}

--- a/web/app/e2e/design-review/lib/png.mjs
+++ b/web/app/e2e/design-review/lib/png.mjs
@@ -20,6 +20,8 @@
  * adjustable threshold for free from data the report has already loaded.
  */
 
+import { inflateSync } from 'node:zlib';
+
 const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 /**
@@ -43,4 +45,144 @@ export function readPngSize(buffer) {
   // unreadable rather than emitting an aspect ratio that divides by zero.
   if (width === 0 || height === 0) return null;
   return { width, height };
+}
+
+/**
+ * Channel count per colour type, for the non-palette types.
+ *
+ * Palette (3) is absent deliberately: it needs the PLTE and tRNS chunks to
+ * mean anything, no browser emits it for a screenshot, and supporting it
+ * would be code that never runs in production and is therefore never known
+ * to work. `decodePng` returns null for it, and callers already handle null.
+ */
+const CHANNELS = { 0: 1, 2: 3, 4: 2, 6: 4 };
+
+/**
+ * Reverses one scanline's filter, in place.
+ *
+ * The five filter types are defined in terms of the byte to the left (`a`),
+ * the byte above (`b`) and the byte above-left (`c`), where anything off the
+ * edge of the image is zero. Working directly on the output buffer means the
+ * already-unfiltered previous row is exactly where `b` needs to read from.
+ */
+function unfilter(type, row, previous, bytesPerPixel) {
+  const width = row.length;
+  switch (type) {
+    case 0:
+      return;
+    case 1: // Sub — predict from the pixel to the left.
+      for (let i = bytesPerPixel; i < width; i++) row[i] = (row[i] + row[i - bytesPerPixel]) & 0xff;
+      return;
+    case 2: // Up — predict from the pixel above.
+      if (previous) for (let i = 0; i < width; i++) row[i] = (row[i] + previous[i]) & 0xff;
+      return;
+    case 3: // Average — the mean of left and above, rounded down.
+      for (let i = 0; i < width; i++) {
+        const left = i >= bytesPerPixel ? row[i - bytesPerPixel] : 0;
+        const above = previous ? previous[i] : 0;
+        row[i] = (row[i] + ((left + above) >> 1)) & 0xff;
+      }
+      return;
+    case 4: // Paeth — whichever of left/above/above-left is closest to their linear estimate.
+      for (let i = 0; i < width; i++) {
+        const left = i >= bytesPerPixel ? row[i - bytesPerPixel] : 0;
+        const above = previous ? previous[i] : 0;
+        const aboveLeft = previous && i >= bytesPerPixel ? previous[i - bytesPerPixel] : 0;
+        const estimate = left + above - aboveLeft;
+        const dLeft = Math.abs(estimate - left);
+        const dAbove = Math.abs(estimate - above);
+        const dAboveLeft = Math.abs(estimate - aboveLeft);
+        const predicted = dLeft <= dAbove && dLeft <= dAboveLeft ? left : dAbove <= dAboveLeft ? above : aboveLeft;
+        row[i] = (row[i] + predicted) & 0xff;
+      }
+      return;
+    default:
+      throw new Error(`unknown PNG filter type ${type}`);
+  }
+}
+
+/**
+ * Decodes a PNG to `{ width, height, data }` with `data` as RGBA bytes, or
+ * null for anything outside the shape screenshots actually take (8-bit,
+ * non-interlaced, non-palette).
+ *
+ * This exists so the changed-pixel figure can be computed in Node instead of
+ * only in the browser. Without it the only place a diff ratio existed was
+ * inside the rendered report, which meant a PR comment could say that a
+ * screen changed but not by how much — and "something changed" without a
+ * magnitude is the kind of notification people learn to ignore.
+ *
+ * Chromium writes colour type 2 (no alpha) for screenshots, so that is the
+ * path that matters; the others are handled because doing so is a few lines
+ * and the alternative is a null return that reads like a bug.
+ */
+export function decodePng(buffer) {
+  const size = readPngSize(buffer);
+  if (!size) return null;
+
+  const bitDepth = buffer[24];
+  const colourType = buffer[25];
+  const interlace = buffer[28];
+  const channels = CHANNELS[colourType];
+  // Interlaced PNGs store seven separate reduced images; screenshots are
+  // never interlaced and handling Adam7 for a case that does not arise
+  // would be untested code by construction.
+  if (bitDepth !== 8 || !channels || interlace !== 0) return null;
+
+  // IDAT may be split across any number of chunks, and zlib requires them
+  // concatenated before inflation — a per-chunk inflate fails on the second
+  // chunk of any image large enough to have one, which is most of them.
+  const parts = [];
+  let offset = 8;
+  while (offset + 8 <= buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.subarray(offset + 4, offset + 8).toString('ascii');
+    if (type === 'IDAT') parts.push(buffer.subarray(offset + 8, offset + 8 + length));
+    if (type === 'IEND') break;
+    offset += 12 + length; // length + type + data + CRC
+  }
+  if (!parts.length) return null;
+
+  let raw;
+  try {
+    raw = inflateSync(Buffer.concat(parts));
+  } catch {
+    // A corrupt or truncated image: the report should say so on that one
+    // screen rather than abort the run.
+    return null;
+  }
+
+  const { width, height } = size;
+  const bytesPerPixel = channels;
+  const stride = width * channels;
+  if (raw.length < height * (stride + 1)) return null;
+
+  const data = Buffer.alloc(width * height * 4);
+  let previous = null;
+  const row = Buffer.alloc(stride);
+  for (let y = 0; y < height; y++) {
+    const start = y * (stride + 1);
+    raw.copy(row, 0, start + 1, start + 1 + stride);
+    unfilter(raw[start], row, previous, bytesPerPixel);
+
+    // Widen to RGBA so every caller compares the same four channels,
+    // whatever the source encoding was.
+    for (let x = 0; x < width; x++) {
+      const from = x * channels;
+      const to = (y * width + x) * 4;
+      if (channels >= 3) {
+        data[to] = row[from];
+        data[to + 1] = row[from + 1];
+        data[to + 2] = row[from + 2];
+        data[to + 3] = channels === 4 ? row[from + 3] : 255;
+      } else {
+        // Greyscale, with or without alpha.
+        data[to] = data[to + 1] = data[to + 2] = row[from];
+        data[to + 3] = channels === 2 ? row[from + 1] : 255;
+      }
+    }
+    previous = Buffer.from(row);
+  }
+
+  return { width, height, data };
 }

--- a/web/app/e2e/design-review/lib/png.mjs
+++ b/web/app/e2e/design-review/lib/png.mjs
@@ -1,0 +1,46 @@
+/**
+ * Just enough PNG to know how big a baseline is.
+ *
+ * The report needs every screenshot's pixel dimensions so the HTML can
+ * reserve the right aspect ratio before the image decodes (otherwise a
+ * gallery of a dozen screens reflows as each one lands) and so a
+ * desktop/mobile pair can be told apart by shape rather than by trusting
+ * the filename.
+ *
+ * That is the *only* thing needed from the format, so this reads the IHDR
+ * header rather than pulling in a decoder. Playwright writes plain
+ * truecolour-with-alpha PNGs whose IHDR is always the first chunk, which
+ * the spec requires of every encoder, so the fixed offsets below are not a
+ * shortcut around a general case — there is no general case to handle.
+ *
+ * Actual pixel comparison deliberately does NOT happen here; it happens in
+ * the browser on a canvas (see render.mjs). Diffing in Node would mean a
+ * full PNG decoder as a new dependency, and the result would be a static
+ * image; doing it client-side gets the slider, the onion-skin and the
+ * adjustable threshold for free from data the report has already loaded.
+ */
+
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/**
+ * Reads `{ width, height }` from a PNG buffer, or returns null for anything
+ * that isn't one.
+ *
+ * Returns null rather than throwing: a malformed or truncated file here is
+ * a baseline that someone's git-lfs or merge tool mangled, and the report
+ * is far more useful if it renders that screen with a "couldn't read this
+ * image" note than if the whole run dies on it.
+ */
+export function readPngSize(buffer) {
+  // 8 signature + 4 length + 4 "IHDR" + 8 (width, height) = 24 bytes minimum.
+  if (!Buffer.isBuffer(buffer) || buffer.length < 24) return null;
+  if (!buffer.subarray(0, 8).equals(SIGNATURE)) return null;
+  if (buffer.subarray(12, 16).toString('ascii') !== 'IHDR') return null;
+
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  // A zero dimension is legal to encode but not legal PNG; treat it as
+  // unreadable rather than emitting an aspect ratio that divides by zero.
+  if (width === 0 || height === 0) return null;
+  return { width, height };
+}

--- a/web/app/e2e/design-review/lib/png.mjs
+++ b/web/app/e2e/design-review/lib/png.mjs
@@ -115,6 +115,13 @@ function unfilter(type, row, previous, bytesPerPixel) {
  * Chromium writes colour type 2 (no alpha) for screenshots, so that is the
  * path that matters; the others are handled because doing so is a few lines
  * and the alternative is a null return that reads like a bug.
+ *
+ * **This is not a PNG validator.** It reads the shapes a browser produces
+ * and returns null for everything else; it does not verify chunk CRCs, and
+ * it trusts the declared dimensions against the inflated length only far
+ * enough not to read out of bounds. That is the right trade for committed
+ * baselines, which arrive from Playwright through git. Do not point it at
+ * an untrusted PNG from elsewhere without revisiting that.
  */
 export function decodePng(buffer) {
   const size = readPngSize(buffer);
@@ -158,12 +165,17 @@ export function decodePng(buffer) {
   if (raw.length < height * (stride + 1)) return null;
 
   const data = Buffer.alloc(width * height * 4);
-  let previous = null;
   const row = Buffer.alloc(stride);
+  // Two buffers reused for the whole image rather than one allocated per
+  // scanline. A desktop baseline is 720 rows and a full-page one can be
+  // several thousand, so the per-row allocation was that many short-lived
+  // buffers per image, on every image in the report.
+  const previousRow = Buffer.alloc(stride);
+  let hasPrevious = false;
   for (let y = 0; y < height; y++) {
     const start = y * (stride + 1);
     raw.copy(row, 0, start + 1, start + 1 + stride);
-    unfilter(raw[start], row, previous, bytesPerPixel);
+    unfilter(raw[start], row, hasPrevious ? previousRow : null, bytesPerPixel);
 
     // Widen to RGBA so every caller compares the same four channels,
     // whatever the source encoding was.
@@ -181,7 +193,8 @@ export function decodePng(buffer) {
         data[to + 3] = channels === 2 ? row[from + 1] : 255;
       }
     }
-    previous = Buffer.from(row);
+    row.copy(previousRow);
+    hasPrevious = true;
   }
 
   return { width, height, data };

--- a/web/app/e2e/design-review/lib/screens.mjs
+++ b/web/app/e2e/design-review/lib/screens.mjs
@@ -18,7 +18,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { WORKTREE, readBlob } from './git.mjs';
+import { WORKTREE, readBlob, GIT_TIMEOUT_MS } from './git.mjs';
 import { readPngSize } from './png.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -77,12 +77,14 @@ export async function listBaselinePaths(root, ref) {
     const { stdout } = await execFileAsync('git', ['-C', root, 'ls-files', '--cached', '--others', '--exclude-standard'], {
       encoding: 'utf8',
       maxBuffer: 32 * 1024 * 1024,
+      timeout: GIT_TIMEOUT_MS,
     });
     return stdout.split('\n').filter(isBaselinePath);
   }
   const { stdout } = await execFileAsync('git', ['-C', root, 'ls-tree', '-r', '--name-only', ref], {
     encoding: 'utf8',
     maxBuffer: 32 * 1024 * 1024,
+    timeout: GIT_TIMEOUT_MS,
   });
   return stdout.split('\n').filter(isBaselinePath);
 }

--- a/web/app/e2e/design-review/lib/screens.mjs
+++ b/web/app/e2e/design-review/lib/screens.mjs
@@ -108,8 +108,22 @@ export function titleize(shot) {
  * never "throw" — a spec written in a shape this doesn't recognise simply
  * contributes no annotation.
  */
+/**
+ * Ceiling on the spec source this will scan.
+ *
+ * The extraction below is a handful of unanchored regexes run repeatedly
+ * over slices of the file, which is fine for a spec (a few kilobytes) and
+ * quadratic-ish on something pathological. No real spec comes close, so a
+ * file past this size is a generated or vendored artifact that happens to
+ * end in `.spec.ts` — and the correct response to it is to contribute no
+ * annotations rather than to spend a minute proving it has none.
+ */
+const MAX_SPEC_BYTES = 512 * 1024;
+
 export async function readSpecAnnotations(root, ref, specPath) {
-  const source = (await readBlob(root, ref, specPath))?.toString('utf8');
+  const blob = await readBlob(root, ref, specPath);
+  if (!blob || blob.length > MAX_SPEC_BYTES) return new Map();
+  const source = blob.toString('utf8');
   if (!source) return new Map();
 
   // Every block comment in the file, with the offset just past its `*/`.

--- a/web/app/e2e/design-review/lib/screens.mjs
+++ b/web/app/e2e/design-review/lib/screens.mjs
@@ -1,0 +1,159 @@
+/**
+ * Turns committed baseline PNGs into the "screens" the report is organised
+ * around.
+ *
+ * Playwright's on-disk layout already encodes everything needed:
+ *
+ *   tests/visual/<spec>.spec.ts-snapshots/<shot>-<project>-<platform>.png
+ *
+ * so a screen is recovered from the path rather than from a hand-maintained
+ * registry. That matters more than it looks: a registry is a second list to
+ * update, and the one thing guaranteed about a second list is that the day
+ * someone adds a screen they will update only the first. Deriving from the
+ * filesystem means a new baseline appears in the report the moment it is
+ * written, with no other edit anywhere.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { WORKTREE, readBlob } from './git.mjs';
+import { readPngSize } from './png.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/** Matches `<shot>-<project>-<platform>.png`, e.g. `login-page-chromium-desktop-linux.png`. */
+const BASELINE_FILE = /^(?<shot>.+)-(?<project>chromium-desktop|chromium-mobile|webkit-mobile)-(?<platform>[a-z0-9]+)\.png$/;
+
+/**
+ * How each Playwright project is presented to a designer.
+ *
+ * Project names are an implementation detail of the config; "Desktop" and
+ * "Mobile" are what someone reviewing a layout actually thinks in. The
+ * `order` field is what keeps desktop on the left of every pair, rather than
+ * whatever order the filesystem happened to hand back.
+ */
+export const PROJECTS = {
+  'chromium-desktop': { label: 'Desktop', device: 'Desktop Chrome', form: 'desktop', order: 0 },
+  'chromium-mobile': { label: 'Mobile', device: 'Pixel 7', form: 'mobile', order: 1 },
+  'webkit-mobile': { label: 'Mobile (WebKit)', device: 'iPhone 15', form: 'mobile', order: 2 },
+};
+
+/** True for any path Playwright would have written a baseline to. */
+export function isBaselinePath(relPath) {
+  return relPath.includes('.spec.ts-snapshots/') && relPath.endsWith('.png');
+}
+
+/**
+ * Splits a baseline path into its parts, or returns null if it doesn't look
+ * like one.
+ *
+ * An unrecognised filename is skipped rather than guessed at. A stray PNG in
+ * a snapshots directory is far more likely to be somebody's scratch file
+ * than a screen, and inventing a project name for it would put a fake
+ * viewport into the report.
+ */
+export function parseBaselinePath(relPath) {
+  if (!isBaselinePath(relPath)) return null;
+  const dir = path.posix.dirname(relPath);
+  const file = path.posix.basename(relPath);
+  const groups = BASELINE_FILE.exec(file)?.groups;
+  if (!groups) return null;
+
+  // `<spec>.spec.ts-snapshots` → `<spec>.spec.ts`, which is the spec that
+  // owns this baseline and the file a reviewer would open.
+  const specPath = path.posix.join(path.posix.dirname(dir), path.posix.basename(dir).replace(/-snapshots$/, ''));
+
+  return { path: relPath, specPath, shot: groups.shot, project: groups.project, platform: groups.platform };
+}
+
+/** Every baseline path present at a ref (or on disk, for the working tree). */
+export async function listBaselinePaths(root, ref) {
+  if (ref === WORKTREE) {
+    // `git ls-files` rather than a directory walk so the result respects
+    // .gitignore, and `--others` so a baseline written but not yet staged —
+    // the normal state mid-iteration — is still found.
+    const { stdout } = await execFileAsync('git', ['-C', root, 'ls-files', '--cached', '--others', '--exclude-standard'], {
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return stdout.split('\n').filter(isBaselinePath);
+  }
+  const { stdout } = await execFileAsync('git', ['-C', root, 'ls-tree', '-r', '--name-only', ref], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return stdout.split('\n').filter(isBaselinePath);
+}
+
+/**
+ * Human title for a screenshot name: `chat-composer-empty` → `Chat composer
+ * empty`. Only the first word is capitalised, so an acronym or product name
+ * that a designer wrote into the shot name survives as they wrote it.
+ */
+export function titleize(shot) {
+  const words = shot.replace(/[-_]+/g, ' ').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Pulls the enclosing `test(...)` title — and the comment above it — out of a
+ * spec, keyed by screenshot name.
+ *
+ * This is a regex pass over the source, not a parse. A real parse would need
+ * a TypeScript AST for what is, at best, a nicety: the report is perfectly
+ * usable showing `personality-detail` alone, and everything this adds is
+ * extra context on a card. So every failure mode here is "return less",
+ * never "throw" — a spec written in a shape this doesn't recognise simply
+ * contributes no annotation.
+ */
+export async function readSpecAnnotations(root, ref, specPath) {
+  const source = (await readBlob(root, ref, specPath))?.toString('utf8');
+  if (!source) return new Map();
+
+  // Every block comment in the file, with the offset just past its `*/`.
+  const comments = [...source.matchAll(/\/\*\*(?<body>[\s\S]*?)\*\//g)].map(match => ({
+    end: match.index + match[0].length,
+    text: match.groups.body
+      .split('\n')
+      .map(line => line.replace(/^\s*\*\s?/, '').trimEnd())
+      .join('\n')
+      .trim(),
+  }));
+
+  /**
+   * The doc comment for the declaration starting at `declStart`, if there is
+   * one. "Is one" means the comment ends within a couple of lines of the
+   * declaration — far enough to tolerate a blank line or a decorator, close
+   * enough that an unrelated comment from earlier in the file can't be
+   * mistaken for documentation of this test.
+   */
+  const docFor = declStart => {
+    if (declStart === undefined) return undefined;
+    const candidate = comments.filter(comment => comment.end <= declStart).at(-1);
+    if (!candidate) return undefined;
+    return source.slice(candidate.end, declStart).trim() === '' ? candidate.text : undefined;
+  };
+
+  const annotations = new Map();
+  const shotRe = /toHaveScreenshot\(\s*['"`](?<shot>[^'"`]+)\.png['"`]/g;
+  for (const match of source.matchAll(shotRe)) {
+    const before = source.slice(0, match.index);
+    // The nearest preceding `test(` and `test.describe(` are the ones this
+    // screenshot sits inside. `test.describe` is matched first and excluded
+    // from the `test(` pattern so a describe title can't be read as a test
+    // title in a file that has only describes.
+    const testMatch = [...before.matchAll(/\btest(?!\.describe)(?:\.\w+)*\(\s*\n?\s*['"`](?<title>[^'"`]+)['"`]/g)].at(-1);
+    const describeMatch = [...before.matchAll(/\btest\.describe\(\s*['"`](?<title>[^'"`]+)['"`]/g)].at(-1);
+
+    annotations.set(match.groups.shot, {
+      testTitle: testMatch?.groups?.title,
+      describeTitle: describeMatch?.groups?.title,
+      // A test's own comment wins; a describe's comment covers the whole
+      // group and is the right fallback when the individual test has none.
+      note: docFor(testMatch?.index) ?? docFor(describeMatch?.index),
+    });
+  }
+  return annotations;
+}

--- a/web/app/e2e/design-review/markdown.mjs
+++ b/web/app/e2e/design-review/markdown.mjs
@@ -53,7 +53,7 @@ function short(filePath) {
   return appIndex === -1 ? filePath : parts.slice(appIndex + 1).join('/');
 }
 
-export function renderMarkdown(model, { reportLink, reportHint } = {}) {
+export function renderMarkdown(model, { reportLink, runLink } = {}) {
   const { summary } = model;
   const touched = summary.changed + summary.added + summary.removed;
   const lines = [];
@@ -116,8 +116,20 @@ export function renderMarkdown(model, { reportLink, reportHint } = {}) {
     lines.push(`<sub>${summary.unchanged} other screen${summary.unchanged === 1 ? '' : 's'} unchanged.</sub>`, '');
   }
 
-  if (reportLink) {
-    lines.push(`**[Open the before/after report →](${reportLink})**${reportHint ? ` ${reportHint}` : ''}`, '');
+  // The download link points straight at the artifact, not at the workflow
+  // run. A run page puts the artifact behind a scroll to the bottom and an
+  // "Artifacts" section most readers will not think to look for, which is a
+  // poor last step for the one thing this comment exists to hand over.
+  if (reportLink || runLink) {
+    const parts = [];
+    if (reportLink) parts.push(`### ⬇️ [Download the interactive report](${reportLink})`);
+    lines.push(...parts, '');
+    // Say what arrives, because a zip that turns out to hold a single HTML
+    // file is a much smaller ask than an unlabelled download implies.
+    lines.push(
+      `A zip containing one self-contained HTML file — open it in any browser, nothing to check out or install. Drag the divider to compare, or switch to side-by-side, onion-skin or pixel-difference.${runLink ? ` ([workflow run](${runLink}))` : ''}`,
+      '',
+    );
   }
 
   lines.push(

--- a/web/app/e2e/design-review/markdown.mjs
+++ b/web/app/e2e/design-review/markdown.mjs
@@ -1,0 +1,128 @@
+/**
+ * The model as a pull request comment.
+ *
+ * A third rendering of the same `collect()` output, alongside the HTML report
+ * and `--json`. The point of that shape is this file: the comment and the
+ * report a reader opens from it cannot disagree about which screens changed,
+ * because neither works it out for itself.
+ *
+ * Written for someone scanning a PR page, not reading a report. It says what
+ * changed and by how much, names the thing nothing is showing them, and
+ * stops. Everything else is behind the link.
+ */
+
+import path from 'node:path';
+
+/** `11.2%`, or `0.04%` for a change small enough that one decimal reads as zero. */
+function percent(ratio) {
+  if (!ratio) return '0%';
+  return `${(ratio * 100).toFixed(ratio < 0.001 ? 3 : ratio < 0.01 ? 2 : 1)}%`;
+}
+
+/** What a single viewport cell says. */
+function cell(variant) {
+  switch (variant.status) {
+    case 'changed':
+      // A changed variant whose images would not decode still changed; say so
+      // rather than printing a confident "0%".
+      return variant.diff ? `**${percent(variant.diff.ratio)}**` : '**changed**';
+    case 'added':
+      return 'new';
+    case 'removed':
+      return 'removed';
+    default:
+      return '·';
+  }
+}
+
+/**
+ * Short form of a path for a comment, where a full repo path is mostly
+ * prefix.
+ *
+ * Cuts after the *last* `app` segment, not the first. The paths here look
+ * like `web/app/src/app/features/billing/…`, so matching the first one
+ * leaves `src/app/…` — still readable, but it keeps the two segments that
+ * carry no information while the line is already long. The last match lands
+ * on the source root, giving `features/billing/…`. A file directly under
+ * the source root (`web/app/src/styles.scss`) has only the workspace `app`
+ * to match and keeps its `src/` prefix, which is correct for it.
+ */
+function short(filePath) {
+  const parts = filePath.split('/');
+  const appIndex = parts.lastIndexOf('app');
+  return appIndex === -1 ? filePath : parts.slice(appIndex + 1).join('/');
+}
+
+export function renderMarkdown(model, { reportLink, reportHint } = {}) {
+  const { summary } = model;
+  const touched = summary.changed + summary.added + summary.removed;
+  const lines = [];
+
+  // The heading carries the whole verdict, because on a busy PR page it is
+  // often the only part that gets read.
+  const headline = touched
+    ? `${touched} screen${touched === 1 ? '' : 's'} changed`
+    : summary.screens
+      ? 'no screen changed'
+      : 'no screens under visual coverage';
+  lines.push(`### Design review · ${headline}`, '');
+
+  if (!model.base.sha) {
+    lines.push(`> No merge base with \`${model.base.ref}\` — nothing to compare against, so every screen below reads as new.`, '');
+  }
+
+  const moved = model.screens.filter(screen => screen.status !== 'unchanged');
+  if (moved.length) {
+    // Columns are the viewports actually present, in their canonical order,
+    // so a report covering only desktop does not carry an empty mobile column.
+    const projects = [];
+    for (const screen of model.screens) {
+      for (const variant of screen.variants) {
+        if (!projects.some(entry => entry.project === variant.project)) projects.push(variant);
+      }
+    }
+    projects.sort((a, b) => a.order - b.order);
+
+    lines.push(`| Screen | ${projects.map(variant => variant.label).join(' | ')} |`);
+    lines.push(`| --- | ${projects.map(() => '---').join(' | ')} |`);
+    for (const screen of moved) {
+      const cells = projects.map(entry => {
+        const variant = screen.variants.find(candidate => candidate.project === entry.project);
+        return variant ? cell(variant) : '—';
+      });
+      lines.push(`| ${screen.title} | ${cells.join(' | ')} |`);
+    }
+    lines.push('', `<sub>Percentages are the share of pixels that differ, compared at the default sensitivity.</sub>`, '');
+  } else if (summary.screens) {
+    lines.push(`All ${summary.screens} covered screens are byte-identical to \`${model.base.ref}\`.`, '');
+  }
+
+  // The gap list. Deliberately not folded into a <details>: it is the part
+  // of this comment most worth acting on and least likely to be sought out.
+  const uncovered = model.impact.uncovered ?? [];
+  if (uncovered.length) {
+    lines.push(
+      `⚠️ **${uncovered.length} design file${uncovered.length === 1 ? '' : 's'} changed that no covered screen renders.** Nothing above shows what ${uncovered.length === 1 ? 'it looks' : 'they look'} like now.`,
+      '',
+    );
+    // Capped, because a wide-ranging PR can touch dozens and a comment that
+    // long stops being read at all.
+    for (const file of uncovered.slice(0, 10)) lines.push(`- \`${short(file.path)}\``);
+    if (uncovered.length > 10) lines.push(`- …and ${uncovered.length - 10} more`);
+    lines.push('');
+  }
+
+  if (summary.unchanged && moved.length) {
+    lines.push(`<sub>${summary.unchanged} other screen${summary.unchanged === 1 ? '' : 's'} unchanged.</sub>`, '');
+  }
+
+  if (reportLink) {
+    lines.push(`**[Open the before/after report →](${reportLink})**${reportHint ? ` ${reportHint}` : ''}`, '');
+  }
+
+  lines.push(
+    `<sub>Compared \`${model.base.ref}\` (\`${model.base.sha?.slice(0, 7) ?? 'none'}\`) with \`${model.head.worktree ? 'working tree' : model.head.ref}\` (\`${model.head.sha?.slice(0, 7) ?? '?'}\`). Baselines are read from git, not from a test run — see \`${path.posix.join('web/app/e2e/design-review', 'README.md')}\`.</sub>`,
+  );
+
+  return `${lines.join('\n').replace(/\n{3,}/g, '\n\n').trim()}\n`;
+}

--- a/web/app/e2e/design-review/markdown.mjs
+++ b/web/app/e2e/design-review/markdown.mjs
@@ -68,7 +68,7 @@ export function renderMarkdown(model, { reportLink, reportHint } = {}) {
   lines.push(`### Design review · ${headline}`, '');
 
   if (!model.base.sha) {
-    lines.push(`> No merge base with \`${model.base.ref}\` — nothing to compare against, so every screen below reads as new.`, '');
+    lines.push(`> **No merge base with \`${model.base.ref}\`** — ${model.base.reason ?? 'nothing to compare against'}. Every screen below therefore reads as new.`, '');
   }
 
   const moved = model.screens.filter(screen => screen.status !== 'unchanged');

--- a/web/app/e2e/design-review/render.mjs
+++ b/web/app/e2e/design-review/render.mjs
@@ -1,0 +1,111 @@
+/**
+ * Renders the collected model as one self-contained HTML file.
+ *
+ * "Self-contained" is the requirement that drives everything else here.
+ * The audience for this report is a designer who is not going to clone the
+ * repo, and the delivery mechanism is going to be a Slack message or a
+ * drag onto a browser window — so images are inlined as data URIs and there
+ * is no external stylesheet, no CDN, and no fetch. One file, opens offline,
+ * survives being forwarded.
+ *
+ * The cost of that is size, which is why identical images are stored once
+ * (see `assetTable`): most screens in a typical PR are unchanged, and an
+ * unchanged screen would otherwise embed the same PNG twice.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ASSET_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'assets');
+
+/**
+ * The report's stylesheet and behaviour live in `assets/` as real `.css` and
+ * `.js` files, inlined at render time, rather than as template literals in
+ * this module.
+ *
+ * Same output either way; the difference is that an editor gives them syntax
+ * highlighting and a formatter, and a template literal makes every backtick
+ * and `${` in the source something you have to remember to escape. The
+ * report is a UI a designer is going to look at closely, so the files that
+ * define how it looks should be as easy to work on as any other UI.
+ */
+async function inlineAsset(name) {
+  return readFile(path.join(ASSET_DIR, name), 'utf8');
+}
+
+/**
+ * Collapses every image in the model to a deduplicated table of data URIs,
+ * replacing each `{ buffer }` with an index into it.
+ *
+ * Deduplication is by content hash rather than by path, which matters for
+ * the common case: an unchanged screen's before and after are the same
+ * bytes at the same path, and a changed screen may still share a viewport
+ * with another shot.
+ */
+function assetTable(screens) {
+  const assets = [];
+  const indexByHash = new Map();
+
+  const intern = image => {
+    if (!image) return null;
+    const hash = createHash('sha1').update(image.buffer).digest('hex');
+    if (!indexByHash.has(hash)) {
+      indexByHash.set(hash, assets.length);
+      assets.push(`data:image/png;base64,${image.buffer.toString('base64')}`);
+    }
+    return { asset: indexByHash.get(hash), path: image.path, bytes: image.bytes, width: image.width, height: image.height };
+  };
+
+  const lean = screens.map(screen => ({
+    ...screen,
+    variants: screen.variants.map(variant => ({ ...variant, before: intern(variant.before), after: intern(variant.after) })),
+  }));
+
+  return { assets, screens: lean };
+}
+
+/**
+ * Embeds a value as JSON inside a `<script type="application/json">`.
+ *
+ * `<` is escaped rather than only the `</script>` sequence. The HTML parser
+ * ends a script block on `</script` in any casing and with arbitrary
+ * whitespace before the `>`, and there are enough near-misses (`<!--`
+ * starting a comment inside a script) that escaping the one character all
+ * of them begin with is the only version of this that is obviously correct.
+ */
+function embedJson(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+export async function render(model) {
+  const { assets, screens } = assetTable(model.screens);
+  const payload = { ...model, screens, assets, repoRoot: undefined };
+
+  return `<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(reportTitle(model))}</title>
+<style>${await inlineAsset('report.css')}</style>
+</head>
+<body>
+<div id="app" aria-busy="true"></div>
+<script type="application/json" id="design-data">${embedJson(payload)}</script>
+<script>${await inlineAsset('report.js')}</script>
+</body>
+</html>
+`;
+}
+
+export function reportTitle(model) {
+  if (model.pr) return `Design review — PR #${model.pr.number}: ${model.pr.title}`;
+  if (model.head.branch) return `Design review — ${model.head.branch}`;
+  return 'Design review';
+}
+
+function escapeHtml(text) {
+  return String(text).replace(/[&<>"']/g, character => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[character]);
+}

--- a/web/app/e2e/design-review/tests/cli.test.mjs
+++ b/web/app/e2e/design-review/tests/cli.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * CLI argument handling.
+ *
+ * Every case here is one where the wrong behaviour is not a crash but a
+ * *plausible report about the wrong thing*, which is the failure mode this
+ * tool can least afford: a reviewer has no way to tell a confidently wrong
+ * before/after from a correct one.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const CLI = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'cli.mjs');
+
+/** Runs the CLI and returns `{ code, stdout, stderr }` without throwing. */
+async function run(...args) {
+  try {
+    const { stdout, stderr } = await execFileAsync('node', [CLI, ...args], { encoding: 'utf8', timeout: 60_000 });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    return { code: error.code ?? 1, stdout: error.stdout ?? '', stderr: error.stderr ?? '' };
+  }
+}
+
+test('an empty inline value is rejected, not passed through as a ref', async () => {
+  // `--base=` parses as an inline value of "", which reached git as an empty
+  // ref. git does not error on that — it resolves to nothing — so the report
+  // came back claiming every screen was new, with exit code 0 and no
+  // warning. This is the single worst outcome the tool has.
+  const result = await run('--base=', '--out', '/dev/null');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /--base needs a value/);
+  assert.ok(!/\d+ new/.test(result.stdout), 'it must not produce a report at all');
+});
+
+test('a flag where a value belongs is not swallowed as one', async () => {
+  // Otherwise this compares against a ref literally named "--open".
+  const result = await run('--base', '--open');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /--base needs a value/);
+});
+
+test('a lone -- is skipped, because npm leaves one behind', async () => {
+  const result = await run('--', '--help');
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Design review report/);
+});
+
+test('an unknown flag fails with the message and the usage, not a stack trace', async () => {
+  const result = await run('--nope');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /Unknown option: --nope/);
+  assert.ok(!result.stderr.includes('at parseArgs'), 'no stack trace');
+});
+
+test('--open does nothing in a non-interactive context', async () => {
+  // stdout is a pipe here, so this is the CI shape: the flag must be
+  // refused rather than spawning a platform opener nobody asked for.
+  const result = await run('--open', '--out', '/dev/null', '--base', 'HEAD');
+
+  assert.match(result.stderr, /--open is for interactive use/);
+});

--- a/web/app/e2e/design-review/tests/collect.test.mjs
+++ b/web/app/e2e/design-review/tests/collect.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * Collector tests. Run with `npm run design:review:test` (plain `node --test`
+ * — this tool has no dependencies and its tests keep it that way).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { collect } from '../collect.mjs';
+import { FixtureRepo, SNAPSHOT_DIR } from './fixture-repo.mjs';
+import { makePng } from './png-fixture.mjs';
+
+const SPEC = `web/app/e2e/tests/visual/demo.visual.spec.ts`;
+
+/** A repo with one committed screen on main, and a branch checked out. */
+async function repoOnBranch() {
+  const repo = await FixtureRepo.create();
+  await repo.write(
+    SPEC,
+    [
+      `import { test, expect } from '../../fixtures';`,
+      ``,
+      `/**`,
+      ` * Static screens only — nothing downstream of a model reply.`,
+      ` */`,
+      `test.describe('demo screens', () => {`,
+      `  test('the landing page', { tag: ['@visual'] }, async ({ page }) => {`,
+      `    await expect(page).toHaveScreenshot('landing.png');`,
+      `  });`,
+      `});`,
+    ].join('\n'),
+  );
+  await repo.write(`${SNAPSHOT_DIR}/landing-chromium-desktop-linux.png`, makePng(1280, 720, [20, 20, 20]));
+  await repo.write(`${SNAPSHOT_DIR}/landing-chromium-mobile-linux.png`, makePng(412, 915, [20, 20, 20]));
+  await repo.commit('seed');
+  await repo.git('checkout', '-b', 'redesign');
+  return repo;
+}
+
+test('an untouched branch reports every screen as unchanged', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main' });
+
+  assert.equal(model.summary.screens, 1);
+  assert.equal(model.summary.unchanged, 1);
+  assert.equal(model.summary.changed, 0);
+  assert.deepEqual(
+    model.screens[0].variants.map(variant => variant.label),
+    ['Desktop', 'Mobile'],
+    'desktop must sort before mobile so every pair reads the same way',
+  );
+});
+
+test('a regenerated baseline is reported as changed, with the old image as "before"', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  await repo.write(`${SNAPSHOT_DIR}/landing-chromium-desktop-linux.png`, makePng(1280, 900, [240, 240, 240]));
+  await repo.commit('restyle the landing page');
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main', headRef: 'HEAD' });
+
+  assert.equal(model.summary.changed, 1);
+  const [desktop, mobile] = model.screens[0].variants;
+  assert.equal(desktop.status, 'changed');
+  assert.equal(mobile.status, 'unchanged', 'a viewport whose baseline did not move must not be dragged along');
+  // The before side has to come out of history, not off disk — this is the
+  // whole reason the tool exists.
+  assert.equal(desktop.before.height, 720);
+  assert.equal(desktop.after.height, 900);
+  assert.equal(model.screens[0].status, 'changed', 'a screen is as changed as its worst viewport');
+});
+
+test('uncommitted and untracked baselines are picked up by default', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  // Neither staged nor committed: the state a designer is actually in while
+  // iterating, and the default the tool has to handle.
+  await repo.write(`${SNAPSHOT_DIR}/landing-chromium-desktop-linux.png`, makePng(1280, 720, [99, 99, 99]));
+  await repo.write(`${SNAPSHOT_DIR}/settings-chromium-desktop-linux.png`, makePng(1280, 720, [5, 5, 5]));
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main' });
+
+  assert.equal(model.summary.changed, 1);
+  assert.equal(model.summary.added, 1);
+  const added = model.screens.find(screen => screen.shot === 'settings');
+  assert.equal(added.status, 'added');
+  assert.equal(added.variants[0].before, null, 'a new screen has no before side');
+});
+
+test('a deleted baseline is reported as removed, keeping the image that was lost', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  await repo.remove(`${SNAPSHOT_DIR}/landing-chromium-mobile-linux.png`);
+  await repo.commit('drop the mobile baseline');
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main', headRef: 'HEAD' });
+
+  assert.equal(model.summary.removed, 1);
+  const mobile = model.screens[0].variants.find(variant => variant.form === 'mobile');
+  assert.equal(mobile.status, 'removed');
+  assert.ok(mobile.before, 'the removed image must still be shown — it is the only record of it left');
+  assert.equal(mobile.after, null);
+});
+
+test('the spec supplies the screen title, group and doc comment', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main' });
+  const screen = model.screens[0];
+
+  assert.equal(screen.title, 'The landing page');
+  assert.equal(screen.group, 'demo screens');
+  assert.match(screen.note, /Static screens only/);
+});
+
+test('changes on the base branch are not attributed to this one', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  // Someone else lands an unrelated screen on main after the fork point.
+  await repo.git('checkout', 'main');
+  await repo.write(`${SNAPSHOT_DIR}/unrelated-chromium-desktop-linux.png`, makePng(1280, 720, [7, 7, 7]));
+  await repo.commit('someone else ships a screen');
+  await repo.git('checkout', 'redesign');
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main', headRef: 'HEAD' });
+
+  // Diffing against the tip of main would call `unrelated` "removed" by this
+  // branch. Against the merge base — the correct comparison — this branch
+  // changed nothing.
+  assert.equal(model.summary.removed, 0);
+  assert.equal(model.summary.changed, 0);
+  assert.equal(model.summary.screens, 1);
+});
+
+test('design files no screen renders are listed as uncovered', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  await repo.write('web/app/src/app/features/billing/billing-page.component.html', '<section>invoices</section>');
+  await repo.write('web/app/src/app/features/billing/billing-page.component.ts', 'export class BillingPage {}');
+  await repo.commit('add a billing page');
+
+  const model = await collect({ cwd: repo.root, baseRef: 'main', headRef: 'HEAD' });
+
+  assert.deepEqual(
+    model.impact.uncovered.map(file => file.path),
+    ['web/app/src/app/features/billing/billing-page.component.html'],
+    'only design surface is listed — a component .ts is not something a screenshot would have shown',
+  );
+  assert.equal(model.impact.uncovered[0].area, 'billing');
+});
+
+test('a missing merge base degrades to a gallery rather than failing', async t => {
+  const repo = await repoOnBranch();
+  t.after(() => repo.dispose());
+
+  const model = await collect({ cwd: repo.root, baseRef: 'no-such-branch' });
+
+  assert.equal(model.base.sha, null);
+  assert.equal(model.summary.screens, 1);
+  assert.equal(model.summary.added, 1, 'with nothing to compare against, every screen is new');
+});

--- a/web/app/e2e/design-review/tests/diff.test.mjs
+++ b/web/app/e2e/design-review/tests/diff.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Decoder and pixel-comparison tests.
+ *
+ * This is the code most able to be confidently wrong: a decoder that
+ * mishandles one filter type still returns an image, and a comparison that
+ * mis-scales still returns a percentage. Both would flow straight into a PR
+ * comment as a number nobody could tell was nonsense.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { decodePng, readPngSize } from '../lib/png.mjs';
+import { diffPngs, DEFAULT_THRESHOLD } from '../lib/diff.mjs';
+import { makePng } from './png-fixture.mjs';
+
+const COLOUR_TYPES = [0, 2, 4, 6];
+const FILTERS = [0, 1, 2, 3, 4];
+const CARRIES_COLOUR = new Set([2, 6]);
+const CARRIES_ALPHA = new Set([4, 6]);
+
+test('every colour type and row filter decodes back to the pixels encoded', () => {
+  for (const colourType of COLOUR_TYPES) {
+    for (const filter of FILTERS) {
+      const image = decodePng(makePng(9, 7, [180, 90, 45, 200], { colourType, filter }));
+      assert.ok(image, `colour type ${colourType}, filter ${filter} failed to decode`);
+      assert.equal(image.data.length, 9 * 7 * 4, 'output is always widened to RGBA');
+
+      // Sample a pixel away from the edges, where the left/above predictors
+      // are all in play rather than clamped to zero.
+      const pixel = [...image.data.subarray((4 * 9 + 5) * 4, (4 * 9 + 5) * 4 + 4)];
+      assert.deepEqual(
+        pixel,
+        [...(CARRIES_COLOUR.has(colourType) ? [180, 90, 45] : [180, 180, 180]), CARRIES_ALPHA.has(colourType) ? 200 : 255],
+        `colour type ${colourType}, filter ${filter}`,
+      );
+    }
+  }
+});
+
+test('shapes outside what a screenshot can be decode to null, not to garbage', () => {
+  // Palette (3) needs PLTE to mean anything. Returning null lets callers show
+  // "couldn't read this" instead of a plausible-looking wrong image.
+  const palette = Buffer.from(makePng(4, 4));
+  palette[25] = 3;
+  assert.equal(decodePng(palette), null);
+
+  const interlaced = Buffer.from(makePng(4, 4));
+  interlaced[28] = 1;
+  assert.equal(decodePng(interlaced), null);
+
+  assert.equal(decodePng(Buffer.from('not a png')), null);
+  // Truncated mid-IDAT — what a mangled binary merge leaves behind.
+  assert.equal(decodePng(makePng(64, 64).subarray(0, 40)), null);
+});
+
+test('identical images differ by nothing; inverted ones by everything', () => {
+  const black = makePng(20, 10, [0, 0, 0]);
+  assert.equal(diffPngs(black, makePng(20, 10, [0, 0, 0])).ratio, 0);
+  assert.equal(diffPngs(black, makePng(20, 10, [255, 255, 255])).ratio, 1);
+});
+
+test('a change below the sensitivity threshold does not count', () => {
+  const base = makePng(20, 10, [100, 100, 100]);
+  const cutoff = Math.round(DEFAULT_THRESHOLD * 255);
+
+  // Exactly at the cutoff is not "greater than", so it stays uncounted —
+  // this is the boundary the browser's copy of the rule has to match.
+  assert.equal(diffPngs(base, makePng(20, 10, [100 + cutoff, 100, 100])).ratio, 0);
+  assert.equal(diffPngs(base, makePng(20, 10, [100 + cutoff + 1, 100, 100])).ratio, 1);
+});
+
+test('the comparison is per channel, so a shift in one is not diluted by the others', () => {
+  const base = makePng(8, 8, [100, 100, 100]);
+  // One channel moves well past the threshold while the other two are
+  // identical. A distance metric averaged over channels could miss this.
+  assert.equal(diffPngs(base, makePng(8, 8, [100, 160, 100])).ratio, 1);
+});
+
+test('a taller image counts the region only one side covers as changed', () => {
+  const short = makePng(10, 10, [30, 30, 30]);
+  const tall = makePng(10, 20, [30, 30, 30]);
+
+  const result = diffPngs(short, tall);
+
+  // The overlapping 10x10 is identical; the 10 rows only the tall image has
+  // are the change. Scaling to a common size would have reported 0% and
+  // hidden a doubling in page height.
+  assert.equal(result.width, 10);
+  assert.equal(result.height, 20);
+  assert.equal(result.changed, 100);
+  assert.equal(result.ratio, 0.5);
+});
+
+test('an undecodable side yields null rather than a misleading zero', () => {
+  assert.equal(diffPngs(makePng(4, 4), Buffer.from('junk')), null);
+});
+
+test('readPngSize and decodePng agree on dimensions', () => {
+  const png = makePng(37, 19, [1, 2, 3], { colourType: 2, filter: 4 });
+  const decoded = decodePng(png);
+  assert.deepEqual(readPngSize(png), { width: decoded.width, height: decoded.height });
+});

--- a/web/app/e2e/design-review/tests/fixture-repo.mjs
+++ b/web/app/e2e/design-review/tests/fixture-repo.mjs
@@ -1,0 +1,60 @@
+/**
+ * Builds a throwaway git repository for the tests to read.
+ *
+ * The collector's whole job is reading history, so a test that stubs git out
+ * would only prove that the stub matches the stub. Every case here runs
+ * against a real repository with real commits — it costs a few hundred
+ * milliseconds and it is the only way the merge-base logic, the untracked
+ * file handling and the rename detection get tested at all.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+export const SNAPSHOT_DIR = 'web/app/e2e/tests/visual/demo.visual.spec.ts-snapshots';
+
+export class FixtureRepo {
+  constructor(root) {
+    this.root = root;
+  }
+
+  static async create() {
+    const root = await mkdtemp(path.join(tmpdir(), 'design-review-'));
+    const repo = new FixtureRepo(root);
+    await repo.git('init', '--initial-branch=main');
+    // Identity and signing are set locally so the suite does not depend on
+    // — or disturb — whatever the machine running it has configured.
+    await repo.git('config', 'user.email', 'fixture@example.test');
+    await repo.git('config', 'user.name', 'Fixture');
+    await repo.git('config', 'commit.gpgsign', 'false');
+    return repo;
+  }
+
+  git(...args) {
+    return execFileAsync('git', ['-C', this.root, ...args], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+  }
+
+  async write(relPath, contents) {
+    const full = path.join(this.root, relPath);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, contents);
+  }
+
+  async commit(message) {
+    await this.git('add', '-A');
+    await this.git('commit', '-m', message);
+  }
+
+  async remove(relPath) {
+    await rm(path.join(this.root, relPath));
+  }
+
+  async dispose() {
+    await rm(this.root, { recursive: true, force: true });
+  }
+}

--- a/web/app/e2e/design-review/tests/git.test.mjs
+++ b/web/app/e2e/design-review/tests/git.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * Tests for reading the change set out of git.
+ *
+ * These are all about paths that git *displays* differently from how they
+ * exist: renames abbreviated with braces, and names that git backslash-quotes
+ * because they contain a space or a non-ASCII byte. Getting one wrong
+ * produces a path that does not exist, attached to a plausible-looking file
+ * entry, which then flows into the impact list and the "no screen covers
+ * this" list as a file nobody can find.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { changedFiles, resolveBase } from '../lib/git.mjs';
+import { FixtureRepo } from './fixture-repo.mjs';
+import { makePng } from './png-fixture.mjs';
+
+async function seeded(files) {
+  const repo = await FixtureRepo.create();
+  for (const [file, contents] of Object.entries(files)) await repo.write(file, contents);
+  await repo.commit('seed');
+  const base = (await repo.git('rev-parse', 'HEAD')).stdout.trim();
+  return { repo, base };
+}
+
+test('a rename inside a nested directory keeps its real path and its status', async t => {
+  const { repo, base } = await seeded({ 'web/app/src/app/features/billing/invoice.component.html': '<p>a</p>\n'.repeat(40) });
+  t.after(() => repo.dispose());
+
+  // git abbreviates this to `web/app/src/app/features/{billing =>
+  // payments}/invoice.component.html` in its human-readable output.
+  await mkdir(path.join(repo.root, 'web/app/src/app/features/payments'), { recursive: true });
+  await repo.git('mv', 'web/app/src/app/features/billing/invoice.component.html', 'web/app/src/app/features/payments/invoice.component.html');
+  await repo.commit('move billing to payments');
+
+  const files = await changedFiles(repo.root, base, 'HEAD');
+
+  assert.deepEqual(
+    files.map(file => [file.path, file.status]),
+    [['web/app/src/app/features/payments/invoice.component.html', 'renamed']],
+  );
+});
+
+test('a rename with no shared path structure is also reported whole', async t => {
+  const { repo, base } = await seeded({ 'plain.txt': 'x\n'.repeat(40) });
+  t.after(() => repo.dispose());
+
+  await repo.git('mv', 'plain.txt', 'renamed.txt');
+  await repo.commit('rename');
+
+  const files = await changedFiles(repo.root, base, 'HEAD');
+  assert.deepEqual(files.map(file => [file.path, file.status]), [['renamed.txt', 'renamed']]);
+});
+
+test('paths git would quote survive verbatim', async t => {
+  // Without `-z`, git renders this as `"web/app/src/a file \303\251.css"` —
+  // quoted, octal-escaped, and not the name of anything on disk.
+  const quoted = 'web/app/src/a file é.css';
+  const { repo, base } = await seeded({ 'web/app/src/placeholder.txt': 'x\n' });
+  t.after(() => repo.dispose());
+
+  await repo.write(quoted, '.a { color: red }\n');
+  await repo.commit('add an awkwardly named stylesheet');
+
+  const files = await changedFiles(repo.root, base, 'HEAD');
+  assert.deepEqual(files.map(file => file.path), [quoted]);
+});
+
+test('binary files report no line counts rather than a fabricated zero', async t => {
+  // A real PNG, not a few handpicked bytes: git decides "binary" by looking
+  // for a NUL in the first 8000 bytes, so a short header-shaped buffer is
+  // still text to it and reports line counts like any other file.
+  const { repo, base } = await seeded({ 'web/app/src/logo.png': makePng(8, 8, [10, 20, 30]) });
+  t.after(() => repo.dispose());
+
+  await repo.write('web/app/src/logo.png', makePng(8, 8, [200, 30, 40]));
+  await repo.commit('change the logo');
+
+  const [file] = await changedFiles(repo.root, base, 'HEAD');
+  assert.equal(file.added, null);
+  assert.equal(file.deleted, null);
+});
+
+test('an unresolvable base ref is distinguished from a missing common ancestor', async t => {
+  const { repo } = await seeded({ 'a.txt': 'x\n' });
+  t.after(() => repo.dispose());
+
+  // The two produce an identical empty report, and only one is the user's
+  // typo — so the reason has to say which.
+  const typo = await resolveBase(repo.root, 'orgin/man', 'HEAD');
+  assert.equal(typo.sha, null);
+  assert.match(typo.reason, /does not resolve to a commit/);
+
+  const orphan = (await repo.git('commit-tree', (await repo.git('hash-object', '-t', 'tree', '/dev/null')).stdout.trim(), '-m', 'unrelated')).stdout.trim();
+  const unrelated = await resolveBase(repo.root, orphan, 'HEAD');
+  assert.equal(unrelated.sha, null);
+  assert.match(unrelated.reason, /no common ancestor/);
+});

--- a/web/app/e2e/design-review/tests/markdown.test.mjs
+++ b/web/app/e2e/design-review/tests/markdown.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * PR-comment tests.
+ *
+ * The comment is the part most people will ever see, and it is posted
+ * automatically — so a wrong headline is a wrong headline on every PR until
+ * someone notices. These pin the claims it makes.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderMarkdown } from '../markdown.mjs';
+
+function variant(project, label, order, status, ratio) {
+  return { project, label, order, form: label.toLowerCase(), status, diff: ratio == null ? null : { ratio, changed: 1, total: 100 } };
+}
+
+function model({ screens = [], uncovered = [], base = { ref: 'origin/main', sha: 'a'.repeat(40) } } = {}) {
+  const count = status => screens.filter(screen => screen.status === status).length;
+  return {
+    base,
+    head: { ref: 'HEAD', sha: 'b'.repeat(40), worktree: false },
+    screens,
+    impact: { uncovered },
+    summary: {
+      screens: screens.length,
+      changed: count('changed'),
+      added: count('added'),
+      removed: count('removed'),
+      unchanged: count('unchanged'),
+    },
+  };
+}
+
+const changedScreen = {
+  title: 'Personality detail',
+  status: 'changed',
+  variants: [variant('chromium-desktop', 'Desktop', 0, 'changed', 0.112), variant('chromium-mobile', 'Mobile', 1, 'unchanged')],
+};
+
+test('the headline states the verdict, because it is often all that is read', () => {
+  assert.match(renderMarkdown(model({ screens: [changedScreen] })), /^### Design review · 1 screen changed$/m);
+  assert.match(
+    renderMarkdown(model({ screens: [{ title: 'Login', status: 'unchanged', variants: [variant('chromium-desktop', 'Desktop', 0, 'unchanged')] }] })),
+    /^### Design review · no screen changed$/m,
+  );
+});
+
+test('the table shows a percentage per changed viewport and a marker otherwise', () => {
+  const markdown = renderMarkdown(model({ screens: [changedScreen] }));
+
+  assert.match(markdown, /\| Screen \| Desktop \| Mobile \|/);
+  assert.match(markdown, /\| Personality detail \| \*\*11\.2%\*\* \| · \|/);
+});
+
+test('a very small change keeps enough precision to not read as zero', () => {
+  const tiny = { title: 'Modal', status: 'changed', variants: [variant('chromium-desktop', 'Desktop', 0, 'changed', 0.00088)] };
+
+  // Rounded to one decimal this is "0.1%", and at two it is "0.09%" — either
+  // is fine, but "0%" next to the word "changed" reads as a bug.
+  assert.match(renderMarkdown(model({ screens: [tiny] })), /0\.088%|0\.09%/);
+});
+
+test('unchanged screens never reach the table', () => {
+  const markdown = renderMarkdown(
+    model({ screens: [changedScreen, { title: 'Login', status: 'unchanged', variants: [variant('chromium-desktop', 'Desktop', 0, 'unchanged')] }] }),
+  );
+
+  assert.ok(!markdown.includes('| Login |'));
+  assert.match(markdown, /1 other screen unchanged/);
+});
+
+test('uncovered design files are called out rather than folded away', () => {
+  const markdown = renderMarkdown(
+    model({ screens: [changedScreen], uncovered: [{ path: 'web/app/src/app/features/billing/billing-page.component.html', area: 'billing' }] }),
+  );
+
+  assert.match(markdown, /⚠️ \*\*1 design file changed that no covered screen renders/);
+  assert.match(markdown, /`features\/billing\/billing-page\.component\.html`/);
+  // Not inside a <details>: this is the most actionable line in the comment
+  // and the least likely to be opened if hidden.
+  assert.ok(!/<details>[\s\S]*billing/.test(markdown));
+});
+
+test('a long uncovered list is capped so the comment stays readable', () => {
+  const uncovered = Array.from({ length: 14 }, (unused, index) => ({ path: `web/app/src/app/features/f${index}/page.component.html`, area: `f${index}` }));
+
+  const markdown = renderMarkdown(model({ screens: [changedScreen], uncovered }));
+
+  assert.equal(markdown.match(/^- `/gm).length, 10);
+  assert.match(markdown, /…and 4 more/);
+});
+
+test('a missing merge base is stated, not silently rendered as "everything is new"', () => {
+  const markdown = renderMarkdown(model({ screens: [changedScreen], base: { ref: 'origin/main', sha: null } }));
+
+  assert.match(markdown, /No merge base with `origin\/main`/);
+});
+
+test('the report link is included only when there is somewhere to point', () => {
+  assert.ok(!renderMarkdown(model({ screens: [changedScreen] })).includes('Open the before/after report'));
+  assert.match(
+    renderMarkdown(model({ screens: [changedScreen] }), { reportLink: 'https://example.invalid/run/1' }),
+    /\[Open the before\/after report →\]\(https:\/\/example\.invalid\/run\/1\)/,
+  );
+});

--- a/web/app/e2e/design-review/tests/markdown.test.mjs
+++ b/web/app/e2e/design-review/tests/markdown.test.mjs
@@ -96,10 +96,23 @@ test('a missing merge base is stated, not silently rendered as "everything is ne
   assert.match(markdown, /No merge base with `origin\/main`/);
 });
 
-test('the report link is included only when there is somewhere to point', () => {
-  assert.ok(!renderMarkdown(model({ screens: [changedScreen] })).includes('Open the before/after report'));
-  assert.match(
-    renderMarkdown(model({ screens: [changedScreen] }), { reportLink: 'https://example.invalid/run/1' }),
-    /\[Open the before\/after report →\]\(https:\/\/example\.invalid\/run\/1\)/,
-  );
+test('the download points at the artifact, not at the run that made it', () => {
+  // The run page hides the artifact behind a scroll and an "Artifacts"
+  // section, which is a poor last step for the one thing this comment
+  // exists to hand over. The run stays available as secondary context.
+  const markdown = renderMarkdown(model({ screens: [changedScreen] }), {
+    reportLink: 'https://example.invalid/runs/1/artifacts/9',
+    runLink: 'https://example.invalid/runs/1',
+  });
+
+  assert.match(markdown, /\[Download the interactive report\]\(https:\/\/example\.invalid\/runs\/1\/artifacts\/9\)/);
+  assert.match(markdown, /\[workflow run\]\(https:\/\/example\.invalid\/runs\/1\)/);
+  // Say what lands, so a bare "download" is not a leap of faith.
+  assert.match(markdown, /zip containing one self-contained HTML file/);
+});
+
+test('no download section when there is nowhere to point', () => {
+  const markdown = renderMarkdown(model({ screens: [changedScreen] }));
+  assert.ok(!markdown.includes('Download the interactive report'));
+  assert.ok(!markdown.includes('workflow run'));
 });

--- a/web/app/e2e/design-review/tests/png-fixture.mjs
+++ b/web/app/e2e/design-review/tests/png-fixture.mjs
@@ -1,0 +1,64 @@
+/**
+ * Builds a tiny, valid PNG in memory, for tests.
+ *
+ * The alternative — copying a committed baseline into a fixture repo —
+ * would tie every assertion here to whatever the app's login page happens
+ * to look like, so a routine baseline update would break tests that have
+ * nothing to do with the app. A generated image lets a test say "8x8, red"
+ * and mean exactly that.
+ *
+ * Encodes the one PNG shape this tool ever reads: 8-bit truecolour with
+ * alpha, no interlacing, a single IDAT.
+ */
+
+import { deflateSync } from 'node:zlib';
+
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** CRC-32 over type+data, as every PNG chunk requires. */
+function crc32(buffer) {
+  let crc = ~0;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return ~crc >>> 0;
+}
+
+function chunk(type, data) {
+  const typed = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(typed));
+  return Buffer.concat([length, typed, checksum]);
+}
+
+/** A solid-colour RGBA PNG of the given size. */
+export function makePng(width, height, [red, green, blue, alpha = 255] = [0, 0, 0]) {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8; // bit depth
+  header[9] = 6; // colour type: truecolour with alpha
+  // Bytes 10..12 are the compression, filter and interlace methods. All zero
+  // — the only combination the spec defines for this colour type.
+
+  // Each scanline carries a leading filter byte; 0 is "no filtering", which
+  // keeps both the raw bytes and this encoder trivial.
+  const stride = width * 4;
+  const raw = Buffer.alloc(height * (stride + 1));
+  for (let row = 0; row < height; row++) {
+    const start = row * (stride + 1);
+    raw[start] = 0;
+    for (let column = 0; column < width; column++) {
+      const pixel = start + 1 + column * 4;
+      raw[pixel] = red;
+      raw[pixel + 1] = green;
+      raw[pixel + 2] = blue;
+      raw[pixel + 3] = alpha;
+    }
+  }
+
+  return Buffer.concat([SIGNATURE, chunk('IHDR', header), chunk('IDAT', deflateSync(raw)), chunk('IEND', Buffer.alloc(0))]);
+}

--- a/web/app/e2e/design-review/tests/png-fixture.mjs
+++ b/web/app/e2e/design-review/tests/png-fixture.mjs
@@ -34,30 +34,71 @@ function chunk(type, data) {
   return Buffer.concat([length, typed, checksum]);
 }
 
-/** A solid-colour RGBA PNG of the given size. */
-export function makePng(width, height, [red, green, blue, alpha = 255] = [0, 0, 0]) {
+/** Channels per colour type, matching the decoder's own table. */
+const CHANNELS = { 0: 1, 2: 3, 4: 2, 6: 4 };
+
+/**
+ * Applies a PNG row filter, encoding-direction.
+ *
+ * The decoder's hardest code is the five filter reversals, and a fixture
+ * that only ever emitted filter 0 would leave four of them untested while
+ * looking like coverage. Real screenshots use all five — Chromium picks per
+ * scanline — so the fixture can emit any of them and the tests round-trip
+ * each one.
+ */
+function applyFilter(type, row, previous, bytesPerPixel) {
+  const out = Buffer.from(row);
+  for (let i = row.length - 1; i >= 0; i--) {
+    const left = i >= bytesPerPixel ? row[i - bytesPerPixel] : 0;
+    const above = previous ? previous[i] : 0;
+    const aboveLeft = previous && i >= bytesPerPixel ? previous[i - bytesPerPixel] : 0;
+    let predictor = 0;
+    if (type === 1) predictor = left;
+    else if (type === 2) predictor = above;
+    else if (type === 3) predictor = (left + above) >> 1;
+    else if (type === 4) {
+      const estimate = left + above - aboveLeft;
+      const dLeft = Math.abs(estimate - left);
+      const dAbove = Math.abs(estimate - above);
+      const dAboveLeft = Math.abs(estimate - aboveLeft);
+      predictor = dLeft <= dAbove && dLeft <= dAboveLeft ? left : dAbove <= dAboveLeft ? above : aboveLeft;
+    }
+    out[i] = (row[i] - predictor) & 0xff;
+  }
+  return out;
+}
+
+/**
+ * A solid-colour PNG of the given size.
+ *
+ * `colourType` defaults to 6 (RGBA); pass 2 to match what Chromium actually
+ * writes for a screenshot, which is the path the committed baselines take.
+ */
+export function makePng(width, height, [red, green, blue, alpha = 255] = [0, 0, 0], { colourType = 6, filter = 0 } = {}) {
+  const channels = CHANNELS[colourType];
+  if (!channels) throw new Error(`unsupported colour type ${colourType}`);
+
   const header = Buffer.alloc(13);
   header.writeUInt32BE(width, 0);
   header.writeUInt32BE(height, 4);
   header[8] = 8; // bit depth
-  header[9] = 6; // colour type: truecolour with alpha
+  header[9] = colourType;
   // Bytes 10..12 are the compression, filter and interlace methods. All zero
-  // — the only combination the spec defines for this colour type.
+  // — the only combination the spec defines for these colour types.
 
-  // Each scanline carries a leading filter byte; 0 is "no filtering", which
-  // keeps both the raw bytes and this encoder trivial.
-  const stride = width * 4;
+  const stride = width * channels;
+  const samples = channels >= 3 ? [red, green, blue, alpha] : [red, alpha];
   const raw = Buffer.alloc(height * (stride + 1));
+  let previous = null;
   for (let row = 0; row < height; row++) {
-    const start = row * (stride + 1);
-    raw[start] = 0;
+    const line = Buffer.alloc(stride);
     for (let column = 0; column < width; column++) {
-      const pixel = start + 1 + column * 4;
-      raw[pixel] = red;
-      raw[pixel + 1] = green;
-      raw[pixel + 2] = blue;
-      raw[pixel + 3] = alpha;
+      for (let channel = 0; channel < channels; channel++) line[column * channels + channel] = samples[channel];
     }
+    const start = row * (stride + 1);
+    raw[start] = filter;
+    applyFilter(filter, line, previous, channels).copy(raw, start + 1);
+    previous = line;
   }
 
   return Buffer.concat([SIGNATURE, chunk('IHDR', header), chunk('IDAT', deflateSync(raw)), chunk('IEND', Buffer.alloc(0))]);

--- a/web/app/e2e/design-review/tests/render.test.mjs
+++ b/web/app/e2e/design-review/tests/render.test.mjs
@@ -110,6 +110,50 @@ test('the browser and Node comparisons start from the same threshold', async () 
   assert.equal(Number(declared), DEFAULT_THRESHOLD);
 });
 
+/**
+ * Guards for the two defects that made the comparison slider unusable.
+ *
+ * Both were invisible to every other check here: the report rendered, the
+ * images were right, the numbers were right, and nothing threw. They only
+ * appeared when someone actually pressed and dragged. Until there is a
+ * browser harness for this page, these assert the exact properties whose
+ * absence caused each one — which is weaker than driving the gesture, but it
+ * is what stands between a silent reintroduction and a caught one.
+ */
+test('screenshots are not natively draggable', async () => {
+  // A press lands on the <img>, and an image is draggable by default, so the
+  // first pointermove started a drag-and-drop, fired `pointercancel`, and
+  // released the pointer capture. The slider moved once and then froze.
+  //
+  // Asserted against the script rather than the rendered HTML: every image
+  // in this report is created at runtime by `imageLayer`, so the document
+  // that ships contains no <img> markup to inspect.
+  const script = await readFile(path.join(TOOL_DIR, 'assets', 'report.js'), 'utf8');
+  const imageLayer = script.match(/function imageLayer\([\s\S]*?\n  \}/)[0];
+
+  assert.match(imageLayer, /draggable: false/);
+});
+
+test('the stage opts out of browser gesture handling', async () => {
+  const css = await readFile(path.join(TOOL_DIR, 'assets', 'report.css'), 'utf8');
+  const stageRule = css.match(/\.stage \{[\s\S]*?\}/)[0];
+
+  // Without this a touch drag is claimed by the browser as a pan, which
+  // cancels the pointer stream exactly like the image drag did.
+  assert.match(stageRule, /touch-action:\s*none/);
+});
+
+test('the slider reveals by clipping, never by resizing', async () => {
+  const script = await readFile(path.join(TOOL_DIR, 'assets', 'report.js'), 'utf8');
+
+  // The revealed layer is positioned inside the clip box, so animating that
+  // box's width scaled the screenshot down into the revealed strip instead
+  // of cutting it off — the two sides stopped lining up and the comparison
+  // became meaningless while still looking plausible.
+  assert.match(script, /clip\.style\.clipPath = `inset\(/);
+  assert.ok(!/clip\.style\.width\s*=/.test(script), 'clip width must not be animated — clip-path is what preserves scale');
+});
+
 test('the title names the pull request when there is one', () => {
   assert.equal(reportTitle(modelWith([], { pr: { number: 42, title: 'Refresh the nav' } })), 'Design review — PR #42: Refresh the nav');
   assert.equal(reportTitle(modelWith([])), 'Design review — redesign');

--- a/web/app/e2e/design-review/tests/render.test.mjs
+++ b/web/app/e2e/design-review/tests/render.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * Renderer tests.
+ *
+ * The report's value depends on it being one file that opens anywhere, and
+ * on it staying small enough to send. Both are properties nothing else
+ * checks, and both are one careless `<link>` or a lost deduplication away
+ * from quietly going wrong.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { render, reportTitle } from '../render.mjs';
+import { makePng } from './png-fixture.mjs';
+
+function image(buffer, overrides = {}) {
+  return { path: 'x.png', bytes: buffer.length, width: 100, height: 80, buffer, ...overrides };
+}
+
+function modelWith(variants, extra = {}) {
+  return {
+    generatedAt: '2026-09-12T00:00:00.000Z',
+    repoRoot: '/somewhere/private',
+    base: { ref: 'origin/main', sha: 'a'.repeat(40) },
+    head: { ref: 'HEAD', sha: 'b'.repeat(40), branch: 'redesign', subject: 'restyle', worktree: false },
+    pr: null,
+    screens: [{ id: 's', shot: 'landing', title: 'Landing', group: null, note: null, specPath: 'a.spec.ts', status: 'changed', related: [], variants }],
+    impact: { files: [], byCategory: [], byArea: [], designShare: 0, frontendFileCount: 0, uncovered: [] },
+    summary: { screens: 1, changed: 1, added: 0, removed: 0, unchanged: 0 },
+    ...extra,
+  };
+}
+
+test('the report references nothing outside itself', async () => {
+  const png = makePng(100, 80, [10, 20, 30]);
+  const html = await render(modelWith([{ project: 'chromium-desktop', label: 'Desktop', form: 'desktop', order: 0, status: 'changed', path: 'x.png', before: image(png), after: image(makePng(100, 80, [200, 0, 0])) }]));
+
+  assert.ok(!/<link\b/i.test(html), 'no external stylesheet');
+  assert.ok(!/src=["']https?:/i.test(html), 'no remotely hosted images');
+  assert.ok(!/<script[^>]+\bsrc=/i.test(html), 'no external script');
+  assert.match(html, /data:image\/png;base64,/, 'images are inlined');
+});
+
+test('identical images are embedded once', async () => {
+  const png = makePng(100, 80, [10, 20, 30]);
+  // An unchanged screen holds the same bytes on both sides; embedding them
+  // twice would roughly double the size of a report that is mostly unchanged
+  // screens, which is most reports.
+  const html = await render(
+    modelWith([{ project: 'chromium-desktop', label: 'Desktop', form: 'desktop', order: 0, status: 'unchanged', path: 'x.png', before: image(png), after: image(png) }]),
+  );
+
+  const occurrences = html.split('data:image/png;base64,').length - 1;
+  assert.equal(occurrences, 1);
+});
+
+test('the embedded model survives characters that would end a script block', async () => {
+  const html = await render(
+    modelWith([{ project: 'chromium-desktop', label: 'Desktop', form: 'desktop', order: 0, status: 'changed', path: 'x.png', before: null, after: image(makePng(4, 4)) }], {
+      head: { ref: 'HEAD', sha: 'b'.repeat(40), branch: 'fix/</script><img src=x>', subject: '<!-- hi -->', worktree: false },
+    }),
+  );
+
+  const payload = html.match(/<script type="application\/json" id="design-data">([\s\S]*?)<\/script>/)[1];
+  const parsed = JSON.parse(payload.replaceAll('\\u003c', '<'));
+  assert.equal(parsed.head.branch, 'fix/</script><img src=x>');
+  // The raw document must not contain the sequence at all, or the parser
+  // would have closed the block before the JSON ended.
+  assert.ok(!payload.includes('</script>'));
+});
+
+test('the repository path is not leaked into a shareable file', async () => {
+  const html = await render(modelWith([{ project: 'chromium-desktop', label: 'Desktop', form: 'desktop', order: 0, status: 'changed', path: 'x.png', before: null, after: image(makePng(4, 4)) }]));
+
+  assert.ok(!html.includes('/somewhere/private'), 'a report gets forwarded; local paths should not ride along');
+});
+
+test('the title names the pull request when there is one', () => {
+  assert.equal(reportTitle(modelWith([], { pr: { number: 42, title: 'Refresh the nav' } })), 'Design review — PR #42: Refresh the nav');
+  assert.equal(reportTitle(modelWith([])), 'Design review — redesign');
+});

--- a/web/app/e2e/design-review/tests/render.test.mjs
+++ b/web/app/e2e/design-review/tests/render.test.mjs
@@ -9,7 +9,13 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { render, reportTitle } from '../render.mjs';
+import { DEFAULT_THRESHOLD } from '../lib/diff.mjs';
+
+const TOOL_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 import { makePng } from './png-fixture.mjs';
 
 function image(buffer, overrides = {}) {
@@ -72,6 +78,36 @@ test('the repository path is not leaked into a shareable file', async () => {
   const html = await render(modelWith([{ project: 'chromium-desktop', label: 'Desktop', form: 'desktop', order: 0, status: 'changed', path: 'x.png', before: null, after: image(makePng(4, 4)) }]));
 
   assert.ok(!html.includes('/somewhere/private'), 'a report gets forwarded; local paths should not ride along');
+});
+
+test('a pull request title cannot break out of the document', async () => {
+  // The title reaches the page twice, escaped two different ways: as text in
+  // <title> via escapeHtml, and inside the JSON payload via embedJson. The
+  // branch-name test above covers the payload; this covers the element,
+  // because a PR title is attacker-influenced in a way a branch name on your
+  // own machine is not.
+  const hostile = '</title><script>alert(1)</script> & "quoted"';
+  const html = await render(
+    modelWith([{ project: 'chromium-desktop', label: 'Desktop', form: 'desktop', order: 0, status: 'changed', path: 'x.png', before: null, after: image(makePng(4, 4)) }], {
+      pr: { number: 7, title: hostile, url: 'https://example.invalid/7' },
+    }),
+  );
+
+  assert.ok(!html.includes('<script>alert(1)</script>'), 'the raw script tag must not appear anywhere');
+  assert.match(html, /<title>Design review — PR #7: &lt;\/title&gt;/);
+});
+
+test('the browser and Node comparisons start from the same threshold', async () => {
+  // The rule is implemented twice on purpose — Node so the PR comment can
+  // quote a figure without rendering, the browser so the sensitivity slider
+  // moves without a round trip. Nothing links them at runtime, so this is
+  // what catches the two drifting apart and quietly disagreeing about how
+  // much of a screen changed.
+  const reportSource = await readFile(path.join(TOOL_DIR, 'assets', 'report.js'), 'utf8');
+  const declared = reportSource.match(/const DEFAULT_THRESHOLD = ([\d.]+);/)?.[1];
+
+  assert.ok(declared, 'report.js must declare DEFAULT_THRESHOLD for this to be checkable');
+  assert.equal(Number(declared), DEFAULT_THRESHOLD);
 });
 
 test('the title names the pull request when there is one', () => {

--- a/web/app/e2e/design-review/tests/units.test.mjs
+++ b/web/app/e2e/design-review/tests/units.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the pure pieces: path parsing, file classification and the
+ * name-match heuristic.
+ *
+ * These pin behaviour that is easy to change by accident and impossible to
+ * notice — a report with a slightly worse heuristic still renders, still
+ * looks right, and quietly stops pointing at the correct files.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseBaselinePath, titleize, isBaselinePath } from '../lib/screens.mjs';
+import { categorize, featureArea, relatedFiles, summarizeImpact } from '../lib/impact.mjs';
+import { readPngSize } from '../lib/png.mjs';
+import { makePng } from './png-fixture.mjs';
+
+test('baseline paths decompose into spec, shot and project', () => {
+  const parsed = parseBaselinePath('web/app/e2e/tests/visual/auth.visual.spec.ts-snapshots/login-page-chromium-desktop-linux.png');
+
+  assert.equal(parsed.specPath, 'web/app/e2e/tests/visual/auth.visual.spec.ts');
+  assert.equal(parsed.shot, 'login-page');
+  assert.equal(parsed.project, 'chromium-desktop');
+  assert.equal(parsed.platform, 'linux');
+});
+
+test('a shot name containing a project-like word is still split at the real boundary', () => {
+  // The shot below ends in "-mobile", which a greedy split would hand to the
+  // project field and leave the report with a project called "mobile".
+  const parsed = parseBaselinePath('e2e/tests/visual/nav.visual.spec.ts-snapshots/sidebar-mobile-chromium-mobile-linux.png');
+
+  assert.equal(parsed.shot, 'sidebar-mobile');
+  assert.equal(parsed.project, 'chromium-mobile');
+});
+
+test('non-baseline files in a snapshots directory are skipped, not guessed at', () => {
+  assert.equal(parseBaselinePath('e2e/tests/visual/x.spec.ts-snapshots/scratch.png'), null);
+  assert.equal(parseBaselinePath('web/app/src/assets/logo.png'), null);
+  assert.equal(isBaselinePath('web/app/src/assets/logo.png'), false);
+});
+
+test('titles capitalise only the first word, leaving names as written', () => {
+  assert.equal(titleize('chat-composer-empty'), 'Chat composer empty');
+  assert.equal(titleize('oauth-SSO-prompt'), 'Oauth SSO prompt');
+});
+
+test('file categories follow precedence, not just extension', () => {
+  assert.equal(categorize('web/app/e2e/tests/visual/a.spec.ts-snapshots/x-chromium-desktop-linux.png').id, 'baseline');
+  // Same extension, different meaning: an app asset is design surface, a
+  // baseline is evidence about it.
+  assert.equal(categorize('web/app/src/assets/logo.png').id, 'asset');
+  assert.equal(categorize('web/app/src/app/features/chat/chat.component.html').id, 'template');
+  assert.equal(categorize('web/app/src/app/features/chat/chat.component.scss').id, 'style');
+  assert.equal(categorize('web/app/src/app/features/chat/chat.component.ts').id, 'component');
+  // A component's own unit test is a test first, even though it is app source.
+  assert.equal(categorize('web/app/src/app/features/chat/chat.component.spec.ts').id, 'spec');
+  assert.equal(categorize('internal/handlers/chat.go').id, 'other');
+});
+
+test('feature areas descend past container directories', () => {
+  assert.equal(featureArea('web/app/src/app/features/personality/detail/x.ts'), 'personality');
+  assert.equal(featureArea('web/app/src/app/shared/ui/modal/modal.component.ts'), 'shared/ui');
+  assert.equal(featureArea('web/app/src/app/app.ts'), 'app root');
+  assert.equal(featureArea('internal/handlers/chat.go'), null, 'backend files have no frontend area');
+});
+
+test('related files match on meaningful words only', () => {
+  const { files } = summarizeImpact([
+    { path: 'web/app/src/app/features/personality/detail/personality-detail-page.component.html', status: 'modified', added: 3, deleted: 1 },
+    { path: 'web/app/src/app/features/chat/chat-composer.component.ts', status: 'modified', added: 2, deleted: 0 },
+    { path: 'web/app/src/app/shared/ui/button/button.component.ts', status: 'modified', added: 1, deleted: 0 },
+  ]);
+
+  const related = relatedFiles({ shot: 'personality-detail', specPath: 'web/app/e2e/tests/visual/personalities.visual.spec.ts' }, files);
+
+  assert.deepEqual(related, ['web/app/src/app/features/personality/detail/personality-detail-page.component.html']);
+  // `button.component.ts` shares only stop words with every screen name. If
+  // it started matching, the hint would fire on everything and mean nothing.
+  assert.ok(!related.some(file => file.includes('button')));
+});
+
+test('design share counts frontend files only', () => {
+  const impact = summarizeImpact([
+    { path: 'web/app/src/app/features/chat/chat.component.html', status: 'modified', added: 10, deleted: 2 },
+    { path: 'web/app/src/app/features/chat/chat.component.scss', status: 'modified', added: 4, deleted: 0 },
+    { path: 'internal/handlers/chat.go', status: 'modified', added: 120, deleted: 30 },
+  ]);
+
+  // Two of two frontend files are pure surface. The Go file is excluded
+  // rather than counted as zero — otherwise a PR that happens to touch the
+  // backend would read as barely a design change.
+  assert.equal(impact.designShare, 1);
+  assert.equal(impact.frontendFileCount, 2);
+});
+
+test('PNG dimensions come from the header; anything else reads as unknown', () => {
+  assert.deepEqual(readPngSize(makePng(412, 915)), { width: 412, height: 915 });
+  assert.equal(readPngSize(Buffer.from('not a png at all')), null);
+  // A truncated file — the shape a mangled binary merge leaves behind.
+  assert.equal(readPngSize(makePng(8, 8).subarray(0, 16)), null);
+});

--- a/web/app/e2e/docs/what-runs-where.md
+++ b/web/app/e2e/docs/what-runs-where.md
@@ -210,6 +210,19 @@ Like the Go smoke test, it's `continue-on-error: true`: real inference is
 slower and less deterministic than the mock backend, so a flaky run
 shouldn't block the PR.
 
+**`design-review` builds a before/after report instead of running tests.**
+`.github/workflows/design-review.yml` is the odd one out here: it executes
+no Playwright at all. It reads the committed baselines at the merge base and
+on the branch and renders the pair, because a designer who updates a
+baseline makes the visual suite pass — the change becomes invisible in every
+report above precisely because it was done correctly. The job needs no
+browser, no backend and no `npm ci`, finishes in about a second, uploads the
+report as an artifact, and leaves a sticky comment naming the screens that
+moved and by how much. It also names the templates and styles the PR
+changed that no covered screen renders, which is the one regression the
+suites above are structurally unable to report. See
+`web/app/e2e/design-review/README.md`.
+
 **Why the mock backend in CI streams with a delay.** `e2e-mock.yml` starts
 the API with `MOCK_LLM_STREAM_DELAY_MS=150`. The mock adapter's default is
 0 — every word of the echoed reply is emitted in one synchronous burst, so a

--- a/web/app/e2e/tests/visual/README.md
+++ b/web/app/e2e/tests/visual/README.md
@@ -22,3 +22,16 @@ username/avatar button). Baselines are generated and checked inside the official
 Docker image so macOS font rendering never fights CI — see "Visual
 regression" → "Updating snapshots" in `e2e/README.md` for the exact
 commands and the Docker networking recipe that makes it work on macOS.
+
+## Seeing what a change did
+
+A baseline update committed on a branch makes the visual suite pass, which
+means an *intentional* design change leaves no trace in any test report. To
+see the before and after, build the design review report — it reads the
+baselines out of git rather than running anything:
+
+```bash
+npm run design:review
+```
+
+See `e2e/design-review/README.md`, or the `design-review` skill.

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -29,6 +29,8 @@
     "e2e:mock-llm:visual:docker:update": "bash e2e/scripts/visual-docker.sh --update",
     "e2e:check-configs": "bash e2e/scripts/check-config-selection.sh",
     "e2e:check-visual-coverage": "node --test 'e2e/scripts/lib/*.test.mjs' && node e2e/scripts/check-visual-coverage.mjs",
+    "design:review": "node e2e/design-review/cli.mjs",
+    "design:review:test": "node --test \"e2e/design-review/tests/*.test.mjs\"",
     "sdk:generate": "openapi-typescript ../../openapi.yaml -o e2e/sdk/schema.d.ts",
     "lint:e2e": "eslint e2e --max-warnings=0"
   },


### PR DESCRIPTION
## Summary

- Adds `web/app/e2e/design-review/`: a self-contained HTML before/after of every screen the visual suite covers, built by reading git rather than by running a test. A designer changing a screen regenerates its baseline and commits it, so from that commit on `toHaveScreenshot()` compares the new render against the new baseline and passes — the visual report goes green and empty, and the only record of the previous design is a PNG blob in history that no review tool renders. The change becomes invisible precisely because the workflow was followed correctly. This takes the baseline at the merge base as "before" and the baseline on the branch as "after", so the intended change is what you see.
- **Triggered on a PR by the `design-review` label.** The workflow builds the report, uploads it as the `design-review` artifact, and posts a sticky comment naming the screens that moved and by how much; pushing to a labelled PR refreshes both. Opt-in for the same reason every label gate in this repo is — most PRs do not change a screen. The job runs no Playwright, no backend and no `npm ci`, so it costs seconds. Fork PRs get the artifact but no comment: their token is read-only, and `pull_request_target` would hand a write token to a job running the PR's own code.
- The report inlines its images and computes the comparison in the browser: slider, side by side, onion-skin, and a pixel-difference overlay with adjustable sensitivity. It also lists the templates, styles and assets a branch changed that **no** covered screen renders — a restyled component with no baseline is the one regression a visual suite is structurally unable to report.
- For the comment to state a magnitude, the changed-pixel figure has to exist outside the browser, so `lib/png.mjs` gains a decoder for the 8-bit non-interlaced PNGs a browser writes and `lib/diff.mjs` computes the same comparison in Node. The rule is implemented twice on purpose — Node so the comment and `--json` can quote a number without rendering anything, the browser so the sensitivity slider moves without a round trip — from one shared default threshold, with a test reading that constant out of the browser file to stop the two drifting apart.
- Screens are derived from the baseline filenames, with no registry to keep in sync. The rebase onto the new visual specs took coverage from 6 screens to 11 with no edit to this tool.
- Entry points: `make design-review` / `npm run design:review`, the `design-review` skill, the `design-review` label, and `make design-review-test` wired into `frontend-pr-validation`. The existing visual suite answers the complementary question (did anything change by accident) and is unchanged.

## Test plan

- [x] `make pre-commit`
- [x] Frontend lint/test/build — `make design-review-test` (45 tests), `actionlint` clean on the new workflow, and the full PR check set green including all four e2e shards and the visual project.
- [x] Manually verified the report: generated one for a real merged baseline change (the personality detail redesign) and drove the result in Chromium through all four compare modes, both viewports, both themes, and the sensitivity control, with no console errors or warnings. The Node and browser diffs agree exactly (11.2% desktop / 15.7% mobile). Also exercised the added / removed / unchanged and both missing-merge-base paths.
- [x] Manually verified the label end to end on this PR: the push before labelling skipped, applying the label ran the workflow to success, the artifact downloaded and opened in Chromium with every image decoding, and both a re-run and a subsequent push patched the sticky comment in place rather than posting a second one.

### Review feedback addressed

The rename finding was real, and worse than reported. `changedFiles` parsed git's human-readable output, where a move inside a nested directory is abbreviated to `dir/{old => new}/file`; the regex turned that into `payments}/invoice.component.html` — a path that exists nowhere — and lost the rename status with it, so the file surfaced in the impact and "not covered" lists as something nobody could open. Both commands now use `-z` and are parsed by field, which also fixes paths git backslash-quotes for containing a space or a non-ASCII byte.

Also fixed: the PR lookup validated a ref it never passed to `gh`, while the real hazard was that `gh pr view` resolves the checked-out branch, so any other `--head` would stamp a report about one change with another change's title; a lone `--` (what npm leaves behind) failed the simplest possible invocation; a flag given where a value belongs was swallowed as a ref name, producing a wrong report rather than an error; and `resolveBase` collapsed "you typo'd the ref" and "no common ancestor" into one indistinguishable empty report.

Declined, with reasons: `createImageBitmap` in place of `Image.decode` (needs a blob round-trip from a data URI to solve a problem nothing has measured), and comments instructing readers to update tests when changing a heuristic — the tests already fail in that case, which is the mechanism that works.

## Checklist

- [x] No credentials, personal exports, generated local state, or production config committed
- [x] Public defaults still work without hosted services
- [ ] Updated architecture docs (only if this touches system boundaries)
- [ ] Regenerated the e2e SDK (only if `openapi.yaml` changed)
