### PR TITLE
fix: Trigger emoji autocomplete right after an emoji

### DIFF
--- a/web/app/e2e/tests/functional/chat/emoji-shortcodes.spec.ts
+++ b/web/app/e2e/tests/functional/chat/emoji-shortcodes.spec.ts
@@ -56,3 +56,19 @@ test('does not suggest for identifier-style colons', async ({ chatPage, seed, us
   await expect(chatPage.emojiAutocomplete).toBeHidden();
   await expect(chatPage.composerInput).toHaveValue('scope:value');
 });
+
+test('suggests when the colon is immediately after an emoji', async ({ chatPage, seed, userWithPersonality }) => {
+  const thread = await seed.thread(undefined, {
+    personalityId: userWithPersonality.personality.id,
+  });
+  await chatPage.navigateTo(thread.id as string);
+
+  // No space between a prior emoji and the next `:shortcode` — still autocomplete.
+  await chatPage.composerInput.pressSequentially('🦊:fox');
+
+  await expect(chatPage.emojiAutocomplete).toBeVisible();
+  await chatPage.emojiSuggestion(':fox_face:').click();
+
+  await expect(chatPage.composerInput).toHaveValue('🦊🦊');
+  await expect(chatPage.emojiAutocomplete).toBeHidden();
+});

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.spec.ts
@@ -42,6 +42,12 @@ describe('emoji shortcode helpers', () => {
     it('triggers after opening punctuation', () => {
       expect(activeEmojiShortcodeQuery('(:fox', 5)).toEqual({ query: 'fox', start: 1, end: 5 });
     });
+
+    it('triggers when the colon is immediately after an emoji', () => {
+      // Surrogate-pair emoji must count as a valid boundary, same as whitespace.
+      expect(activeEmojiShortcodeQuery('🦊:fo', 5)).toEqual({ query: 'fo', start: 2, end: 5 });
+      expect(activeEmojiShortcodeQuery('hi 🦊:fox', 9)).toEqual({ query: 'fox', start: 5, end: 9 });
+    });
   });
 
   describe('searchEmojiShortcodes', () => {

--- a/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
+++ b/web/app/src/app/features/chat/helpers/emoji-shortcode.helpers.ts
@@ -36,11 +36,13 @@ export interface EmojiSuggestion {
 }
 
 /**
- * A shortcode may only begin at the start of the draft or after whitespace or
- * opening punctuation. That keeps URL-ish and identifier-ish colons (e.g.
- * `https://host/:id`) from ever opening the popup.
+ * A shortcode may begin at the start of the draft or after any character that
+ * is not an identifier / URL continuation (`A-Za-z0-9_/`). That allows triggers
+ * after whitespace, punctuation, and emoji (e.g. `🦊:fo`) while still keeping
+ * URL-ish and identifier-ish colons (e.g. `https://host/:id`, `scope:value`)
+ * from opening the popup.
  */
-const ACTIVE_SHORTCODE = /(^|[\s([{])(:)([A-Za-z0-9_+\-]{1,64})$/;
+const ACTIVE_SHORTCODE = /(^|[^A-Za-z0-9_/])(:)([A-Za-z0-9_+\-]{1,64})$/;
 
 /**
  * Return the in-progress `:shortcode` immediately before the caret, or null when


### PR DESCRIPTION
## Summary

- Fixes #98: `:shortcode` autocomplete now opens when the colon is typed immediately after an emoji (`🦊:fo`), not only after whitespace.
- Broadens the shortcode boundary to any non-identifier/URL character while still blocking cases like `scope:value` and `https://host/:id`.
- Adds unit + e2e coverage for the emoji-adjacent trigger.

## Test plan

- [ ] `make pre-commit` (fmt, vet, tidy, test, build)
- [x] Frontend lint/test/build (only if `web/` changed)
  - [x] `npx ng test --include='**/emoji-shortcode.helpers.spec.ts' --watch=false` (15 passed)
- [ ] Manually verified: <!-- what, briefly -->

## Checklist

- [x] No credentials, personal exports, generated local state, or production config committed
- [x] Public defaults still work without hosted services (local JWT auth, unlimited usage)
- [ ] Updated `docs/ARCHITECTURE_SUMMARY.md` / the affected `_PACKAGE_SUMMARY.md` if this touches system boundaries
- [ ] Regenerated the e2e SDK (`cd web/app && npm run sdk:generate`) if `openapi.yaml` changed
